### PR TITLE
Add local and remote Zarr file support to Toksearch

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,4 +31,4 @@ dependencies:
   - joblib>=1.3
   - jupyter
   - fsspec
-  - zarr
+  - zarr=3

--- a/environment.yml
+++ b/environment.yml
@@ -30,3 +30,4 @@ dependencies:
   - openblas
   - joblib>=1.3
   - jupyter
+  - fsspec

--- a/environment.yml
+++ b/environment.yml
@@ -31,3 +31,4 @@ dependencies:
   - joblib>=1.3
   - jupyter
   - fsspec
+  - zarr

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 python:
-  - 3.9
-  - 3.10
   - 3.11
 
 c_compiler_version: # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ requirements:
         - joblib>=1.3
         - jupyter
         - fsspec
+        - zarr
 
 test:
     source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
         - joblib>=1.3
         - jupyter
         - fsspec
-        - zarr
+        - zarr=3
 
 test:
     source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ requirements:
         - openblas
         - joblib>=1.3
         - jupyter
+        - fsspec
 
 test:
     source_files:

--- a/tests/test_zarr.py
+++ b/tests/test_zarr.py
@@ -1,0 +1,74 @@
+import os
+from pathlib import Path
+import numpy as np
+import xarray as xr
+import shutil
+import tempfile
+import fsspec
+import unittest
+from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
+
+from toksearch.signal.zarr import ZarrSignal
+
+
+class TestZarrSignal(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.create_tmp_workdir()
+        cls.create_tmp_zarr()
+
+    @classmethod
+    def create_tmp_workdir(self):
+        # Create a temporary directory
+        self.test_dir = Path(tempfile.mkdtemp())
+        # Save the original working directory
+        self.original_dir = Path.cwd()
+        # Change to the temp directory
+        os.chdir(self.test_dir)
+
+    @classmethod
+    def create_tmp_zarr(self):
+        ip = xr.DataArray(
+            np.random.random((1000,)), dims=["time"], attrs=dict(units="A")
+        )
+        time = xr.DataArray(np.linspace(0, 1.0, 1000), dims=["time"])
+        dataset = xr.Dataset(dict(ip=ip, time=time))
+        dataset.to_zarr("30421.zarr", group="magnetics")
+
+    @classmethod
+    def tearDownClass(cls):
+        # Change back to the original working directory
+        os.chdir(cls.original_dir)
+        # Remove the temp directory
+        shutil.rmtree(str(cls.test_dir))
+
+    def test_fetch(self):
+        ip_signal = ZarrSignal(path=self.test_dir, treepath="magnetics/ip")
+        result = ip_signal.fetch(30421)
+        self.assertIsInstance(result, dict)
+        self.assertIn("data", result)
+        self.assertIsInstance(result["data"], np.ndarray)
+        self.assertEqual(result["data"].shape, (1000,))
+        self.assertIsInstance(result["times"], np.ndarray)
+        self.assertEqual(result["times"].shape, (1000,))
+
+    def test_fetch_as_xarray(self):
+        ip_signal = ZarrSignal(path=self.test_dir, treepath="magnetics/ip")
+        result = ip_signal.fetch_as_xarray(30421)
+        self.assertIsInstance(result, xr.DataArray)
+        self.assertEqual(result.shape, (1000,))
+        self.assertEqual(result.attrs["units"], "A")
+
+    def test_fetch_fs(self):
+        # create a local async filesystem object for testing
+        # could replace with s3fs.S3FileSystem(...) etc. for remote file access
+        fs = AsyncFileSystemWrapper(fsspec.filesystem("file"), asynchronous=True)
+        path = f"file://{self.test_dir}"
+        ip_signal = ZarrSignal(path=path, treepath="magnetics/ip", fs=fs)
+        result = ip_signal.fetch(30421)
+        self.assertIsInstance(result, dict)
+        self.assertIn("data", result)
+        self.assertIsInstance(result["data"], np.ndarray)
+        self.assertEqual(result["data"].shape, (1000,))
+        self.assertIsInstance(result["times"], np.ndarray)
+        self.assertEqual(result["times"].shape, (1000,))

--- a/tests/test_zarr.py
+++ b/tests/test_zarr.py
@@ -27,13 +27,18 @@ class TestZarrSignal(unittest.TestCase):
         os.chdir(self.test_dir)
 
     @classmethod
-    def create_tmp_zarr(self, shot: int = 30421, group: str = "magnetics"):
+    def create_tmp_zarr(
+        self,
+        shot: int = 30421,
+        group: str = "magnetics",
+        file_name_format: str = "{shot}.zarr",
+    ):
         ip = xr.DataArray(
             np.random.random((1000,)), dims=["time"], attrs=dict(units="A")
         )
         time = xr.DataArray(np.linspace(0, 1.0, 1000), dims=["time"])
         dataset = xr.Dataset(dict(ip=ip, time=time))
-        dataset.to_zarr(f"{shot}.zarr", group=group)
+        dataset.to_zarr(file_name_format.format(shot=shot), group=group)
 
     @classmethod
     def tearDownClass(cls):
@@ -51,12 +56,6 @@ class TestZarrSignal(unittest.TestCase):
         self.assertEqual(result["data"].shape, (1000,))
         self.assertIsInstance(result["times"], np.ndarray)
         self.assertEqual(result["times"].shape, (1000,))
-
-    def test_fetch_no_group(self):
-        self.create_tmp_zarr(30422, group=None)
-        ip_signal = ZarrSignal(path=self.test_dir, treepath="ip")
-        result = ip_signal.fetch_as_xarray(30422)
-        self.assertIsInstance(result, xr.DataArray)
 
     def test_fetch_as_xarray(self):
         ip_signal = ZarrSignal(path=self.test_dir, treepath="magnetics/ip")
@@ -78,3 +77,19 @@ class TestZarrSignal(unittest.TestCase):
         self.assertEqual(result["data"].shape, (1000,))
         self.assertIsInstance(result["times"], np.ndarray)
         self.assertEqual(result["times"].shape, (1000,))
+
+    def test_fetch_no_group(self):
+        self.create_tmp_zarr(30422, group=None)
+        ip_signal = ZarrSignal(path=self.test_dir, treepath="ip")
+        result = ip_signal.fetch_as_xarray(30422)
+        self.assertIsInstance(result, xr.DataArray)
+
+    def test_fetch_custom_file_name_format(self):
+        custom_name = "MAST{shot}.zarr"
+        self.create_tmp_zarr(30423, file_name_format=custom_name)
+
+        ip_signal = ZarrSignal(
+            path=self.test_dir, treepath="magnetics/ip", file_name_format=custom_name
+        )
+        result = ip_signal.fetch_as_xarray(30423)
+        self.assertIsInstance(result, xr.DataArray)

--- a/tests/test_zarr.py
+++ b/tests/test_zarr.py
@@ -27,13 +27,13 @@ class TestZarrSignal(unittest.TestCase):
         os.chdir(self.test_dir)
 
     @classmethod
-    def create_tmp_zarr(self):
+    def create_tmp_zarr(self, shot: int = 30421, group: str = "magnetics"):
         ip = xr.DataArray(
             np.random.random((1000,)), dims=["time"], attrs=dict(units="A")
         )
         time = xr.DataArray(np.linspace(0, 1.0, 1000), dims=["time"])
         dataset = xr.Dataset(dict(ip=ip, time=time))
-        dataset.to_zarr("30421.zarr", group="magnetics")
+        dataset.to_zarr(f"{shot}.zarr", group=group)
 
     @classmethod
     def tearDownClass(cls):
@@ -51,6 +51,12 @@ class TestZarrSignal(unittest.TestCase):
         self.assertEqual(result["data"].shape, (1000,))
         self.assertIsInstance(result["times"], np.ndarray)
         self.assertEqual(result["times"].shape, (1000,))
+
+    def test_fetch_no_group(self):
+        self.create_tmp_zarr(30422, group=None)
+        ip_signal = ZarrSignal(path=self.test_dir, treepath="ip")
+        result = ip_signal.fetch_as_xarray(30422)
+        self.assertIsInstance(result, xr.DataArray)
 
     def test_fetch_as_xarray(self):
         ip_signal = ZarrSignal(path=self.test_dir, treepath="magnetics/ip")

--- a/toksearch/__init__.py
+++ b/toksearch/__init__.py
@@ -14,8 +14,7 @@
 
 from .signal.signal import Signal
 from .signal.zarr import ZarrSignal
-
-# from .signal.mds import MdsSignal, MdsTreePath
+from .signal.mds import MdsSignal, MdsTreePath
 from .pipeline.align import XarrayAligner
 from .pipeline import Pipeline
 

--- a/toksearch/__init__.py
+++ b/toksearch/__init__.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 from .signal.signal import Signal
-from .signal.mds import MdsSignal, MdsTreePath
+from .signal.zarr import ZarrSignal
+
+# from .signal.mds import MdsSignal, MdsTreePath
 from .pipeline.align import XarrayAligner
 from .pipeline import Pipeline
 
@@ -21,4 +23,4 @@ from pathlib import Path
 
 from . import _version
 
-__version__ = _version.get_versions()['version']
+__version__ = _version.get_versions()["version"]

--- a/toksearch/signal/zarr.py
+++ b/toksearch/signal/zarr.py
@@ -73,7 +73,9 @@ class ZarrSignal(Signal):
             # edge case: default to using local `file://` protocol if none specified
             shot_file = f"file://{shot_file}"
         protocol, file_path = str(shot_file).split("://", maxsplit=1)
-        group_name, signal_name = self.treepath.rsplit("/", maxsplit=1)
+        parts = self.treepath.rsplit("/", maxsplit=1)
+        signal_name = parts[-1]
+        group_name = parts[-2] if len(parts) > 1 else None
 
         store = zarr.storage.FsspecStore(fs=self.fs, path=file_path)
         store = xr.open_zarr(store, group=group_name)

--- a/toksearch/signal/zarr.py
+++ b/toksearch/signal/zarr.py
@@ -31,6 +31,7 @@ class ZarrSignal(Signal):
         treepath: str,
         dims: Iterable[str] = ("times",),
         fetch_units: bool = True,
+        file_name_format: str = "{shot}.zarr",
         fs: Optional[AsyncFileSystem] = None,
     ):
         """Create a signal object that fetches data from an MDSplus tree
@@ -41,6 +42,9 @@ class ZarrSignal(Signal):
             dims: See documentation for the Signal class. Defaults to ('times',)
             fetch_units: See documentation for the Signal class. Defaults
                 to True.
+            file_name_format: A format string containing a parameter `shot`
+                for finding shot files. e.g. `MyFunName-{shot}.zarr`. Default format will search
+                for files called `{shot}.zarr`.
             fs: The `fsspec` filesystem object to use (optional). If `None`
                 assume that Zarr store is a local path
         """
@@ -49,6 +53,7 @@ class ZarrSignal(Signal):
         self.treepath = treepath
         self.fetch_units = fetch_units
         self.dims = dims
+        self.file_name_format = file_name_format
         self.fs = fs
         if fs is None:
             self.fs = AsyncFileSystemWrapper(
@@ -68,7 +73,7 @@ class ZarrSignal(Signal):
                 attribute is True, the dictionary will also contain a key 'units' with the units
                 of the data and dimensions.
         """
-        shot_file = os.path.join(self.path, f"{shot}.zarr")
+        shot_file = os.path.join(self.path, self.file_name_format.format(shot=shot))
         if "://" not in shot_file:
             # edge case: default to using local `file://` protocol if none specified
             shot_file = f"file://{shot_file}"

--- a/toksearch/signal/zarr.py
+++ b/toksearch/signal/zarr.py
@@ -1,0 +1,112 @@
+"""This module provides classes for fetching data from Zarr stores
+
+The main class for user applications is the ZarrSignal class. This class
+provides a way to fetch data from Zarr stores either on a local disk or
+from a remote server. The ZarrSignal class is a subclass of the Signal class
+and provides the same interface as the Signal class.
+
+The ZarrSignal class is a wrapper around the ZarrLocalSignal and ZarrRemoteSignal
+classes. The ZarrLocalSignal class is used to fetch data from a local disk and
+the ZarrRemoteSignal class is used to fetch data from a remote server. The
+ZarrSignal class determines which class to use based on the location argument
+provided to the constructor.
+"""
+
+import os
+import fsspec
+import zarr
+import zarr.storage
+import xarray as xr
+from typing import Iterable, Optional
+from fsspec import AbstractFileSystem
+from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
+
+from .signal import Signal
+
+
+class ZarrSignal(Signal):
+    def __init__(
+        self,
+        path: str,
+        treepath: str,
+        dims: Iterable[str] = ("times",),
+        fetch_units: bool = True,
+        fs: Optional[AbstractFileSystem] = None,
+    ):
+        """Create a signal object that fetches data from an MDSplus tree
+
+        Arguments:
+            path: The tdi expression to fetch data from
+            treepath: The name of the signal within the store to load. e.g. `magentics/ip`
+            dims: See documentation for the Signal class. Defaults to ('times',)
+            fetch_units: See documentation for the Signal class. Defaults
+                to True.
+            fs: The `fsspec` filesystem object to use (optional). If `None`
+                assume that Zarr store is a local path
+        """
+        super().__init__()
+        self.path = path
+        self.treepath = treepath
+        self.fetch_units = fetch_units
+        self.dims = dims
+        self.fs = fs
+        if fs is None:
+            self.fs = AsyncFileSystemWrapper(
+                fsspec.filesystem("file"), asynchronous=True
+            )
+
+    def gather(self, shot):
+        """Gather the data for a shot
+
+        Arguments:
+            shot (int): The shot number to gather the data for
+
+        Returns:
+            dict: A dictionary containing the data gathered for the signal. The dictionary
+                will contain a key 'data' with the data, and keys for each dimension of the
+                data, with the values being the values of the dimensions. If the with_units
+                attribute is True, the dictionary will also contain a key 'units' with the units
+                of the data and dimensions.
+        """
+        shot_file = os.path.join(self.path, f"{shot}.zarr")
+        if "://" not in shot_file:
+            # edge case: default to using local `file://` protocol if none specified
+            shot_file = f"file://{shot_file}"
+        protocol, file_path = str(shot_file).split("://", maxsplit=1)
+        group_name, signal_name = self.treepath.rsplit("/", maxsplit=1)
+
+        store = zarr.storage.FsspecStore(fs=self.fs, path=file_path)
+        store = xr.open_zarr(store, group=group_name)
+        signal = store[signal_name]
+        data = signal.values
+
+        # Add data
+        result = dict(data=data)
+
+        # Add dimensions
+        units = {}
+        for new_dim, dim in zip(self.dims, signal.sizes.keys()):
+            if dim in store:
+                result[new_dim] = store[dim].values
+
+        # Add units
+        if self.fetch_units:
+            units = {}
+            result["units"] = {"data": signal.attrs.get("units", "")}
+            for new_dim, dim in zip(self.dims, signal.sizes.keys()):
+                if dim in store:
+                    units[new_dim] = store[dim].attrs.get("units", "")
+
+        return result
+
+    def cleanup_shot(self, shot: int):
+        """Close the tree for this shot
+
+        Arguments:
+            shot (int): The shot number to close the tree for
+        """
+        pass
+
+    def cleanup(self):
+        """Cleanup"""
+        pass

--- a/toksearch/signal/zarr.py
+++ b/toksearch/signal/zarr.py
@@ -18,7 +18,7 @@ import zarr
 import zarr.storage
 import xarray as xr
 from typing import Iterable, Optional
-from fsspec import AbstractFileSystem
+from fsspec.asyn import AsyncFileSystem
 from fsspec.implementations.asyn_wrapper import AsyncFileSystemWrapper
 
 from .signal import Signal
@@ -31,7 +31,7 @@ class ZarrSignal(Signal):
         treepath: str,
         dims: Iterable[str] = ("times",),
         fetch_units: bool = True,
-        fs: Optional[AbstractFileSystem] = None,
+        fs: Optional[AsyncFileSystem] = None,
     ):
         """Create a signal object that fetches data from an MDSplus tree
 


### PR DESCRIPTION
Hi @sammuli,

Sorry it has taken me so long to get around to this.

Here is a PR proposing to add the necessary code to support the [FAIR MAST](https://mastapp.site/) dataset to toksearch.

I have tried to write this in a generic way that is agnostic to our project and will work with any Zarr file written by `xarray`. The `ZarrSignal` class assumes that the user has a folder of zarr files (either local or remote).

For example, for local files called `./my/local/path/{shot}.zarr` one can do:

```python
ip_signal = ZarrSignal(path="./my/local/path/", treepath="magnetics/ip")
result = ip_signal.fetch_as_xarray(30421)
```

For remote files, such as our data stored in S3, we can do something like this:

```python
import s3fs
endpoint = "https://echo.stfc.ac.uk"
fs = s3fs.S3FileSystem(anon=True, endpoint_url=endpoint, asynchronous=True)
signal = ZarrSignal("s3://mast/level2/shots/", "magnetics/ip", fs=fs)
ds = signal.fetch_as_xarray(30421)
```
In theory this should support other remote filesystem implemented by `fsspec` 

Happy to hear feedback and adjust the implementation as needed!

If this PR looks good then we could consider adding support for NetCDF as well as UDA and SAL access layers from UKAEA.