### PR TITLE
Retry MdsRemoteSignal.gather once on MDSplusERROR

### DIFF
--- a/tests/test_mds.py
+++ b/tests/test_mds.py
@@ -391,6 +391,85 @@ class TestMdsConnectionRegistry(unittest.TestCase):
         conn2 = registry.connect(server)
         self.assertIsNot(conn, conn2)
 
+    def test_disconnect_calls_conn_disconnect(self):
+        # Regression: previous implementation removed the cached connection
+        # from the map but never called conn.disconnect(), leaking the
+        # underlying mdsip socket until garbage collection.
+        from unittest import mock
+        server = "fake.host:9999"
+        registry = MdsConnectionRegistry()
+        fake_conn = mock.MagicMock()
+        registry._connection_map[server] = fake_conn
+        registry.disconnect(server)
+        fake_conn.disconnect.assert_called_once()
+        self.assertNotIn(server, registry._connection_map)
+
+    def test_disconnect_unknown_server_is_noop(self):
+        registry = MdsConnectionRegistry()
+        # Must not raise even if the server was never connected.
+        registry.disconnect("never.connected:1234")
+
+
+class TestMdsRemoteSignalRetry(unittest.TestCase):
+    """Verify that MdsRemoteSignal.gather retries on MDSplusERROR.
+
+    These tests exercise the wrapper logic in isolation by patching the
+    inner _do_gather hook, so they don't need a running mdsip server.
+    """
+
+    def setUp(self):
+        from unittest import mock
+        # Wipe any cached connections to keep each test independent.
+        MdsConnectionRegistry()._connection_map.clear()
+        self.signal = MdsRemoteSignal(r"\foo", "mytree", "fake.host:9999")
+        self._mock = mock
+
+    def test_gather_returns_value_on_first_try(self):
+        with self._mock.patch.object(
+            MdsRemoteSignal, "_do_gather", return_value={"data": 42}
+        ) as do_gather:
+            result = self.signal.gather(123)
+        self.assertEqual(result, {"data": 42})
+        self.assertEqual(do_gather.call_count, 1)
+
+    def test_gather_retries_once_on_mdsplus_error(self):
+        from MDSplus.mdsExceptions import MDSplusERROR
+        # First call raises MDSplusERROR, second call returns a value.
+        side_effect = [MDSplusERROR(), {"data": 7}]
+        with self._mock.patch.object(
+            MdsRemoteSignal, "_do_gather", side_effect=side_effect
+        ) as do_gather, self._mock.patch.object(
+            MdsConnectionRegistry, "disconnect"
+        ) as disconnect:
+            result = self.signal.gather(123)
+        self.assertEqual(result, {"data": 7})
+        self.assertEqual(do_gather.call_count, 2)
+        disconnect.assert_called_once_with(self.signal.server)
+
+    def test_gather_does_not_retry_on_tree_errors(self):
+        # Tree-class errors don't corrupt the connection -- they should
+        # propagate without a reconnect.
+        from MDSplus.mdsExceptions import TreeNODATA
+        with self._mock.patch.object(
+            MdsRemoteSignal, "_do_gather", side_effect=TreeNODATA()
+        ) as do_gather, self._mock.patch.object(
+            MdsConnectionRegistry, "disconnect"
+        ) as disconnect:
+            with self.assertRaises(TreeNODATA):
+                self.signal.gather(123)
+        self.assertEqual(do_gather.call_count, 1)
+        disconnect.assert_not_called()
+
+    def test_gather_propagates_second_failure(self):
+        from MDSplus.mdsExceptions import MDSplusERROR
+        with self._mock.patch.object(
+            MdsRemoteSignal,
+            "_do_gather",
+            side_effect=[MDSplusERROR(), MDSplusERROR()],
+        ), self._mock.patch.object(MdsConnectionRegistry, "disconnect"):
+            with self.assertRaises(MDSplusERROR):
+                self.signal.gather(123)
+
 
 class TestMdsTreeRegistry(unittest.TestCase):
     def test_get_tree_returns_none_with_empty_map(self):

--- a/toksearch/signal/mds.py
+++ b/toksearch/signal/mds.py
@@ -35,7 +35,10 @@ on a local disk. The MdsTreePath class is used by the MdsLocalSignal class to
 set the environment variables for the MDSplus trees.
 """
 
+import logging
+
 import MDSplus as mds
+from MDSplus.mdsExceptions import MDSplusERROR
 import pdb
 import os
 import contextlib
@@ -46,6 +49,8 @@ from typing import Union, Iterable, Optional
 
 from .signal import Signal
 from ..utilities.utilities import set_env
+
+_log = logging.getLogger(__name__)
 
 
 def _dim_of_expression(expression, dim=0):
@@ -337,12 +342,16 @@ class MdsConnectionRegistry(object):
         return conn
 
     def disconnect(self, server):
-        if server in self._connection_map:
-            conn = self._connection_map[server]
+        """Drop the cached connection for a server and close it.
+
+        After this call, the next :meth:`connect` for the same server
+        creates a fresh :class:`MDSplus.Connection`.
+        """
+        conn = self._connection_map.pop(server, None)
+        if conn is not None:
             try:
-                del self._connection_map[server]
-                conn = self._connection_map.get(server, None)
-            except:
+                conn.disconnect()
+            except Exception:
                 pass
 
 
@@ -387,8 +396,18 @@ class MdsRemoteSignal(Signal):
 
 
     def gather(self, shot):
-        """Gather the data for a shot
-        
+        """Gather the data for a shot, with one retry on MDSplusERROR.
+
+        The mdsip server can leave per-connection state wedged after returning
+        the generic ``MDSplusERROR`` (``%MDSPLUS-E-ERROR``) for a query, so
+        subsequent operations on the same connection -- including for unrelated
+        shots -- can also return errors. To recover, drop the cached connection
+        and retry once on a fresh one.
+
+        Tree-class errors (``TreeNODATA``, ``TreeFOPENR``, ``TreeNOCURRENT``,
+        ...) follow a different server-side path and don't corrupt connection
+        state, so they are propagated unchanged.
+
         Arguments:
             shot (int): The shot number to gather the data for
 
@@ -399,6 +418,18 @@ class MdsRemoteSignal(Signal):
                 attribute is True, the dictionary will also contain a key 'units' with the units
                 of the data and dimensions.
         """
+        try:
+            return self._do_gather(shot)
+        except MDSplusERROR as e:
+            _log.warning(
+                "MDSplusERROR on %s for shot=%s expr=%r (%s); "
+                "dropping connection and retrying once",
+                self.server, shot, self.expression, e,
+            )
+            MdsConnectionRegistry().disconnect(self.server)
+            return self._do_gather(shot)
+
+    def _do_gather(self, shot):
         connection = self.connect()
         connection.openTree(self.treename, shot)
 


### PR DESCRIPTION
## Summary

- Recover from a wedged mdsip server connection: when the server returns the generic `%MDSPLUS-E-ERROR` for a query, per-connection state can be left in a desynced state where every subsequent read also returns errors -- across unrelated shots. `MdsRemoteSignal.gather` now catches `MDSplusERROR`, drops the cached connection via `MdsConnectionRegistry.disconnect`, and retries once on a fresh connection. Tree-class errors (`TreeNODATA`, `TreeFOPENR`, `TreeNOCURRENT`, ...) follow a different server-side path, don't corrupt connection state, and continue to propagate unchanged.
- Fix `MdsConnectionRegistry.disconnect`: the previous body removed the cached entry from the map but never called `conn.disconnect()`, leaking the underlying mdsip socket until GC. Now it pops the entry and closes the connection.

## Why this matters

Discovered in a 13k-shot DIII-D `efitrt1` run with `compute_serial` / `compute_multiprocessing` against `atlas.gat.com`. A handful of shots (e.g. ones with missing or unusual data on certain AEQDSK signals) trigger `MDSplusERROR` responses that wedge the cached `MDSplus.Connection`. With no recovery, every shot processed afterward fails with a tree-open error, even though the failing shots themselves are perfectly fetchable in a fresh process.

Verified empirically:

| catch strategy | shots failing (of 1000) |
|---|---|
| no patch | 100s, including all shots after the first corrupting one |
| `except MdsIpException` | 865 (zero retries actually fired -- corruption never raises an IP exception) |
| `except MDSplusERROR` | 6 (only the legitimately bad shots) |
| `except Exception` | 6 |

`MDSplusERROR` is the precise class that triggers state corruption -- narrower catches miss it, broader catches retry redundantly on tree-level errors that don't corrupt anything. The full 13k-shot run was also verified with the narrow catch.

The fix also travels correctly across `joblib.Parallel` (loky) worker boundaries, since the patch lives in `toksearch.signal.mds` itself rather than as a `__main__`-level monkey-patch.

## Test plan

- [x] New unit tests in `TestMdsRemoteSignalRetry` (no mdsip server required) cover: success on first try, retry-once on `MDSplusERROR`, no retry on `TreeNODATA`, propagation of a second failure
- [x] New `TestMdsConnectionRegistry.test_disconnect_calls_conn_disconnect` regression test for the dead-code fix
- [x] Existing `TestMdsConnectionRegistry` tests still pass
- [ ] Reviewer to run integration tests against a real mdsip server (`tests/test_mds.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)