### PR TITLE
Python 3 12 build

### DIFF
--- a/.github/workflows/conda_build.yaml
+++ b/.github/workflows/conda_build.yaml
@@ -25,11 +25,6 @@ jobs:
           miniforge-version: latest
           channels: conda-forge
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu' # See 'Supported distributions' for available options
-          java-version: '8'
-
       - name: Build Conda package
         run: |
           mamba install --yes boa

--- a/environment.yml
+++ b/environment.yml
@@ -19,16 +19,16 @@ channels:
 dependencies:
   - python
   - mdsplus-xrd
-  - numpy>=1.20, <2
+  - numpy >=1.20, <2
   - pymssql
   - ray-core
-  - pyspark
+  - pyspark >=4
   - scipy
   - sh
   - xarray
   - bottleneck
   - openblas
-  - joblib>=1.3
+  - joblib >=1.3
   - jupyter
   - fsspec
   - zarr=3

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -14,6 +14,15 @@
 
 python:
   - 3.11
+  - 3.12
+
+pin_run_as_build:
+  python: 
+    min_pin: x.x
+    max_pin: x.x
 
 c_compiler_version: # [unix]
-  - 13.2 # [linux]
+  - 12 # [linux]
+
+c_stdlib:
+- sysroot

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ source:
 requirements:
     build:
         - {{ compiler('c') }}
+        - {{ stdlib('c') }}
     host:
         - python
         - numpy>=1.20, <2

--- a/tests/test_aligner.py
+++ b/tests/test_aligner.py
@@ -108,7 +108,7 @@ class TestTimebaseAligner(unittest.TestCase):
         self._align("s1", "pad", True)
         res = self.pipeline.compute_shot(self.shot)
         ds = res["ds"]
-        self.assertEquals(self.d2[-2], ds["s2"].values[-1])
+        self.assertEqual(self.d2[-2], ds["s2"].values[-1])
         self.assertFalse(res.errors)
 
     def test_with_ndarray_input_pad(self):

--- a/tests/test_mds.py
+++ b/tests/test_mds.py
@@ -191,11 +191,11 @@ class TestMdsSignal(unittest.TestCase):
 
     def test_local_has_correct_treepath(self):
         sig = MdsSignal("blah", "efit01", location="abc")
-        self.assertEquals(sig.sig.treepath, "abc")
+        self.assertEqual(sig.sig.treepath, "abc")
 
     def test_local_with_double_colons(self):
         sig = MdsSignal("blah", "efit01", location="abc::")
-        self.assertEquals(sig.sig.treepath, "abc::")
+        self.assertEqual(sig.sig.treepath, "abc::")
 
     def test_create_remote_mdsignal(self):
         sig = MdsSignal("blah", "efit01", location="remote://blah")
@@ -325,8 +325,8 @@ class TestMdsRemoteSignal(GenericTestMdsSignal, unittest.TestCase):
     #    #shot = self.defaults.unitless_shot() #use shot that doesnt have units defined
     #    shot = DEFAULT_SHOT
     #    results = sig.fetch(shot)
-    #    self.assertEquals(results['units']['data']," ")
-    #    self.assertEquals(results['units']['times']," ")
+    #    self.assertEqual(results['units']['data']," ")
+    #    self.assertEqual(results['units']['times']," ")
 
 
 class TestMdsLocalSignal(GenericTestMdsSignal, unittest.TestCase):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -22,4 +22,4 @@ class TestSetEnv(unittest.TestCase):
         arbitrary_string = "aardvark"
         var = "some_variable"
         with set_env(var, arbitrary_string):
-            self.assertEquals(os.environ[var], arbitrary_string)
+            self.assertEqual(os.environ[var], arbitrary_string)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -79,7 +79,7 @@ class TestSignalRegistry(unittest.TestCase):
         reg.register(sig)
         reg.register(sig)
         self.assertIn(sig, reg)
-        self.assertEquals(len(reg.signals), 1)
+        self.assertEqual(len(reg.signals), 1)
 
 
 class TestDimensionedSignal(unittest.TestCase):
@@ -103,7 +103,7 @@ class TestDimensionedSignal(unittest.TestCase):
         sig = self.signal().set_callback(lambda _: {"data": 1234})
         shot = 1234
         res = sig.fetch(shot)
-        self.assertEquals(res["data"], 1234)
+        self.assertEqual(res["data"], 1234)
 
     def test_fetch_no_times(self):
         sig = self.signal(dims=None)


### PR DESCRIPTION
- Add 3.12 python
- New build will link against latest mdsplus-xrd which removes the old restrictive mdsplus requirements
- Now use conda to manage openjdk dependency of pyspark

Tested to build successfully for python 3.11locally