### PR TITLE
Fix set_env/unset_env

### DIFF
--- a/tests/test_mds.py
+++ b/tests/test_mds.py
@@ -149,8 +149,9 @@ class TestMdsTreePath(unittest.TestCase):
         # Clear the variables in they already exist
         for key, val in paths.items():
             varname = MdsTreePath.variable_name(key)
-            if varname in os.environ:
-                del os.environ[varname]
+            os.environ.pop(varname, None)
+            #if varname in os.environ:
+            #    del os.environ[varname]
             self.assertNotIn(varname, os.environ)
 
         # Check if the variables are set inside the context manager

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import unittest
+import os
 
 
-from toksearch.utilities.utilities import capture_exception
+from toksearch.utilities.utilities import capture_exception, set_env, unset_env
 
 
 class TestUtilities(unittest.TestCase):
@@ -26,6 +27,25 @@ class TestUtilities(unittest.TestCase):
         except Exception as e:
             val = capture_exception("my label", e)
 
-        self.assertEquals(val["label"], "my label")
+        self.assertEqual(val["label"], "my label")
         self.assertTrue("Exception" in val["type"])
         self.assertTrue(val["traceback"].startswith("Traceback"))
+
+
+    def test_set_env(self):
+
+        os.environ.pop("MY_VAR", None)
+
+        with set_env("MY_VAR", "MY_VAL"):
+            self.assertEqual(os.getenv("MY_VAR", None), "MY_VAL")
+
+        self.assertIsNone(os.getenv("MY_VAR", None))
+
+    def test_unset_env(self):
+
+        os.environ["MY_VAR"] = "MY_VAL"
+
+        with unset_env("MY_VAR"):
+            self.assertIsNone(os.getenv("MY_VAR", None))
+
+        self.assertEqual(os.getenv("MY_VAR", None), "MY_VAL")

--- a/toksearch/utilities/utilities.py
+++ b/toksearch/utilities/utilities.py
@@ -21,25 +21,27 @@ import traceback
 @contextlib.contextmanager
 def set_env(var, val):
     """Context mananger to temporarily set environment variable"""
-    old_environ = dict(os.environ)
+    old_val = os.getenv(var, None)
     os.environ[var] = val
     try:
         yield
     finally:
-        os.environ.clear()
-        os.environ.update(old_environ)
+        if old_val is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = old_val
 
 
 @contextlib.contextmanager
 def unset_env(var):
     """Context mananger to temporarily set environment variable"""
-    old_environ = dict(os.environ)
+    old_val = os.getenv(var, None)
     os.environ.pop(var, None)
     try:
         yield
     finally:
-        os.environ.clear()
-        os.environ.update(old_environ)
+        if old_val is not None:
+            os.environ[var] = old_val
 
 
 def chunk_it(seq, num):


### PR DESCRIPTION
The previous implementation of set_env/unset_env would call os.environ.clear() before reinstating the environment. This was causing a race condition (and subsequent segfault) when running in Ray (probably due to the way ray does threading).