### PR TITLE
Use sysroot_linux-64=2.17 in meta.yaml

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -24,5 +24,8 @@ pin_run_as_build:
 c_compiler_version: # [unix]
   - 12 # [linux]
 
+c_stdlib: # [linux]
+  - sysroot #[linux]
+
 c_stdlib_version: # [linux]
-- 2.17 # [linux]
+  - 2.17 # [linux]


### PR DESCRIPTION
Forces use of glibc version compatible with rhel 8