### PR TITLE
toksearch.llm PR 1: library core

### DIFF
--- a/docs/superpowers/plans/2026-05-18-toksearch-llm-pr1.md
+++ b/docs/superpowers/plans/2026-05-18-toksearch-llm-pr1.md
@@ -1,0 +1,3798 @@
+# `toksearch.llm` PR 1 — Library Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the `toksearch.llm` library: a sync, callback-driven `Session` API over Anthropic and OpenAI backends, with `run_python` (persistent namespace) and `lookup_docs` tools, a minimal `toksearch chat` / `toksearch query` CLI, and end-to-end test coverage via a `FakeBackend`. This is PR 1 of the migration described in the design doc.
+
+**Architecture:** New `toksearch/llm/` subpackage. State is owned by `Session`; backends are stateless adapters that implement `run_conversation(session, prompt, callbacks, max_iterations) -> TurnComplete`. `_ToolLoopBackend` holds the shared tool-use loop for Anthropic and OpenAI; subclasses translate to/from native shapes. `FakeBackend` returns scripted assistant turns and is the testing seam for Session-level tests. Tools are backend-agnostic `ToolSpec`s registered with the Session at construction; `run_python` execs against `session.namespace`; `lookup_docs` reads `SKILL.md` files from `extra_skill_dirs`. CLI is a thin argparse wrapper installed as the `toksearch` console script.
+
+**Tech Stack:** Python 3.11, `anthropic`, `openai`, `unittest`, `unittest.mock`, `argparse`, `tomllib` (stdlib), pixi-managed env. Apache 2.0 license header on every new file.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-18-toksearch-llm-design.md`
+
+## Scope notes — what's deferred from the spec
+
+To keep PR 1 reviewable, the following spec items are explicitly deferred to follow-up PRs (call them out in the PR description):
+
+- **Streaming text deltas.** `_ToolLoopBackend` calls the blocking, non-streaming API; `on_text` fires once per assistant turn with the complete text. OpenAI's tool-arg streaming reassembly is not needed yet.
+- **`prompt_toolkit`-based REPL.** `toksearch chat` in PR 1 uses stdlib `input()` with a flat prompt. Multi-line input, history, and key bindings come later.
+- **Slash commands `/save`, `/history`, `/namespace`, `/backend`, `/model`.** Only `/help`, `/reset`, `/quit` ship in PR 1.
+- **`--confirm` flag.** Auto-approve only in PR 1; `confirm` callable on `Session.send()` is wired through and tested, but no CLI flag yet.
+- **`toksearch llm test` connectivity check.** Deferred.
+- **`cache_control` on Anthropic system prompt.** Deferred (small optimization).
+- **Entry-point discovery (`toksearch.llm.namespace` / `.skills` / `.presets`).** Deferred to PR 2. In PR 1, `Session` takes explicit `packages=` and `extra_skill_dirs=` keyword arguments; `packages` is currently unused (defaults to `["toksearch"]` which is hardcoded into the namespace).
+- **`ClaudeSDKBackend`.** Deferred to PR 3.
+
+All deferred items have placeholder seams in PR 1 so adding them later is additive, not a refactor.
+
+---
+
+## File Structure
+
+| File | Action | Purpose |
+|---|---|---|
+| `toksearch/llm/__init__.py` | Create | Public re-exports: `Session`, event types, `LLMError`, `Config`, `Preset`. |
+| `toksearch/llm/errors.py` | Create | `LLMError` and subclasses. |
+| `toksearch/llm/events.py` | Create | `TextDelta`, `ToolCall`, `ToolResult`, `TurnComplete` frozen dataclasses. |
+| `toksearch/llm/messages.py` | Create | Provider-neutral history: `Message`, `TextBlock`, `ToolUseBlock`, `ToolResultBlock`. |
+| `toksearch/llm/config.py` | Create | `Config` dataclass + `load_config()` (TOML + env overlay). |
+| `toksearch/llm/presets.py` | Create | `Preset` dataclass + built-in `anthropic` / `openai` presets + `resolve_preset()`. |
+| `toksearch/llm/tools.py` | Create | `ToolSpec`, `ToolOutput`, `run_python` handler, `lookup_docs` handler, skill discovery helpers. |
+| `toksearch/llm/prompts.py` | Create | Kernel system-prompt template + `build_system_prompt(skills, namespace_extras)`. |
+| `toksearch/llm/backends/__init__.py` | Create | Backend registry + `get_backend(name, config)`. |
+| `toksearch/llm/backends/base.py` | Create | `Backend` ABC, `_ToolLoopBackend`, `AssistantTurn`, `Callbacks` dataclasses. |
+| `toksearch/llm/backends/anthropic.py` | Create | `AnthropicBackend` (subclass of `_ToolLoopBackend`). |
+| `toksearch/llm/backends/openai.py` | Create | `OpenAIBackend` (subclass of `_ToolLoopBackend`). |
+| `toksearch/llm/backends/fake.py` | Create | `FakeBackend` — scripted turn returner; testing seam. |
+| `toksearch/llm/session.py` | Create | `Session` class — orchestrates state, dispatches to backend, manages namespace. |
+| `toksearch/llm/cli.py` | Create | `toksearch chat` + `toksearch query` argparse entrypoint. |
+| `pyproject.toml` | Modify | Add `[project.optional-dependencies] llm = [...]` and `[project.scripts] toksearch = ...`. |
+| `setup.py` | Modify | Add `llm` subpackages to the package list; add `entry_points` for the console script. |
+| `tests/test_llm_errors.py` | Create | Tests for `LLMError` hierarchy. |
+| `tests/test_llm_events.py` | Create | Tests for event dataclasses. |
+| `tests/test_llm_messages.py` | Create | Tests for `Message` / `ContentBlock` round-trip. |
+| `tests/test_llm_config.py` | Create | Tests for `load_config()` precedence. |
+| `tests/test_llm_presets.py` | Create | Tests for preset resolution. |
+| `tests/test_llm_tools.py` | Create | Tests for `run_python` (namespace persistence, error capture, KeyboardInterrupt) and `lookup_docs`. |
+| `tests/test_llm_prompts.py` | Create | Tests for system-prompt assembly. |
+| `tests/test_llm_backends_base.py` | Create | Tests for `_ToolLoopBackend` loop behavior via a minimal subclass. |
+| `tests/test_llm_backends_fake.py` | Create | Tests for `FakeBackend`. |
+| `tests/test_llm_backends_anthropic.py` | Create | Tests for `AnthropicBackend` with `anthropic.Anthropic` mocked. |
+| `tests/test_llm_backends_openai.py` | Create | Tests for `OpenAIBackend` with `openai.OpenAI` mocked. |
+| `tests/test_llm_session.py` | Create | Session-level tests with `FakeBackend`. |
+| `tests/test_llm_cli.py` | Create | CLI subcommand wiring + slash commands; Session mocked. |
+| `tests/test_llm_package.py` | Create | Confirms `from toksearch.llm import Session, ...` works and console-script entry resolves. |
+
+Test runner: existing `tests/testit.py` uses `unittest.TestLoader().discover(".")`; any file named `test_*.py` is auto-discovered. Tests must not require network. All LLM SDK calls are mocked.
+
+---
+
+## Task 1: Create the `toksearch.llm` package skeleton
+
+**Files:**
+- Create: `toksearch/llm/__init__.py`
+- Create: `toksearch/llm/backends/__init__.py`
+- Create: `tests/test_llm_package.py`
+
+This task establishes the package directory structure so subsequent tasks have a place to put their files. The `__init__.py` files are empty placeholders that will get real re-exports in Task 17.
+
+- [ ] **Step 1: Create `toksearch/llm/__init__.py`**
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""toksearch.llm — Conversational LLM interface for TokSearch.
+
+Public re-exports are wired up at the end of PR 1; see
+``docs/superpowers/specs/2026-05-18-toksearch-llm-design.md``.
+"""
+```
+
+- [ ] **Step 2: Create `toksearch/llm/backends/__init__.py`**
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""Backend implementations for toksearch.llm."""
+```
+
+- [ ] **Step 3: Write a smoke test that the package is importable**
+
+Create `tests/test_llm_package.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Smoke test: the toksearch.llm package and its backends subpackage import."""
+
+import unittest
+
+
+class TestPackageImports(unittest.TestCase):
+    def test_import_toksearch_llm(self):
+        import toksearch.llm  # noqa: F401
+
+    def test_import_toksearch_llm_backends(self):
+        import toksearch.llm.backends  # noqa: F401
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 4: Run the smoke test**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_package -v'
+```
+
+Expected: 2 tests pass. If `import toksearch.llm` fails with `ModuleNotFoundError`, the editable install hasn't picked up the new subpackage — re-run `pixi run build` to refresh.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/__init__.py toksearch/llm/backends/__init__.py tests/test_llm_package.py
+git commit -m "Add toksearch.llm package skeleton"
+```
+
+---
+
+## Task 2: Add the `LLMError` hierarchy
+
+**Files:**
+- Create: `toksearch/llm/errors.py`
+- Create: `tests/test_llm_errors.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_errors.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for the LLMError hierarchy."""
+
+import unittest
+
+from toksearch.llm.errors import (
+    LLMError,
+    LLMConfigError,
+    LLMAuthError,
+    LLMBackendError,
+    LLMRateLimitError,
+    LLMUserAbort,
+)
+
+
+class TestErrorHierarchy(unittest.TestCase):
+    def test_all_inherit_from_llm_error(self):
+        for cls in (LLMConfigError, LLMAuthError, LLMBackendError,
+                    LLMRateLimitError, LLMUserAbort):
+            self.assertTrue(issubclass(cls, LLMError),
+                            f"{cls.__name__} must inherit LLMError")
+
+    def test_llm_error_inherits_from_exception(self):
+        self.assertTrue(issubclass(LLMError, Exception))
+
+    def test_user_abort_inherits_from_keyboard_interrupt(self):
+        # LLMUserAbort is raised in response to user ctrl-C, so it should
+        # also pass `except KeyboardInterrupt` for shells that explicitly
+        # filter on that type.
+        self.assertTrue(issubclass(LLMUserAbort, KeyboardInterrupt))
+
+    def test_raise_and_catch_via_base(self):
+        with self.assertRaises(LLMError):
+            raise LLMAuthError("bad key")
+
+    def test_message_is_preserved(self):
+        try:
+            raise LLMBackendError("503 service unavailable")
+        except LLMBackendError as e:
+            self.assertEqual(str(e), "503 service unavailable")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_errors -v'
+```
+
+Expected: `ModuleNotFoundError: No module named 'toksearch.llm.errors'`.
+
+- [ ] **Step 3: Implement `errors.py`**
+
+Create `toksearch/llm/errors.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Exception hierarchy for toksearch.llm.
+
+All exceptions raised by toksearch.llm inherit from ``LLMError``.  ``LLMUserAbort``
+also inherits from ``KeyboardInterrupt`` so REPL frames can use a single
+``except KeyboardInterrupt`` to handle ctrl-C.
+"""
+
+
+class LLMError(Exception):
+    """Base class for all toksearch.llm exceptions."""
+
+
+class LLMConfigError(LLMError):
+    """Bad configuration: unknown backend, unknown model, malformed preset."""
+
+
+class LLMAuthError(LLMError):
+    """Authentication failure: missing API key, invalid token, 401/403."""
+
+
+class LLMBackendError(LLMError):
+    """Backend returned an unrecoverable error: 5xx, network failure after retries."""
+
+
+class LLMRateLimitError(LLMError):
+    """Rate-limited by the provider; ``Retry-After`` exhausted."""
+
+
+class LLMUserAbort(LLMError, KeyboardInterrupt):
+    """User interrupted the conversation (e.g. ctrl-C between tool calls)."""
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_errors -v'
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/errors.py tests/test_llm_errors.py
+git commit -m "Add LLMError exception hierarchy"
+```
+
+---
+
+## Task 3: Add event dataclasses
+
+**Files:**
+- Create: `toksearch/llm/events.py`
+- Create: `tests/test_llm_events.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_events.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for the event dataclasses dispatched by Session.send()."""
+
+import unittest
+
+from toksearch.llm.events import (
+    TextDelta,
+    ToolCall,
+    ToolResult,
+    TurnComplete,
+)
+
+
+class TestEvents(unittest.TestCase):
+    def test_text_delta_holds_text(self):
+        e = TextDelta(text="hello")
+        self.assertEqual(e.text, "hello")
+
+    def test_tool_call_fields(self):
+        e = ToolCall(id="abc", name="run_python",
+                     args={"code": "x = 1", "thought": "set x"},
+                     thought="set x")
+        self.assertEqual(e.id, "abc")
+        self.assertEqual(e.name, "run_python")
+        self.assertEqual(e.args, {"code": "x = 1", "thought": "set x"})
+        self.assertEqual(e.thought, "set x")
+
+    def test_tool_call_thought_optional(self):
+        e = ToolCall(id="abc", name="lookup_docs",
+                     args={"skill_name": "toksearch-pipeline"},
+                     thought=None)
+        self.assertIsNone(e.thought)
+
+    def test_tool_result_fields(self):
+        e = ToolResult(id="abc", output="42", is_error=False)
+        self.assertFalse(e.is_error)
+        self.assertEqual(e.output, "42")
+
+    def test_turn_complete_fields(self):
+        e = TurnComplete(stop_reason="end_turn", final_text="done")
+        self.assertEqual(e.stop_reason, "end_turn")
+        self.assertEqual(e.final_text, "done")
+
+    def test_events_are_frozen(self):
+        e = TextDelta(text="hi")
+        with self.assertRaises(Exception):  # FrozenInstanceError or AttributeError
+            e.text = "bye"
+
+    def test_events_compare_by_value(self):
+        a = TextDelta(text="hi")
+        b = TextDelta(text="hi")
+        c = TextDelta(text="bye")
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, c)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_events -v'
+```
+
+Expected: `ModuleNotFoundError: No module named 'toksearch.llm.events'`.
+
+- [ ] **Step 3: Implement `events.py`**
+
+Create `toksearch/llm/events.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Event dataclasses dispatched to Session.send() callbacks.
+
+Events are frozen and compare by value.  They are emitted by the active
+``Backend`` while the conversation advances; ``Session.send()`` routes them
+to the appropriate ``on_<kind>`` callback (and to ``on_event`` if provided).
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class TextDelta:
+    """An incremental (or whole, in non-streaming backends) chunk of assistant text."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """The assistant is requesting a tool invocation.
+
+    ``thought`` is populated for ``run_python`` (its schema requires a
+    ``thought`` field) and is ``None`` for tools without one.
+    """
+
+    id: str
+    name: str
+    args: dict
+    thought: str | None
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """The output of a tool invocation, about to be sent back to the model."""
+
+    id: str
+    output: str
+    is_error: bool
+
+
+@dataclass(frozen=True)
+class TurnComplete:
+    """The assistant has finished this turn.
+
+    ``stop_reason``:
+    - ``"end_turn"``: assistant stopped emitting tool calls.
+    - ``"max_iterations"``: hit ``Session.max_iterations`` before end_turn.
+    - ``"interrupted"``: user aborted (ctrl-C) or ``confirm()`` returned False.
+    """
+
+    stop_reason: Literal["end_turn", "max_iterations", "interrupted"]
+    final_text: str
+
+
+Event = TextDelta | ToolCall | ToolResult | TurnComplete
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_events -v'
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/events.py tests/test_llm_events.py
+git commit -m "Add event dataclasses for Session callbacks"
+```
+
+---
+
+## Task 4: Add `Message` and `ContentBlock` types
+
+**Files:**
+- Create: `toksearch/llm/messages.py`
+- Create: `tests/test_llm_messages.py`
+
+Provider-neutral history representation.  Backends translate to/from their native
+shapes on the boundary; the Session and tests see only this taxonomy.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_messages.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for the provider-neutral Message / ContentBlock types."""
+
+import unittest
+
+from toksearch.llm.messages import (
+    Message,
+    TextBlock,
+    ToolUseBlock,
+    ToolResultBlock,
+    block_to_dict,
+    dict_to_block,
+    message_to_dict,
+    dict_to_message,
+)
+
+
+class TestContentBlocks(unittest.TestCase):
+    def test_text_block_kind(self):
+        b = TextBlock(text="hi")
+        self.assertEqual(b.kind, "text")
+        self.assertEqual(b.text, "hi")
+
+    def test_tool_use_block_kind(self):
+        b = ToolUseBlock(id="t1", name="run_python", args={"code": "1"})
+        self.assertEqual(b.kind, "tool_use")
+
+    def test_tool_result_block_kind(self):
+        b = ToolResultBlock(tool_use_id="t1", output="1", is_error=False)
+        self.assertEqual(b.kind, "tool_result")
+
+
+class TestMessage(unittest.TestCase):
+    def test_user_text_message(self):
+        m = Message(role="user", content=[TextBlock(text="hello")])
+        self.assertEqual(m.role, "user")
+        self.assertEqual(len(m.content), 1)
+
+    def test_assistant_mixed_content(self):
+        m = Message(role="assistant", content=[
+            TextBlock(text="let me run code"),
+            ToolUseBlock(id="t1", name="run_python",
+                         args={"code": "x = 1", "thought": "set x"}),
+        ])
+        self.assertEqual(len(m.content), 2)
+
+
+class TestSerialization(unittest.TestCase):
+    """Round-trip support for future /save persistence."""
+
+    def test_text_block_round_trip(self):
+        b = TextBlock(text="hi")
+        d = block_to_dict(b)
+        self.assertEqual(d, {"kind": "text", "text": "hi"})
+        self.assertEqual(dict_to_block(d), b)
+
+    def test_tool_use_block_round_trip(self):
+        b = ToolUseBlock(id="t1", name="run_python", args={"code": "x"})
+        d = block_to_dict(b)
+        self.assertEqual(d, {"kind": "tool_use", "id": "t1",
+                             "name": "run_python", "args": {"code": "x"}})
+        self.assertEqual(dict_to_block(d), b)
+
+    def test_tool_result_block_round_trip(self):
+        b = ToolResultBlock(tool_use_id="t1", output="ok", is_error=False)
+        d = block_to_dict(b)
+        self.assertEqual(d, {"kind": "tool_result", "tool_use_id": "t1",
+                             "output": "ok", "is_error": False})
+        self.assertEqual(dict_to_block(d), b)
+
+    def test_message_round_trip(self):
+        m = Message(role="assistant", content=[
+            TextBlock(text="a"),
+            ToolUseBlock(id="t1", name="run_python", args={"code": "1"}),
+        ])
+        d = message_to_dict(m)
+        self.assertEqual(d["role"], "assistant")
+        self.assertEqual(len(d["content"]), 2)
+        self.assertEqual(dict_to_message(d), m)
+
+    def test_dict_to_block_rejects_unknown_kind(self):
+        with self.assertRaises(ValueError):
+            dict_to_block({"kind": "bogus"})
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_messages -v'
+```
+
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement `messages.py`**
+
+Create `toksearch/llm/messages.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Provider-neutral conversation history representation.
+
+``Message`` is one turn in the history.  Its ``content`` is a list of
+``ContentBlock``s — a tagged union (``kind`` field) of text, tool-use, and
+tool-result blocks.  Backends translate to and from their native shapes on
+their request/response boundary; the Session and tests see only this taxonomy.
+
+``*_to_dict`` and ``dict_to_*`` helpers provide JSON-safe round-trip so
+``/save`` (future) can serialize the history without provider-specific objects.
+"""
+
+from dataclasses import dataclass, field
+from typing import Literal, Union
+
+
+@dataclass
+class TextBlock:
+    text: str
+    kind: Literal["text"] = "text"
+
+
+@dataclass
+class ToolUseBlock:
+    id: str
+    name: str
+    args: dict
+    kind: Literal["tool_use"] = "tool_use"
+
+
+@dataclass
+class ToolResultBlock:
+    tool_use_id: str
+    output: str
+    is_error: bool
+    kind: Literal["tool_result"] = "tool_result"
+
+
+ContentBlock = Union[TextBlock, ToolUseBlock, ToolResultBlock]
+
+
+@dataclass
+class Message:
+    role: Literal["user", "assistant"]
+    content: list[ContentBlock] = field(default_factory=list)
+
+
+def block_to_dict(b: ContentBlock) -> dict:
+    if isinstance(b, TextBlock):
+        return {"kind": "text", "text": b.text}
+    if isinstance(b, ToolUseBlock):
+        return {"kind": "tool_use", "id": b.id, "name": b.name, "args": b.args}
+    if isinstance(b, ToolResultBlock):
+        return {"kind": "tool_result", "tool_use_id": b.tool_use_id,
+                "output": b.output, "is_error": b.is_error}
+    raise ValueError(f"Unknown block type: {type(b).__name__}")
+
+
+def dict_to_block(d: dict) -> ContentBlock:
+    kind = d.get("kind")
+    if kind == "text":
+        return TextBlock(text=d["text"])
+    if kind == "tool_use":
+        return ToolUseBlock(id=d["id"], name=d["name"], args=d["args"])
+    if kind == "tool_result":
+        return ToolResultBlock(tool_use_id=d["tool_use_id"],
+                               output=d["output"], is_error=d["is_error"])
+    raise ValueError(f"Unknown block kind: {kind!r}")
+
+
+def message_to_dict(m: Message) -> dict:
+    return {"role": m.role,
+            "content": [block_to_dict(b) for b in m.content]}
+
+
+def dict_to_message(d: dict) -> Message:
+    return Message(role=d["role"],
+                   content=[dict_to_block(b) for b in d["content"]])
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_messages -v'
+```
+
+Expected: 10 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/messages.py tests/test_llm_messages.py
+git commit -m "Add provider-neutral Message and ContentBlock types"
+```
+
+---
+
+## Task 5: Add `Config` and `load_config()`
+
+**Files:**
+- Create: `toksearch/llm/config.py`
+- Create: `tests/test_llm_config.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_config.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for Config and load_config()."""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from toksearch.llm.config import Config, load_config
+
+
+class TestConfigDefaults(unittest.TestCase):
+    def test_default_backend_is_none(self):
+        cfg = Config()
+        self.assertIsNone(cfg.backend)
+
+    def test_default_max_iterations(self):
+        cfg = Config()
+        self.assertEqual(cfg.max_iterations, 20)
+
+    def test_anthropic_key_default(self):
+        cfg = Config()
+        self.assertIsNone(cfg.anthropic_api_key)
+
+
+class TestLoadConfig(unittest.TestCase):
+    def setUp(self):
+        # Isolate env so test order doesn't matter
+        self._saved_env = {k: os.environ.pop(k, None)
+                           for k in ("FDP_LLM_BACKEND",
+                                     "ANTHROPIC_API_KEY",
+                                     "OPENAI_API_KEY")}
+
+    def tearDown(self):
+        for k, v in self._saved_env.items():
+            if v is not None:
+                os.environ[k] = v
+
+    def test_no_file_no_env_returns_defaults(self):
+        cfg = load_config(config_path=Path("/does/not/exist"))
+        self.assertIsNone(cfg.backend)
+        self.assertEqual(cfg.max_iterations, 20)
+
+    def test_loads_from_toml(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write('[llm]\nbackend = "openai"\nmax_iterations = 5\n'
+                    'anthropic_api_key = "sk-file"\n')
+            path = Path(f.name)
+        try:
+            cfg = load_config(config_path=path)
+            self.assertEqual(cfg.backend, "openai")
+            self.assertEqual(cfg.max_iterations, 5)
+            self.assertEqual(cfg.anthropic_api_key, "sk-file")
+        finally:
+            path.unlink()
+
+    def test_env_overrides_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write('[llm]\nbackend = "openai"\nanthropic_api_key = "sk-file"\n')
+            path = Path(f.name)
+        try:
+            with mock.patch.dict(os.environ, {"FDP_LLM_BACKEND": "anthropic",
+                                              "ANTHROPIC_API_KEY": "sk-env"}):
+                cfg = load_config(config_path=path)
+            self.assertEqual(cfg.backend, "anthropic")
+            self.assertEqual(cfg.anthropic_api_key, "sk-env")
+        finally:
+            path.unlink()
+
+    def test_malformed_toml_raises_config_error(self):
+        from toksearch.llm.errors import LLMConfigError
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write("this is not [valid toml")
+            path = Path(f.name)
+        try:
+            with self.assertRaises(LLMConfigError):
+                load_config(config_path=path)
+        finally:
+            path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_config -v'
+```
+
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement `config.py`**
+
+Create `toksearch/llm/config.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Configuration object and loader for toksearch.llm.
+
+Precedence (highest first):
+  1. CLI flags (applied by callers after ``load_config()`` returns)
+  2. Environment variables: ``FDP_LLM_BACKEND``, ``ANTHROPIC_API_KEY``,
+     ``OPENAI_API_KEY``
+  3. ``~/.fdp/config.toml`` (``[llm]`` table)
+  4. Built-in defaults
+"""
+
+import os
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .errors import LLMConfigError
+
+
+@dataclass
+class Config:
+    backend: str | None = None          # preset name; None → caller's default
+    model: str | None = None            # overrides preset's default model
+    max_iterations: int = 20
+    anthropic_api_key: str | None = None
+    openai_api_key: str | None = None
+    user_presets: dict = field(default_factory=dict)
+
+
+_DEFAULT_CONFIG_PATH = Path.home() / ".fdp" / "config.toml"
+
+
+def load_config(config_path: Path | None = None) -> Config:
+    cfg = Config()
+    path = config_path if config_path is not None else _DEFAULT_CONFIG_PATH
+    if path.exists():
+        try:
+            with path.open("rb") as f:
+                data = tomllib.load(f)
+        except tomllib.TOMLDecodeError as e:
+            raise LLMConfigError(f"Malformed TOML in {path}: {e}") from e
+        llm = data.get("llm", {})
+        if "backend" in llm:
+            cfg.backend = llm["backend"]
+        if "model" in llm:
+            cfg.model = llm["model"]
+        if "max_iterations" in llm:
+            cfg.max_iterations = int(llm["max_iterations"])
+        if "anthropic_api_key" in llm:
+            cfg.anthropic_api_key = llm["anthropic_api_key"]
+        if "openai_api_key" in llm:
+            cfg.openai_api_key = llm["openai_api_key"]
+        cfg.user_presets = llm.get("presets", {})
+    # Env overlay
+    if "FDP_LLM_BACKEND" in os.environ:
+        cfg.backend = os.environ["FDP_LLM_BACKEND"]
+    if "ANTHROPIC_API_KEY" in os.environ:
+        cfg.anthropic_api_key = os.environ["ANTHROPIC_API_KEY"]
+    if "OPENAI_API_KEY" in os.environ:
+        cfg.openai_api_key = os.environ["OPENAI_API_KEY"]
+    return cfg
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_config -v'
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/config.py tests/test_llm_config.py
+git commit -m "Add Config dataclass and load_config() with env overlay"
+```
+
+---
+
+## Task 6: Add `Preset` and preset resolution
+
+**Files:**
+- Create: `toksearch/llm/presets.py`
+- Create: `tests/test_llm_presets.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_presets.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for Preset resolution."""
+
+import unittest
+
+from toksearch.llm.config import Config
+from toksearch.llm.errors import LLMConfigError
+from toksearch.llm.presets import Preset, resolve_preset, BUILTIN_PRESETS
+
+
+class TestPreset(unittest.TestCase):
+    def test_builtin_anthropic_exists(self):
+        self.assertIn("anthropic", BUILTIN_PRESETS)
+        p = BUILTIN_PRESETS["anthropic"]
+        self.assertEqual(p.backend, "anthropic")
+        self.assertEqual(p.api_key_env, "ANTHROPIC_API_KEY")
+
+    def test_builtin_openai_exists(self):
+        self.assertIn("openai", BUILTIN_PRESETS)
+        p = BUILTIN_PRESETS["openai"]
+        self.assertEqual(p.backend, "openai")
+        self.assertEqual(p.api_key_env, "OPENAI_API_KEY")
+
+
+class TestResolvePreset(unittest.TestCase):
+    def test_resolves_builtin(self):
+        p = resolve_preset("anthropic", Config())
+        self.assertEqual(p.backend, "anthropic")
+
+    def test_unknown_preset_raises(self):
+        with self.assertRaises(LLMConfigError):
+            resolve_preset("nonexistent", Config())
+
+    def test_user_preset_overrides_builtin(self):
+        cfg = Config(user_presets={"anthropic": {"model": "custom-model"}})
+        p = resolve_preset("anthropic", cfg)
+        # User preset is shallow-merged onto built-in; model is overridden.
+        self.assertEqual(p.model, "custom-model")
+        # Other fields fall through from built-in.
+        self.assertEqual(p.backend, "anthropic")
+
+    def test_user_only_preset(self):
+        cfg = Config(user_presets={"mysite": {"backend": "anthropic",
+                                              "base_url": "https://x.example",
+                                              "model": "claude-sonnet-4-6",
+                                              "api_key_env": "MY_KEY"}})
+        p = resolve_preset("mysite", cfg)
+        self.assertEqual(p.backend, "anthropic")
+        self.assertEqual(p.base_url, "https://x.example")
+        self.assertEqual(p.api_key_env, "MY_KEY")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_presets -v'
+```
+
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement `presets.py`**
+
+Create `toksearch/llm/presets.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Backend presets.
+
+A ``Preset`` is a named configuration that maps a user-facing backend name
+(e.g. ``"anthropic"``, ``"amsc"``, ``"openai"``) to a concrete ``Backend``
+class plus the kwargs needed to construct it.  Presets exist so that
+site-specific endpoints (AmSC's Anthropic-compatible URL, etc.) can be added
+without subclassing ``AnthropicBackend`` just to change a ``base_url``.
+
+Built-in presets ship with core toksearch.  User presets come from
+``~/.fdp/config.toml``'s ``[llm.presets.<name>]`` tables and are merged in via
+``Config.user_presets``.  In PR 2, package-contributed presets will also be
+discovered via the ``toksearch.llm.presets`` entry point.
+"""
+
+from dataclasses import dataclass, field, replace
+
+from .config import Config
+from .errors import LLMConfigError
+
+
+@dataclass(frozen=True)
+class Preset:
+    backend: str                # "anthropic" | "openai" | "claude-max"
+    model: str | None = None
+    base_url: str | None = None
+    api_key_file: str | None = None
+    api_key_env: str | None = None
+    extra: dict = field(default_factory=dict)
+
+
+BUILTIN_PRESETS: dict[str, Preset] = {
+    "anthropic": Preset(
+        backend="anthropic",
+        model="claude-sonnet-4-6",
+        api_key_env="ANTHROPIC_API_KEY",
+    ),
+    "openai": Preset(
+        backend="openai",
+        model="gpt-4o",
+        api_key_env="OPENAI_API_KEY",
+    ),
+}
+
+
+def resolve_preset(name: str, config: Config) -> Preset:
+    """Resolve a preset name to a fully-populated ``Preset``.
+
+    Lookup order: user presets > built-in presets.  When a preset name exists
+    in both, the user preset's fields are merged on top of the built-in.
+    """
+    user = config.user_presets.get(name, {})
+    if name in BUILTIN_PRESETS:
+        base = BUILTIN_PRESETS[name]
+        if user:
+            return replace(base, **{k: v for k, v in user.items()
+                                    if k in {"backend", "model", "base_url",
+                                             "api_key_file", "api_key_env"}})
+        return base
+    if user:
+        try:
+            return Preset(**{k: v for k, v in user.items()
+                             if k in {"backend", "model", "base_url",
+                                      "api_key_file", "api_key_env", "extra"}})
+        except TypeError as e:
+            raise LLMConfigError(f"Invalid user preset {name!r}: {e}") from e
+    raise LLMConfigError(
+        f"Unknown backend / preset: {name!r}. Built-in presets: "
+        f"{sorted(BUILTIN_PRESETS)}. Define a user preset in "
+        f"~/.fdp/config.toml under [llm.presets.{name}].")
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_presets -v'
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/presets.py tests/test_llm_presets.py
+git commit -m "Add Preset dataclass and resolution with built-in presets"
+```
+
+---
+
+## Task 7: Add `ToolSpec`, `ToolOutput`, and the `run_python` handler
+
+**Files:**
+- Create: `toksearch/llm/tools.py`
+- Create: `tests/test_llm_tools.py` (only the `run_python` sections — `lookup_docs` is added in Task 8)
+
+This task adds the tool type scaffolding plus the first tool handler.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_tools.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for tools.py — ToolSpec, ToolOutput, and tool handlers.
+
+Tool handlers take ``(args: dict, session)``.  These tests pass a duck-typed
+stub with a ``.namespace`` attribute; the real ``Session`` class is tested in
+``test_llm_session.py``.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from toksearch.llm.tools import (
+    ToolSpec,
+    ToolOutput,
+    RUN_PYTHON,
+)
+
+
+def _stub_session(namespace: dict | None = None):
+    return SimpleNamespace(namespace=namespace if namespace is not None else {})
+
+
+class TestToolSpec(unittest.TestCase):
+    def test_run_python_spec_shape(self):
+        self.assertEqual(RUN_PYTHON.name, "run_python")
+        self.assertIn("code", RUN_PYTHON.input_schema["properties"])
+        self.assertIn("thought", RUN_PYTHON.input_schema["properties"])
+        self.assertEqual(set(RUN_PYTHON.input_schema["required"]),
+                         {"code", "thought"})
+
+
+class TestRunPython(unittest.TestCase):
+    def test_simple_expression_no_output(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler({"code": "x = 1 + 1", "thought": "test"}, s)
+        self.assertFalse(out.is_error)
+        self.assertEqual(s.namespace["x"], 2)
+
+    def test_stdout_captured(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler({"code": "print('hi')", "thought": "x"}, s)
+        self.assertFalse(out.is_error)
+        self.assertIn("hi", out.text)
+
+    def test_stderr_captured(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler({"code": "import sys; sys.stderr.write('warn\\n')",
+                                  "thought": "x"}, s)
+        self.assertFalse(out.is_error)
+        self.assertIn("warn", out.text)
+
+    def test_exception_becomes_error(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler({"code": "1/0", "thought": "boom"}, s)
+        self.assertTrue(out.is_error)
+        self.assertIn("ZeroDivisionError", out.text)
+        # Traceback contains the offending line:
+        self.assertIn("Traceback", out.text)
+
+    def test_namespace_persists_across_calls(self):
+        s = _stub_session()
+        RUN_PYTHON.handler({"code": "x = 42", "thought": "set"}, s)
+        out = RUN_PYTHON.handler({"code": "print(x * 2)", "thought": "read"}, s)
+        self.assertIn("84", out.text)
+
+    def test_no_output_message(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler({"code": "x = 1", "thought": "x"}, s)
+        self.assertEqual(out.text, "(no output)")
+
+    def test_keyboard_interrupt_returns_interrupted(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler(
+            {"code": "raise KeyboardInterrupt()", "thought": "x"}, s)
+        self.assertTrue(out.is_error)
+        self.assertTrue(out.interrupted)
+        self.assertEqual(out.text, "(interrupted)")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_tools -v'
+```
+
+Expected: `ModuleNotFoundError: No module named 'toksearch.llm.tools'`.
+
+- [ ] **Step 3: Implement `tools.py` with `run_python` only**
+
+Create `toksearch/llm/tools.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tools registered with a Session.
+
+Two tools ship in PR 1:
+
+- ``run_python`` — executes Python code in the Session's persistent namespace.
+- ``lookup_docs`` — returns the SKILL.md body for a named skill.
+
+Tool handlers take ``(args: dict, session)`` and return a ``ToolOutput``.
+"""
+
+import io
+import traceback
+from contextlib import redirect_stdout, redirect_stderr
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class ToolOutput:
+    """Result of a tool invocation."""
+
+    text: str
+    is_error: bool = False
+    interrupted: bool = False    # True only when handler caught KeyboardInterrupt
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Backend-agnostic tool descriptor.
+
+    Backends translate ``input_schema`` to their native shape on request build.
+    """
+
+    name: str
+    description: str
+    input_schema: dict
+    handler: Callable[[dict, Any], ToolOutput]
+
+
+# ----------------------------------------------------------------------
+# run_python
+# ----------------------------------------------------------------------
+
+_RUN_PYTHON_DESCRIPTION = (
+    "Execute a Python code string. The execution namespace persists across "
+    "calls within this session, so variables set in earlier calls are "
+    "available later. The namespace is pre-populated with: toksearch, plt "
+    "(matplotlib.pyplot), pd (pandas), np (numpy). Returns captured stdout "
+    "and stderr. Populate 'thought' with a one-sentence description of what "
+    "this code does and why."
+)
+
+
+def _run_python_handler(args: dict, session) -> ToolOutput:
+    code = args["code"]
+    stdout_buf = io.StringIO()
+    stderr_buf = io.StringIO()
+    is_error = False
+    interrupted = False
+    try:
+        with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
+            exec(code, session.namespace)  # noqa: S102 -- intentional
+    except KeyboardInterrupt:
+        return ToolOutput(text="(interrupted)", is_error=True, interrupted=True)
+    except Exception:
+        stderr_buf.write(traceback.format_exc())
+        is_error = True
+    out = stdout_buf.getvalue()
+    err = stderr_buf.getvalue()
+    parts = []
+    if out:
+        parts.append(f"stdout:\n{out}")
+    if err:
+        parts.append(f"stderr:\n{err}")
+    text = "\n".join(parts) if parts else "(no output)"
+    return ToolOutput(text=text, is_error=is_error, interrupted=interrupted)
+
+
+RUN_PYTHON = ToolSpec(
+    name="run_python",
+    description=_RUN_PYTHON_DESCRIPTION,
+    input_schema={
+        "type": "object",
+        "properties": {
+            "code":    {"type": "string",
+                        "description": "Python code to execute."},
+            "thought": {"type": "string",
+                        "description": "One-sentence description of what this "
+                                       "code does and why."},
+        },
+        "required": ["code", "thought"],
+    },
+    handler=_run_python_handler,
+)
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_tools -v'
+```
+
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/tools.py tests/test_llm_tools.py
+git commit -m "Add ToolSpec, ToolOutput, and run_python handler"
+```
+
+---
+
+## Task 8: Add the `lookup_docs` handler
+
+**Files:**
+- Modify: `toksearch/llm/tools.py`
+- Modify: `tests/test_llm_tools.py`
+
+- [ ] **Step 1: Append lookup_docs tests**
+
+Open `tests/test_llm_tools.py` and add this class after `TestRunPython`:
+
+```python
+class TestLookupDocs(unittest.TestCase):
+    """``lookup_docs`` reads SKILL.md bodies from the Session's skill registry.
+
+    The handler accesses ``session.skills`` (a dict[name -> Skill]) which the
+    real Session builds at __init__ from ``extra_skill_dirs`` + the core
+    ``toksearch/skills/`` directory.  These tests stub that mapping.
+    """
+
+    def _stub_session(self, skills):
+        return SimpleNamespace(skills=skills)
+
+    def test_unknown_skill_is_error(self):
+        from toksearch.llm.tools import LOOKUP_DOCS
+        s = self._stub_session({})
+        out = LOOKUP_DOCS.handler({"skill_name": "missing"}, s)
+        self.assertTrue(out.is_error)
+        self.assertIn("missing", out.text)
+
+    def test_known_skill_returns_body(self):
+        from toksearch.llm.tools import LOOKUP_DOCS, Skill
+        s = self._stub_session({"foo": Skill(name="foo",
+                                             description="d",
+                                             body="Hello body.")})
+        out = LOOKUP_DOCS.handler({"skill_name": "foo"}, s)
+        self.assertFalse(out.is_error)
+        self.assertEqual(out.text, "Hello body.")
+
+    def test_lookup_docs_spec_shape(self):
+        from toksearch.llm.tools import LOOKUP_DOCS
+        self.assertEqual(LOOKUP_DOCS.name, "lookup_docs")
+        self.assertIn("skill_name", LOOKUP_DOCS.input_schema["properties"])
+        self.assertEqual(LOOKUP_DOCS.input_schema["required"], ["skill_name"])
+
+
+class TestDiscoverSkills(unittest.TestCase):
+    def test_returns_empty_for_nonexistent_dirs(self):
+        from toksearch.llm.tools import discover_skills
+        skills = discover_skills([Path("/nonexistent")])
+        self.assertEqual(skills, {})
+
+    def test_parses_skill_with_frontmatter(self):
+        from toksearch.llm.tools import discover_skills, parse_skill_md
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            sk = root / "myskill"
+            sk.mkdir()
+            (sk / "SKILL.md").write_text(
+                "---\nname: myskill\ndescription: My skill\n---\n\n"
+                "Body content here.\n")
+            skills = discover_skills([root])
+            self.assertIn("myskill", skills)
+            self.assertEqual(skills["myskill"].description, "My skill")
+            self.assertIn("Body content here", skills["myskill"].body)
+
+    def test_skips_dirs_without_skill_md(self):
+        from toksearch.llm.tools import discover_skills
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "not_a_skill").mkdir()
+            self.assertEqual(discover_skills([root]), {})
+
+    def test_parse_skill_md_no_frontmatter(self):
+        from toksearch.llm.tools import parse_skill_md
+        import tempfile
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md",
+                                          delete=False) as f:
+            f.write("Just body, no frontmatter.\n")
+            path = Path(f.name)
+        try:
+            fm, body = parse_skill_md(path)
+            self.assertEqual(fm, {})
+            self.assertIn("Just body", body)
+        finally:
+            path.unlink()
+```
+
+Also add this import at the top of the test file (after the existing `from toksearch.llm.tools import` line, modify it):
+
+```python
+from toksearch.llm.tools import (
+    ToolSpec,
+    ToolOutput,
+    RUN_PYTHON,
+)
+from pathlib import Path
+```
+
+- [ ] **Step 2: Run tests and verify the new ones fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_tools -v'
+```
+
+Expected: `RUN_PYTHON` tests still pass; the new `TestLookupDocs` and
+`TestDiscoverSkills` tests fail with `ImportError` for `LOOKUP_DOCS`, `Skill`,
+`discover_skills`, `parse_skill_md`.
+
+- [ ] **Step 3: Extend `tools.py` with `lookup_docs` and skill discovery**
+
+Append to `toksearch/llm/tools.py`:
+
+```python
+# ----------------------------------------------------------------------
+# lookup_docs + skill discovery
+# ----------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Skill:
+    name: str
+    description: str
+    body: str
+
+
+def parse_skill_md(path: Path) -> tuple[dict, str]:
+    """Return ``(frontmatter, body)`` for a SKILL.md file.
+
+    Frontmatter is the YAML-ish block between two ``---`` lines at the top of
+    the file (we only need ``name`` and ``description`` so we do a tiny
+    line-by-line parser instead of pulling in PyYAML).  If no frontmatter is
+    present, returns ``({}, full_text)``.
+    """
+    text = path.read_text()
+    if text.startswith("---"):
+        _, fm, body = text.split("---", 2)
+        fm_dict = {}
+        for line in fm.strip().splitlines():
+            if ":" in line:
+                k, _, v = line.partition(":")
+                fm_dict[k.strip()] = v.strip()
+        return fm_dict, body.lstrip("\n")
+    return {}, text
+
+
+def discover_skills(skill_dirs: list[Path]) -> dict[str, Skill]:
+    """Return ``{name: Skill}`` for every SKILL.md found under the given dirs.
+
+    Each entry in ``skill_dirs`` is searched one level deep: each subdirectory
+    containing a ``SKILL.md`` becomes a skill named after the subdirectory.
+    Dirs that don't exist are silently skipped.
+    """
+    skills: dict[str, Skill] = {}
+    for d in skill_dirs:
+        if not d.exists():
+            continue
+        for sub in sorted(d.iterdir()):
+            if not sub.is_dir():
+                continue
+            skill_md = sub / "SKILL.md"
+            if not skill_md.exists():
+                continue
+            fm, body = parse_skill_md(skill_md)
+            skills[sub.name] = Skill(
+                name=sub.name,
+                description=fm.get("description", ""),
+                body=body,
+            )
+    return skills
+
+
+_LOOKUP_DOCS_DESCRIPTION = (
+    "Read a documentation skill. Returns the SKILL.md body for one of the "
+    "registered skills. Call this when you need detail on a specific "
+    "toksearch feature beyond what's in the system prompt."
+)
+
+
+def _lookup_docs_handler(args: dict, session) -> ToolOutput:
+    name = args["skill_name"]
+    skill = session.skills.get(name)
+    if skill is None:
+        available = sorted(session.skills)
+        return ToolOutput(
+            text=f"Unknown skill: {name!r}. Available: {available}",
+            is_error=True,
+        )
+    return ToolOutput(text=skill.body, is_error=False)
+
+
+LOOKUP_DOCS = ToolSpec(
+    name="lookup_docs",
+    description=_LOOKUP_DOCS_DESCRIPTION,
+    input_schema={
+        "type": "object",
+        "properties": {
+            "skill_name": {
+                "type": "string",
+                "description": "Name of a skill registered with the Session.",
+            },
+        },
+        "required": ["skill_name"],
+    },
+    handler=_lookup_docs_handler,
+)
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_tools -v'
+```
+
+Expected: all 15 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/tools.py tests/test_llm_tools.py
+git commit -m "Add lookup_docs tool and skill discovery"
+```
+
+---
+
+## Task 9: Add `prompts.build_system_prompt`
+
+**Files:**
+- Create: `toksearch/llm/prompts.py`
+- Create: `tests/test_llm_prompts.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_prompts.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for system-prompt assembly."""
+
+import unittest
+
+from toksearch.llm.tools import Skill
+from toksearch.llm.prompts import build_system_prompt
+
+
+class TestBuildSystemPrompt(unittest.TestCase):
+    def test_contains_kernel_text(self):
+        sp = build_system_prompt(skills={}, namespace_entries=[])
+        self.assertIn("TokSearch", sp)
+        self.assertIn("run_python", sp)
+
+    def test_lists_namespace_entries(self):
+        sp = build_system_prompt(
+            skills={},
+            namespace_entries=[("toksearch_d3d", "DIII-D signal classes")],
+        )
+        self.assertIn("toksearch_d3d", sp)
+        self.assertIn("DIII-D signal classes", sp)
+
+    def test_lists_skills_in_catalog(self):
+        sp = build_system_prompt(
+            skills={"foo": Skill(name="foo", description="Foo skill", body=""),
+                    "bar": Skill(name="bar", description="Bar skill", body="")},
+            namespace_entries=[],
+        )
+        self.assertIn("foo", sp)
+        self.assertIn("Foo skill", sp)
+        self.assertIn("bar", sp)
+        self.assertIn("Bar skill", sp)
+
+    def test_empty_catalogs_omit_sections(self):
+        sp = build_system_prompt(skills={}, namespace_entries=[])
+        # Should still be a non-empty kernel prompt without empty bullet lists.
+        self.assertNotIn("\n-\n", sp)
+        self.assertNotIn(" - :", sp)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_prompts -v'
+```
+
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement `prompts.py`**
+
+Create `toksearch/llm/prompts.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""System-prompt assembly.
+
+The kernel prompt is small (~20 lines) and constant.  The dynamic parts —
+the list of contributed packages and the catalog of available skills — are
+built from the Session's installed contributors at construction time.
+"""
+
+from .tools import Skill
+
+
+_KERNEL = """\
+You are a TokSearch expert. Use the run_python tool to execute code that fetches
+and analyzes fusion data. The namespace persists across tool calls in this
+session - variables from earlier calls are available in later ones.
+
+{namespace_section}{catalog_section}Rules:
+- Do not include import statements; common modules are pre-imported.
+- If code raises an error, read the traceback, fix it, and try again.
+- When you have a result, store it in a variable named `result` or describe it
+  in plain text. Do not call any tool to "finish" - just stop emitting tool calls.
+"""
+
+
+def build_system_prompt(
+    skills: dict[str, Skill],
+    namespace_entries: list[tuple[str, str]],
+) -> str:
+    """Build the system prompt from the registered contributors.
+
+    Parameters
+    ----------
+    skills:
+        Mapping of skill name to ``Skill`` (from ``tools.discover_skills``).
+    namespace_entries:
+        List of ``(name, description)`` for each package contributed to the
+        run_python namespace (core toksearch + any extras).
+    """
+    if namespace_entries:
+        lines = ["You have access to fusion data via the following installed packages:"]
+        for name, desc in namespace_entries:
+            lines.append(f"- {name}: {desc}" if desc else f"- {name}")
+        namespace_section = "\n".join(lines) + "\n\n"
+    else:
+        namespace_section = ""
+
+    if skills:
+        lines = ["Available documentation skills (call lookup_docs(skill_name=...) to read):"]
+        for name in sorted(skills):
+            desc = skills[name].description
+            lines.append(f"- {name}: {desc}" if desc else f"- {name}")
+        catalog_section = "\n".join(lines) + "\n\n"
+    else:
+        catalog_section = ""
+
+    return _KERNEL.format(namespace_section=namespace_section,
+                          catalog_section=catalog_section)
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_prompts -v'
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/prompts.py tests/test_llm_prompts.py
+git commit -m "Add system-prompt assembly"
+```
+
+---
+
+## Task 10: Add `Backend` ABC, `AssistantTurn`, `Callbacks`, and `_ToolLoopBackend`
+
+**Files:**
+- Create: `toksearch/llm/backends/base.py`
+- Create: `tests/test_llm_backends_base.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_backends_base.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for the Backend ABC and _ToolLoopBackend shared loop.
+
+We construct a minimal subclass (``ScriptedToolLoopBackend``) that returns
+pre-scripted ``AssistantTurn``s from ``_send_request``, which lets us verify
+the loop's behavior (tool execution, history appending, max_iterations, etc.)
+without any provider SDK.
+"""
+
+import unittest
+from types import SimpleNamespace
+from typing import Iterable
+
+from toksearch.llm.backends.base import (
+    Backend,
+    AssistantTurn,
+    Callbacks,
+    _ToolLoopBackend,
+)
+from toksearch.llm.events import TurnComplete
+from toksearch.llm.messages import (
+    Message, TextBlock, ToolUseBlock, ToolResultBlock,
+)
+from toksearch.llm.tools import ToolSpec, ToolOutput
+
+
+def _ok_tool(name="echo"):
+    """A trivial tool that returns its input as text."""
+    return ToolSpec(
+        name=name,
+        description="echo",
+        input_schema={"type": "object",
+                      "properties": {"x": {"type": "string"}}},
+        handler=lambda args, sess: ToolOutput(text=args["x"], is_error=False),
+    )
+
+
+class ScriptedToolLoopBackend(_ToolLoopBackend):
+    """A _ToolLoopBackend whose _send_request returns scripted turns."""
+
+    name = "scripted"
+    default_model = "scripted-1"
+
+    def __init__(self, turns: Iterable[AssistantTurn]):
+        self._turns = list(turns)
+
+    def _send_request(self, *, system_prompt, history, tools, model,
+                      on_text=None):
+        return self._turns.pop(0)
+
+
+def _make_session(tools=None):
+    """Minimal Session-shaped stub for the loop to drive."""
+    s = SimpleNamespace()
+    s.history = []
+    s.namespace = {}
+    s.system_prompt = "sys"
+    s.model = "scripted-1"
+    s.tool_specs = tools or []
+    s._tools_by_name = {t.name: t for t in s.tool_specs}
+    def append_user(msg):
+        s.history.append(Message(role="user", content=[TextBlock(text=msg)]))
+    def append_assistant(blocks):
+        s.history.append(Message(role="assistant", content=list(blocks)))
+    def append_tool_result(tool_use_id, output, is_error):
+        s.history.append(Message(role="user", content=[
+            ToolResultBlock(tool_use_id=tool_use_id,
+                            output=output, is_error=is_error)]))
+    def execute_tool(block: ToolUseBlock) -> ToolOutput:
+        return s._tools_by_name[block.name].handler(block.args, s)
+    s._append_user = append_user
+    s._append_assistant = append_assistant
+    s._append_tool_result = append_tool_result
+    s._execute_tool = execute_tool
+    return s
+
+
+class TestBackendABC(unittest.TestCase):
+    def test_backend_is_abstract(self):
+        with self.assertRaises(TypeError):
+            Backend()
+
+
+class TestToolLoop(unittest.TestCase):
+    def test_end_turn_with_only_text(self):
+        backend = ScriptedToolLoopBackend([
+            AssistantTurn(blocks=[TextBlock(text="all done")],
+                          stop_reason="end_turn"),
+        ])
+        sess = _make_session()
+        cbs = Callbacks()
+        result = backend.run_conversation(sess, "hello", cbs, max_iterations=5)
+        self.assertEqual(result.stop_reason, "end_turn")
+        self.assertEqual(result.final_text, "all done")
+        # History: user prompt + assistant turn
+        self.assertEqual(len(sess.history), 2)
+        self.assertEqual(sess.history[0].role, "user")
+        self.assertEqual(sess.history[1].role, "assistant")
+
+    def test_tool_use_then_end(self):
+        tool = _ok_tool("echo")
+        backend = ScriptedToolLoopBackend([
+            AssistantTurn(blocks=[ToolUseBlock(id="t1", name="echo",
+                                               args={"x": "hi"})],
+                          stop_reason="tool_use"),
+            AssistantTurn(blocks=[TextBlock(text="ok")],
+                          stop_reason="end_turn"),
+        ])
+        sess = _make_session(tools=[tool])
+        calls, results = [], []
+        cbs = Callbacks(on_tool_call=calls.append,
+                        on_tool_result=results.append)
+        out = backend.run_conversation(sess, "go", cbs, max_iterations=5)
+        self.assertEqual(out.stop_reason, "end_turn")
+        # One tool call, one tool result fired
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].name, "echo")
+        self.assertEqual(results[0].output, "hi")
+        # History: user, assistant(tool_use), user(tool_result), assistant(text)
+        self.assertEqual([m.role for m in sess.history],
+                         ["user", "assistant", "user", "assistant"])
+
+    def test_max_iterations_caps_loop(self):
+        # Backend keeps emitting tool_use forever
+        tool = _ok_tool("echo")
+        forever = [AssistantTurn(blocks=[ToolUseBlock(id=f"t{i}", name="echo",
+                                                      args={"x": str(i)})],
+                                 stop_reason="tool_use")
+                   for i in range(10)]
+        backend = ScriptedToolLoopBackend(forever)
+        sess = _make_session(tools=[tool])
+        out = backend.run_conversation(sess, "go", Callbacks(),
+                                        max_iterations=3)
+        self.assertEqual(out.stop_reason, "max_iterations")
+
+    def test_confirm_false_aborts(self):
+        tool = _ok_tool("echo")
+        backend = ScriptedToolLoopBackend([
+            AssistantTurn(blocks=[ToolUseBlock(id="t1", name="echo",
+                                               args={"x": "hi"})],
+                          stop_reason="tool_use"),
+        ])
+        sess = _make_session(tools=[tool])
+        cbs = Callbacks(confirm=lambda call: False)
+        out = backend.run_conversation(sess, "go", cbs, max_iterations=5)
+        self.assertEqual(out.stop_reason, "interrupted")
+
+    def test_on_event_catch_all_fires_for_everything(self):
+        tool = _ok_tool("echo")
+        backend = ScriptedToolLoopBackend([
+            AssistantTurn(blocks=[ToolUseBlock(id="t1", name="echo",
+                                               args={"x": "hi"})],
+                          stop_reason="tool_use"),
+            AssistantTurn(blocks=[TextBlock(text="done")],
+                          stop_reason="end_turn"),
+        ])
+        sess = _make_session(tools=[tool])
+        events = []
+        cbs = Callbacks(on_event=events.append)
+        backend.run_conversation(sess, "go", cbs, max_iterations=5)
+        kinds = [type(e).__name__ for e in events]
+        # ToolCall, ToolResult, TurnComplete at minimum (text deltas optional)
+        self.assertIn("ToolCall", kinds)
+        self.assertIn("ToolResult", kinds)
+        self.assertIn("TurnComplete", kinds)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_backends_base -v'
+```
+
+Expected: `ModuleNotFoundError: No module named 'toksearch.llm.backends.base'`.
+
+- [ ] **Step 3: Implement `backends/base.py`**
+
+Create `toksearch/llm/backends/base.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Backend ABC and the shared tool-use loop.
+
+``_ToolLoopBackend`` holds the loop that all raw-API backends (Anthropic,
+OpenAI, AmSC-via-preset) share.  Subclasses implement only:
+
+- ``_send_request(system_prompt, history, tools, model, on_text)`` returning
+  an ``AssistantTurn``.
+- Translation helpers between our ``ContentBlock`` / ``ToolSpec`` taxonomy and
+  the provider's native shapes.
+
+Streaming text is deferred to a follow-up PR.  In PR 1, ``_send_request`` is
+expected to be non-streaming; it MAY call ``on_text`` once at the end with the
+full assistant text, but the loop does not require it.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Callable, Literal
+
+from ..events import TextDelta, ToolCall, ToolResult, TurnComplete
+from ..messages import Message, TextBlock, ToolUseBlock, ToolResultBlock
+
+
+@dataclass
+class AssistantTurn:
+    """One assistant round-trip from a backend.
+
+    ``blocks`` is the assistant's content this turn (text + tool_use mixed).
+    ``stop_reason`` mirrors the provider's stop reason; ``"tool_use"`` means
+    the loop should execute tools and call ``_send_request`` again.
+    """
+
+    blocks: list  # list[ContentBlock]
+    stop_reason: Literal["tool_use", "end_turn", "max_tokens", "stop_sequence"]
+
+
+@dataclass
+class Callbacks:
+    on_text: Callable[[str], None] | None = None
+    on_tool_call: Callable[[ToolCall], None] | None = None
+    on_tool_result: Callable[[ToolResult], None] | None = None
+    on_event: Callable[[object], None] | None = None
+    confirm: Callable[[ToolCall], bool] | None = None
+
+    def fire_text(self, text: str) -> None:
+        if self.on_text is not None:
+            self.on_text(text)
+        if self.on_event is not None:
+            self.on_event(TextDelta(text=text))
+
+    def fire_tool_call(self, e: ToolCall) -> None:
+        if self.on_tool_call is not None:
+            self.on_tool_call(e)
+        if self.on_event is not None:
+            self.on_event(e)
+
+    def fire_tool_result(self, e: ToolResult) -> None:
+        if self.on_tool_result is not None:
+            self.on_tool_result(e)
+        if self.on_event is not None:
+            self.on_event(e)
+
+    def fire_turn_complete(self, e: TurnComplete) -> None:
+        if self.on_event is not None:
+            self.on_event(e)
+
+
+class Backend(ABC):
+    """Pluggable LLM provider.
+
+    Subclasses advance the conversation by one user-message worth of work,
+    dispatching ``Callbacks`` events along the way.
+    """
+
+    name: str
+    default_model: str
+
+    @abstractmethod
+    def run_conversation(
+        self,
+        session,
+        new_user_message: str,
+        callbacks: Callbacks,
+        max_iterations: int,
+    ) -> TurnComplete:
+        ...
+
+
+class _ToolLoopBackend(Backend):
+    """Shared tool-use loop for raw-API backends (Anthropic, OpenAI)."""
+
+    @abstractmethod
+    def _send_request(self, *, system_prompt, history, tools, model,
+                      on_text=None) -> AssistantTurn:
+        ...
+
+    def run_conversation(self, session, new_user_message, callbacks,
+                          max_iterations):
+        session._append_user(new_user_message)
+        final_text = ""
+        for _ in range(max_iterations):
+            turn = self._send_request(
+                system_prompt=session.system_prompt,
+                history=session.history,
+                tools=session.tool_specs,
+                model=session.model,
+                on_text=callbacks.fire_text,
+            )
+            session._append_assistant(turn.blocks)
+            tool_use_blocks = [b for b in turn.blocks
+                               if isinstance(b, ToolUseBlock)]
+            text_blocks = [b for b in turn.blocks
+                           if isinstance(b, TextBlock)]
+            if text_blocks:
+                final_text = text_blocks[-1].text
+            for block in tool_use_blocks:
+                call = ToolCall(
+                    id=block.id, name=block.name, args=block.args,
+                    thought=block.args.get("thought")
+                            if block.name == "run_python" else None,
+                )
+                callbacks.fire_tool_call(call)
+                if callbacks.confirm is not None and not callbacks.confirm(call):
+                    result = TurnComplete(stop_reason="interrupted", final_text="")
+                    callbacks.fire_turn_complete(result)
+                    return result
+                output = session._execute_tool(block)
+                event = ToolResult(id=block.id, output=output.text,
+                                    is_error=output.is_error)
+                callbacks.fire_tool_result(event)
+                session._append_tool_result(block.id, output.text,
+                                             output.is_error)
+            if turn.stop_reason != "tool_use":
+                result = TurnComplete(stop_reason="end_turn",
+                                       final_text=final_text)
+                callbacks.fire_turn_complete(result)
+                return result
+        result = TurnComplete(stop_reason="max_iterations",
+                               final_text=final_text)
+        callbacks.fire_turn_complete(result)
+        return result
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_backends_base -v'
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/backends/base.py tests/test_llm_backends_base.py
+git commit -m "Add Backend ABC and _ToolLoopBackend shared loop"
+```
+
+---
+
+## Task 11: Add `FakeBackend`
+
+**Files:**
+- Create: `toksearch/llm/backends/fake.py`
+- Create: `tests/test_llm_backends_fake.py`
+
+`FakeBackend` is the testing seam for Session-level tests in Task 13. It does
+NOT subclass `_ToolLoopBackend` — it implements `run_conversation` directly so
+tests can script the full conversation (tool calls included) rather than
+working at the round-trip granularity.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_backends_fake.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for FakeBackend (the testing seam)."""
+
+import unittest
+from types import SimpleNamespace
+
+from toksearch.llm.backends.base import AssistantTurn, Callbacks
+from toksearch.llm.backends.fake import FakeBackend
+from toksearch.llm.messages import (
+    Message, TextBlock, ToolUseBlock, ToolResultBlock,
+)
+from toksearch.llm.tools import ToolSpec, ToolOutput
+
+
+def _stub_session(tools=None):
+    s = SimpleNamespace()
+    s.history = []
+    s.namespace = {}
+    s.system_prompt = "sys"
+    s.model = "fake-1"
+    s.tool_specs = tools or []
+    s._tools_by_name = {t.name: t for t in s.tool_specs}
+    s._append_user = lambda msg: s.history.append(
+        Message(role="user", content=[TextBlock(text=msg)]))
+    s._append_assistant = lambda blocks: s.history.append(
+        Message(role="assistant", content=list(blocks)))
+    s._append_tool_result = lambda tid, out, err: s.history.append(
+        Message(role="user", content=[ToolResultBlock(
+            tool_use_id=tid, output=out, is_error=err)]))
+    s._execute_tool = lambda block: s._tools_by_name[block.name].handler(
+        block.args, s)
+    return s
+
+
+class TestFakeBackend(unittest.TestCase):
+    def test_simple_text_response(self):
+        backend = FakeBackend(scripted_turns=[
+            AssistantTurn(blocks=[TextBlock(text="hi")],
+                          stop_reason="end_turn"),
+        ])
+        sess = _stub_session()
+        out = backend.run_conversation(sess, "hello", Callbacks(),
+                                        max_iterations=5)
+        self.assertEqual(out.stop_reason, "end_turn")
+        self.assertEqual(out.final_text, "hi")
+
+    def test_recording_inspects_calls(self):
+        record = []
+        backend = FakeBackend(scripted_turns=[
+            AssistantTurn(blocks=[TextBlock(text="ok")],
+                          stop_reason="end_turn"),
+        ], record=record)
+        sess = _stub_session()
+        backend.run_conversation(sess, "do thing", Callbacks(),
+                                  max_iterations=5)
+        self.assertEqual(len(record), 1)
+        self.assertEqual(record[0]["user_message"], "do thing")
+        self.assertEqual(record[0]["model"], "fake-1")
+
+    def test_script_exhausted_raises(self):
+        backend = FakeBackend(scripted_turns=[])
+        sess = _stub_session()
+        with self.assertRaises(RuntimeError):
+            backend.run_conversation(sess, "hello", Callbacks(),
+                                      max_iterations=5)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_backends_fake -v'
+```
+
+Expected: `ModuleNotFoundError: No module named 'toksearch.llm.backends.fake'`.
+
+- [ ] **Step 3: Implement `backends/fake.py`**
+
+Create `toksearch/llm/backends/fake.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""FakeBackend — testing seam for Session-level tests.
+
+Subclasses ``_ToolLoopBackend`` so the standard loop drives it.  ``_send_request``
+pops one scripted ``AssistantTurn`` per call.  Optionally records each
+``_send_request`` invocation for inspection.
+"""
+
+from .base import _ToolLoopBackend, AssistantTurn
+
+
+class FakeBackend(_ToolLoopBackend):
+    name = "fake"
+    default_model = "fake-1"
+
+    def __init__(self, scripted_turns=None, record=None):
+        self._turns = list(scripted_turns or [])
+        self._record = record  # list to append call dicts to, or None
+        self._user_message_pending = None
+
+    def run_conversation(self, session, new_user_message, callbacks,
+                          max_iterations):
+        # Capture the user message so _send_request can record it for the
+        # first call of this conversation.
+        self._user_message_pending = new_user_message
+        return super().run_conversation(session, new_user_message, callbacks,
+                                          max_iterations)
+
+    def _send_request(self, *, system_prompt, history, tools, model,
+                      on_text=None) -> AssistantTurn:
+        if not self._turns:
+            raise RuntimeError("FakeBackend script exhausted")
+        if self._record is not None:
+            self._record.append({
+                "system_prompt": system_prompt,
+                "history": list(history),
+                "tools": list(tools),
+                "model": model,
+                "user_message": self._user_message_pending,
+            })
+            # Only attribute the user_message to the first call per turn
+            self._user_message_pending = None
+        return self._turns.pop(0)
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_backends_fake -v'
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/backends/fake.py tests/test_llm_backends_fake.py
+git commit -m "Add FakeBackend testing seam"
+```
+
+---
+
+## Task 12: Wire backend registry
+
+**Files:**
+- Modify: `toksearch/llm/backends/__init__.py`
+- Create: `tests/test_llm_backends_registry.py`
+
+The registry maps backend-class names (NOT preset names) to concrete classes.
+PR 1 registers `"anthropic"` and `"openai"`; PR 3 adds `"claude-max"`. Preset
+resolution (Task 6) maps user-facing names to backend-class names + kwargs.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_llm_backends_registry.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for the backend registry."""
+
+import unittest
+
+from toksearch.llm.errors import LLMConfigError
+
+
+class TestBackendRegistry(unittest.TestCase):
+    def test_get_backend_class_anthropic(self):
+        from toksearch.llm.backends import get_backend_class
+        from toksearch.llm.backends.anthropic import AnthropicBackend
+        self.assertIs(get_backend_class("anthropic"), AnthropicBackend)
+
+    def test_get_backend_class_openai(self):
+        from toksearch.llm.backends import get_backend_class
+        from toksearch.llm.backends.openai import OpenAIBackend
+        self.assertIs(get_backend_class("openai"), OpenAIBackend)
+
+    def test_unknown_raises(self):
+        from toksearch.llm.backends import get_backend_class
+        with self.assertRaises(LLMConfigError):
+            get_backend_class("nonexistent")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_backends_registry -v'
+```
+
+Expected: `ImportError` for `get_backend_class` (and `AnthropicBackend` /
+`OpenAIBackend` which are added in Tasks 14 and 15).
+
+- [ ] **Step 3: Replace `toksearch/llm/backends/__init__.py`**
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""Backend registry and class lookup for toksearch.llm."""
+
+from ..errors import LLMConfigError
+
+
+def get_backend_class(name: str):
+    """Resolve a backend-class name (e.g. 'anthropic', 'openai') to its class.
+
+    Imports the concrete class lazily so the import of ``toksearch.llm.backends``
+    doesn't require ``anthropic`` / ``openai`` SDKs to be installed.
+    """
+    if name == "anthropic":
+        from .anthropic import AnthropicBackend
+        return AnthropicBackend
+    if name == "openai":
+        from .openai import OpenAIBackend
+        return OpenAIBackend
+    raise LLMConfigError(
+        f"Unknown backend: {name!r}. Known: anthropic, openai. "
+        "(claude-max is added in PR 3.)")
+```
+
+- [ ] **Step 4: Note: tests still fail until Tasks 14 and 15**
+
+After implementing Tasks 14 and 15, the registry tests pass. For now, leave
+them red; they're already committed as part of the registry change but the
+imports they rely on don't exist yet.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/backends/__init__.py tests/test_llm_backends_registry.py
+git commit -m "Add backend registry with lazy class lookup"
+```
+
+---
+
+## Task 13: Add `Session`
+
+**Files:**
+- Create: `toksearch/llm/session.py`
+- Create: `tests/test_llm_session.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_session.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Session-level tests using FakeBackend.
+
+The Session class is responsible for: building the system prompt, owning the
+namespace and history, registering tools, dispatching to the backend, and
+providing reset/introspection.
+"""
+
+import unittest
+
+from toksearch.llm.backends.base import AssistantTurn
+from toksearch.llm.backends.fake import FakeBackend
+from toksearch.llm.messages import TextBlock, ToolUseBlock
+from toksearch.llm.session import Session
+
+
+def _text(s):
+    return AssistantTurn(blocks=[TextBlock(text=s)], stop_reason="end_turn")
+
+
+def _tool_use(name, args, id_="t1"):
+    return AssistantTurn(
+        blocks=[ToolUseBlock(id=id_, name=name, args=args)],
+        stop_reason="tool_use",
+    )
+
+
+class TestSessionBasics(unittest.TestCase):
+    def test_send_returns_turn_complete(self):
+        backend = FakeBackend(scripted_turns=[_text("hello")])
+        sess = Session(backend=backend)
+        out = sess.send("hi")
+        self.assertEqual(out.stop_reason, "end_turn")
+        self.assertEqual(out.final_text, "hello")
+
+    def test_namespace_pre_populated(self):
+        backend = FakeBackend(scripted_turns=[_text("ok")])
+        sess = Session(backend=backend)
+        # toksearch and numpy are required; pandas and matplotlib are optional
+        # in the test env (they live in the [llm] extra).
+        self.assertIn("toksearch", sess.namespace)
+        self.assertIn("np", sess.namespace)
+
+    def test_extra_namespace_merged(self):
+        backend = FakeBackend(scripted_turns=[_text("ok")])
+        sess = Session(backend=backend, extra_namespace={"answer": 42})
+        self.assertEqual(sess.namespace["answer"], 42)
+
+
+class TestSessionPersistence(unittest.TestCase):
+    def test_namespace_persists_across_send_calls(self):
+        backend = FakeBackend(scripted_turns=[
+            _tool_use("run_python", {"code": "x = 99", "thought": "set"}),
+            _text("set"),
+            _tool_use("run_python", {"code": "print(x)", "thought": "read"}, id_="t2"),
+            _text("read"),
+        ])
+        sess = Session(backend=backend)
+        sess.send("set x")
+        sess.send("read x")
+        self.assertEqual(sess.namespace["x"], 99)
+
+    def test_reset_clears_namespace_and_history(self):
+        backend = FakeBackend(scripted_turns=[
+            _tool_use("run_python", {"code": "x = 1", "thought": "set"}),
+            _text("done"),
+        ])
+        sess = Session(backend=backend)
+        sess.send("set x")
+        self.assertIn("x", sess.namespace)
+        self.assertGreater(len(sess.history), 0)
+        sess.reset()
+        self.assertNotIn("x", sess.namespace)
+        self.assertEqual(len(sess.history), 0)
+        # Standard names are still there
+        self.assertIn("toksearch", sess.namespace)
+
+
+class TestSessionCallbacks(unittest.TestCase):
+    def test_on_tool_call_fires_before_result(self):
+        backend = FakeBackend(scripted_turns=[
+            _tool_use("run_python", {"code": "print('hi')", "thought": "x"}),
+            _text("done"),
+        ])
+        sess = Session(backend=backend)
+        order = []
+        sess.send("go",
+                  on_tool_call=lambda c: order.append(("call", c.name)),
+                  on_tool_result=lambda r: order.append(("result", r.output)))
+        self.assertEqual(order[0][0], "call")
+        self.assertEqual(order[1][0], "result")
+        self.assertIn("hi", order[1][1])
+
+    def test_confirm_false_aborts(self):
+        backend = FakeBackend(scripted_turns=[
+            _tool_use("run_python", {"code": "print('x')", "thought": "x"}),
+        ])
+        sess = Session(backend=backend)
+        out = sess.send("go", confirm=lambda call: False)
+        self.assertEqual(out.stop_reason, "interrupted")
+
+
+class TestSessionTools(unittest.TestCase):
+    def test_run_python_and_lookup_docs_registered(self):
+        backend = FakeBackend(scripted_turns=[_text("ok")])
+        sess = Session(backend=backend)
+        names = {t.name for t in sess.tool_specs}
+        self.assertEqual(names, {"run_python", "lookup_docs"})
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_session -v'
+```
+
+Expected: `ModuleNotFoundError: No module named 'toksearch.llm.session'`.
+
+- [ ] **Step 3: Implement `session.py`**
+
+Create `toksearch/llm/session.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Session — the user-facing object for toksearch.llm.
+
+Owns: history, run_python namespace, tool registry, skill registry, backend.
+"""
+
+from pathlib import Path
+from typing import Callable
+
+from .backends.base import Backend, Callbacks
+from .events import TurnComplete
+from .messages import Message, TextBlock, ToolResultBlock, ToolUseBlock
+from .prompts import build_system_prompt
+from .tools import LOOKUP_DOCS, RUN_PYTHON, ToolOutput, discover_skills
+
+
+def _default_namespace() -> dict:
+    """Build the standard run_python namespace.
+
+    Imports happen here (not at module load) so that simply importing
+    ``toksearch.llm`` doesn't drag in matplotlib / pandas / numpy until the
+    user actually constructs a Session.  toksearch and numpy are required;
+    pandas and matplotlib are optional (matplotlib is in the ``[llm]`` extra
+    but tests run without it).
+    """
+    import toksearch
+    import numpy as np
+    ns = {"toksearch": toksearch, "np": np}
+    try:
+        import pandas as pd
+        ns["pd"] = pd
+    except ImportError:
+        pass
+    try:
+        import matplotlib
+        matplotlib.use("Agg", force=False)  # idempotent; safe in non-GUI envs
+        import matplotlib.pyplot as plt
+        ns["plt"] = plt
+    except ImportError:
+        pass
+    return ns
+
+
+def _core_skill_dir() -> Path:
+    import toksearch
+    return Path(toksearch.__file__).parent / "skills"
+
+
+class Session:
+    """A conversational LLM session over the run_python persistent namespace."""
+
+    def __init__(
+        self,
+        backend: Backend,
+        model: str | None = None,
+        max_iterations: int = 20,
+        extra_namespace: dict | None = None,
+        packages: list[str] | None = None,    # PR 2 plumbing; unused in PR 1
+        extra_skill_dirs: list[Path] | None = None,
+    ):
+        self.backend = backend
+        self.model = model or backend.default_model
+        self.max_iterations = max_iterations
+        self.namespace = _default_namespace()
+        if extra_namespace:
+            self.namespace.update(extra_namespace)
+        # Skills: core toksearch + any extras the caller passed in
+        skill_dirs = [_core_skill_dir()] + list(extra_skill_dirs or [])
+        self.skills = discover_skills(skill_dirs)
+        # Tools: fixed in PR 1; PR 4 may register more.
+        self.tool_specs = [RUN_PYTHON, LOOKUP_DOCS]
+        self._tools_by_name = {t.name: t for t in self.tool_specs}
+        # System prompt: kernel + dynamic catalogs
+        namespace_entries = [
+            ("toksearch", "core pipeline, MdsSignal, ZarrSignal, fetch_dataset"),
+        ]
+        self.system_prompt = build_system_prompt(self.skills, namespace_entries)
+        # History
+        self.history: list[Message] = []
+
+    # ---- Public API ----
+
+    def send(
+        self,
+        prompt: str,
+        *,
+        on_text: Callable[[str], None] | None = None,
+        on_tool_call=None,
+        on_tool_result=None,
+        on_event=None,
+        confirm=None,
+    ) -> TurnComplete:
+        cbs = Callbacks(
+            on_text=on_text,
+            on_tool_call=on_tool_call,
+            on_tool_result=on_tool_result,
+            on_event=on_event,
+            confirm=confirm,
+        )
+        return self.backend.run_conversation(
+            self, prompt, cbs, max_iterations=self.max_iterations,
+        )
+
+    def reset(self) -> None:
+        """Clear history and reset the namespace to its initial pre-populated state."""
+        self.namespace = _default_namespace()
+        self.history = []
+
+    # ---- Hooks called by backends (semi-private) ----
+
+    def _append_user(self, text: str) -> None:
+        self.history.append(Message(role="user",
+                                     content=[TextBlock(text=text)]))
+
+    def _append_assistant(self, blocks) -> None:
+        self.history.append(Message(role="assistant",
+                                     content=list(blocks)))
+
+    def _append_tool_result(self, tool_use_id: str, output: str,
+                             is_error: bool) -> None:
+        self.history.append(Message(role="user", content=[
+            ToolResultBlock(tool_use_id=tool_use_id,
+                            output=output, is_error=is_error)
+        ]))
+
+    def _execute_tool(self, block: ToolUseBlock) -> ToolOutput:
+        spec = self._tools_by_name.get(block.name)
+        if spec is None:
+            return ToolOutput(text=f"Unknown tool: {block.name}",
+                              is_error=True)
+        return spec.handler(block.args, self)
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_session -v'
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/session.py tests/test_llm_session.py
+git commit -m "Add Session — owner of state, dispatcher to backend"
+```
+
+---
+
+## Task 14: Add `AnthropicBackend`
+
+**Files:**
+- Create: `toksearch/llm/backends/anthropic.py`
+- Create: `tests/test_llm_backends_anthropic.py`
+
+Mocks the `anthropic` SDK so tests don't require the package at test time.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_backends_anthropic.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for AnthropicBackend.
+
+The anthropic SDK is mocked at the module-attribute level (``backend._client``)
+so tests don't need the SDK installed and don't make network calls.
+"""
+
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+# Install a stub `anthropic` module before any imports of the backend so the
+# `import anthropic` inside backend.__init__ resolves to our stub.
+_stub_anthropic = types.ModuleType("anthropic")
+_stub_anthropic.Anthropic = mock.MagicMock
+_stub_anthropic.AuthenticationError = type("AuthenticationError", (Exception,), {})
+_stub_anthropic.RateLimitError = type("RateLimitError", (Exception,), {})
+_stub_anthropic.APIStatusError = type("APIStatusError", (Exception,), {})
+_stub_anthropic.APIConnectionError = type("APIConnectionError", (Exception,), {})
+sys.modules.setdefault("anthropic", _stub_anthropic)
+
+from toksearch.llm.backends.anthropic import AnthropicBackend  # noqa: E402
+from toksearch.llm.backends.base import AssistantTurn  # noqa: E402
+from toksearch.llm.errors import LLMAuthError  # noqa: E402
+from toksearch.llm.messages import TextBlock, ToolUseBlock  # noqa: E402
+from toksearch.llm.tools import ToolSpec, ToolOutput  # noqa: E402
+
+
+def _make_response(text=None, tool_use=None, stop_reason="end_turn"):
+    """Build a fake anthropic.types.Message-shaped response."""
+    blocks = []
+    if text is not None:
+        blocks.append(mock.MagicMock(type="text", text=text))
+    if tool_use is not None:
+        b = mock.MagicMock(type="tool_use")
+        b.id = tool_use["id"]
+        b.name = tool_use["name"]
+        b.input = tool_use["input"]
+        blocks.append(b)
+    resp = mock.MagicMock()
+    resp.content = blocks
+    resp.stop_reason = stop_reason
+    return resp
+
+
+class TestAnthropicSendRequest(unittest.TestCase):
+    def setUp(self):
+        self.backend = AnthropicBackend(api_key="sk-test")
+        self.backend._client = mock.MagicMock()
+
+    def test_text_response_becomes_assistant_turn(self):
+        self.backend._client.messages.create.return_value = _make_response(
+            text="hi", stop_reason="end_turn")
+        turn = self.backend._send_request(
+            system_prompt="sys", history=[], tools=[], model="claude-x")
+        self.assertEqual(turn.stop_reason, "end_turn")
+        self.assertEqual(len(turn.blocks), 1)
+        self.assertIsInstance(turn.blocks[0], TextBlock)
+        self.assertEqual(turn.blocks[0].text, "hi")
+
+    def test_tool_use_response_becomes_tool_use_block(self):
+        self.backend._client.messages.create.return_value = _make_response(
+            tool_use={"id": "t1", "name": "run_python",
+                      "input": {"code": "1+1", "thought": "x"}},
+            stop_reason="tool_use")
+        turn = self.backend._send_request(
+            system_prompt="sys", history=[], tools=[], model="claude-x")
+        self.assertEqual(turn.stop_reason, "tool_use")
+        self.assertEqual(len(turn.blocks), 1)
+        b = turn.blocks[0]
+        self.assertIsInstance(b, ToolUseBlock)
+        self.assertEqual(b.id, "t1")
+        self.assertEqual(b.name, "run_python")
+        self.assertEqual(b.args, {"code": "1+1", "thought": "x"})
+
+    def test_tools_translated_to_anthropic_schema(self):
+        spec = ToolSpec(
+            name="echo",
+            description="echo",
+            input_schema={"type": "object",
+                          "properties": {"x": {"type": "string"}}},
+            handler=lambda a, s: ToolOutput(text="x"),
+        )
+        self.backend._client.messages.create.return_value = _make_response(
+            text="", stop_reason="end_turn")
+        self.backend._send_request(
+            system_prompt="sys", history=[], tools=[spec], model="claude-x")
+        kwargs = self.backend._client.messages.create.call_args.kwargs
+        sent_tools = kwargs["tools"]
+        self.assertEqual(sent_tools[0]["name"], "echo")
+        self.assertEqual(sent_tools[0]["description"], "echo")
+        self.assertEqual(sent_tools[0]["input_schema"],
+                         {"type": "object",
+                          "properties": {"x": {"type": "string"}}})
+
+
+class TestAnthropicAuthError(unittest.TestCase):
+    def test_auth_error_translated_to_llm_auth_error(self):
+        # Build a fresh exception type and patch it onto the anthropic module
+        # so the backend's `except anthropic.AuthenticationError` matches it
+        # regardless of whether the real SDK is installed.
+        import anthropic as _anthropic
+        fake_auth = type("FakeAuth", (Exception,), {})
+        backend = AnthropicBackend(api_key="x")
+        backend._client = mock.MagicMock()
+        with mock.patch.object(_anthropic, "AuthenticationError", fake_auth):
+            backend._client.messages.create.side_effect = fake_auth("401")
+            with self.assertRaises(LLMAuthError):
+                backend._send_request(system_prompt="s", history=[],
+                                       tools=[], model="m")
+
+
+class TestAnthropicBaseUrl(unittest.TestCase):
+    def test_base_url_passed_to_client(self):
+        with mock.patch.object(_stub_anthropic, "Anthropic") as ctor:
+            AnthropicBackend(api_key="x",
+                              base_url="https://custom.example")._build_client()
+            self.assertEqual(
+                ctor.call_args.kwargs["base_url"],
+                "https://custom.example")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_backends_anthropic -v'
+```
+
+Expected: `ModuleNotFoundError: No module named 'toksearch.llm.backends.anthropic'`.
+
+- [ ] **Step 3: Implement `backends/anthropic.py`**
+
+Create `toksearch/llm/backends/anthropic.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""AnthropicBackend — driver for the Anthropic Messages API.
+
+Also serves AmSC and any other Anthropic-compatible endpoint via the
+``base_url`` constructor argument (set by preset resolution).
+
+PR 1 uses the blocking, non-streaming API.  Streaming text deltas are deferred
+to a follow-up PR.
+"""
+
+import anthropic
+
+from ..errors import LLMAuthError, LLMBackendError, LLMRateLimitError
+from ..messages import (
+    Message, TextBlock, ToolResultBlock, ToolUseBlock,
+)
+from .base import AssistantTurn, _ToolLoopBackend
+
+
+class AnthropicBackend(_ToolLoopBackend):
+    name = "anthropic"
+    default_model = "claude-sonnet-4-6"
+
+    def __init__(
+        self,
+        api_key: str | None,
+        base_url: str | None = None,
+        max_tokens: int = 4096,
+    ):
+        self._api_key = api_key
+        self._base_url = base_url
+        self._max_tokens = max_tokens
+        self._client = None  # lazy; tests inject a mock
+
+    def _build_client(self):
+        kwargs = {}
+        if self._api_key is not None:
+            kwargs["api_key"] = self._api_key
+        if self._base_url is not None:
+            kwargs["base_url"] = self._base_url
+        self._client = anthropic.Anthropic(**kwargs)
+        return self._client
+
+    def _ensure_client(self):
+        if self._client is None:
+            self._build_client()
+        return self._client
+
+    # ---- Translation: ToolSpec -> Anthropic tool schema ----
+
+    @staticmethod
+    def _spec_to_native(spec) -> dict:
+        return {
+            "name": spec.name,
+            "description": spec.description,
+            "input_schema": spec.input_schema,
+        }
+
+    # ---- Translation: our Message list -> Anthropic messages= ----
+
+    @staticmethod
+    def _history_to_native(history: list[Message]) -> list[dict]:
+        out = []
+        for m in history:
+            native_blocks = []
+            for b in m.content:
+                if isinstance(b, TextBlock):
+                    native_blocks.append({"type": "text", "text": b.text})
+                elif isinstance(b, ToolUseBlock):
+                    native_blocks.append({
+                        "type": "tool_use",
+                        "id": b.id, "name": b.name, "input": b.args,
+                    })
+                elif isinstance(b, ToolResultBlock):
+                    native_blocks.append({
+                        "type": "tool_result",
+                        "tool_use_id": b.tool_use_id,
+                        "content": b.output,
+                        "is_error": b.is_error,
+                    })
+            out.append({"role": m.role, "content": native_blocks})
+        return out
+
+    # ---- Translation: Anthropic response.content -> our ContentBlock list ----
+
+    @staticmethod
+    def _response_to_blocks(content) -> list:
+        out = []
+        for blk in content:
+            if blk.type == "text":
+                out.append(TextBlock(text=blk.text))
+            elif blk.type == "tool_use":
+                out.append(ToolUseBlock(id=blk.id, name=blk.name,
+                                         args=dict(blk.input)))
+        return out
+
+    # ---- Main entrypoint called by _ToolLoopBackend ----
+
+    def _send_request(self, *, system_prompt, history, tools, model,
+                      on_text=None) -> AssistantTurn:
+        client = self._ensure_client()
+        try:
+            resp = client.messages.create(
+                model=model,
+                max_tokens=self._max_tokens,
+                system=system_prompt,
+                messages=self._history_to_native(history),
+                tools=[self._spec_to_native(t) for t in tools],
+            )
+        except anthropic.AuthenticationError as e:
+            raise LLMAuthError(
+                "Anthropic auth failed. Set ANTHROPIC_API_KEY or pass "
+                "api_key=... to the backend.") from e
+        except anthropic.RateLimitError as e:
+            raise LLMRateLimitError(str(e)) from e
+        except anthropic.APIConnectionError as e:
+            raise LLMBackendError(f"Network error: {e}") from e
+        except anthropic.APIStatusError as e:
+            raise LLMBackendError(f"Anthropic API error: {e}") from e
+        blocks = self._response_to_blocks(resp.content)
+        text_total = "".join(b.text for b in blocks if isinstance(b, TextBlock))
+        if text_total and on_text is not None:
+            on_text(text_total)
+        return AssistantTurn(blocks=blocks, stop_reason=resp.stop_reason)
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_backends_anthropic -v'
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/backends/anthropic.py tests/test_llm_backends_anthropic.py
+git commit -m "Add AnthropicBackend with mocked SDK tests"
+```
+
+---
+
+## Task 15: Add `OpenAIBackend`
+
+**Files:**
+- Create: `toksearch/llm/backends/openai.py`
+- Create: `tests/test_llm_backends_openai.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_backends_openai.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for OpenAIBackend.
+
+The openai SDK is mocked at the module-attribute level so tests don't need
+the SDK installed and don't make network calls.
+"""
+
+import json
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+# Stub openai module + its error types
+_stub_openai = types.ModuleType("openai")
+_stub_openai.OpenAI = mock.MagicMock
+_stub_openai.AuthenticationError = type("AuthenticationError", (Exception,), {})
+_stub_openai.RateLimitError = type("RateLimitError", (Exception,), {})
+_stub_openai.APIConnectionError = type("APIConnectionError", (Exception,), {})
+_stub_openai.APIStatusError = type("APIStatusError", (Exception,), {})
+sys.modules.setdefault("openai", _stub_openai)
+
+from toksearch.llm.backends.openai import OpenAIBackend  # noqa: E402
+from toksearch.llm.errors import LLMAuthError  # noqa: E402
+from toksearch.llm.messages import TextBlock, ToolUseBlock  # noqa: E402
+from toksearch.llm.tools import ToolSpec, ToolOutput  # noqa: E402
+
+
+def _make_chat_response(text=None, tool_calls=None, finish_reason="stop"):
+    """Build a fake openai chat completion response."""
+    msg = mock.MagicMock()
+    msg.content = text
+    msg.tool_calls = []
+    for tc in (tool_calls or []):
+        m = mock.MagicMock()
+        m.id = tc["id"]
+        m.type = "function"
+        m.function.name = tc["name"]
+        m.function.arguments = json.dumps(tc["args"])
+        msg.tool_calls.append(m)
+    choice = mock.MagicMock()
+    choice.message = msg
+    choice.finish_reason = finish_reason
+    resp = mock.MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+class TestOpenAISendRequest(unittest.TestCase):
+    def setUp(self):
+        self.backend = OpenAIBackend(api_key="sk-test")
+        self.backend._client = mock.MagicMock()
+
+    def test_text_response_becomes_assistant_turn(self):
+        self.backend._client.chat.completions.create.return_value = (
+            _make_chat_response(text="hello", finish_reason="stop"))
+        turn = self.backend._send_request(
+            system_prompt="sys", history=[], tools=[], model="gpt-4o")
+        self.assertEqual(turn.stop_reason, "end_turn")
+        self.assertEqual(len(turn.blocks), 1)
+        self.assertIsInstance(turn.blocks[0], TextBlock)
+        self.assertEqual(turn.blocks[0].text, "hello")
+
+    def test_tool_call_response(self):
+        self.backend._client.chat.completions.create.return_value = (
+            _make_chat_response(text=None,
+                                tool_calls=[{"id": "t1", "name": "run_python",
+                                             "args": {"code": "1+1",
+                                                      "thought": "x"}}],
+                                finish_reason="tool_calls"))
+        turn = self.backend._send_request(
+            system_prompt="sys", history=[], tools=[], model="gpt-4o")
+        self.assertEqual(turn.stop_reason, "tool_use")
+        # Should produce one ToolUseBlock (no TextBlock since content is None)
+        tool_blocks = [b for b in turn.blocks if isinstance(b, ToolUseBlock)]
+        self.assertEqual(len(tool_blocks), 1)
+        self.assertEqual(tool_blocks[0].args,
+                         {"code": "1+1", "thought": "x"})
+
+    def test_tools_translated_to_openai_schema(self):
+        spec = ToolSpec(
+            name="echo",
+            description="echo",
+            input_schema={"type": "object",
+                          "properties": {"x": {"type": "string"}}},
+            handler=lambda a, s: ToolOutput(text="x"),
+        )
+        self.backend._client.chat.completions.create.return_value = (
+            _make_chat_response(text="", finish_reason="stop"))
+        self.backend._send_request(
+            system_prompt="sys", history=[], tools=[spec], model="gpt-4o")
+        kwargs = self.backend._client.chat.completions.create.call_args.kwargs
+        sent_tools = kwargs["tools"]
+        self.assertEqual(sent_tools[0]["type"], "function")
+        self.assertEqual(sent_tools[0]["function"]["name"], "echo")
+        self.assertEqual(sent_tools[0]["function"]["parameters"],
+                         {"type": "object",
+                          "properties": {"x": {"type": "string"}}})
+
+    def test_auth_error_translated_to_llm_auth_error(self):
+        import openai as _openai
+        fake_auth = type("FakeAuth", (Exception,), {})
+        with mock.patch.object(_openai, "AuthenticationError", fake_auth):
+            self.backend._client.chat.completions.create.side_effect = (
+                fake_auth("401"))
+            with self.assertRaises(LLMAuthError):
+                self.backend._send_request(system_prompt="s", history=[],
+                                            tools=[], model="m")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_backends_openai -v'
+```
+
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement `backends/openai.py`**
+
+Create `toksearch/llm/backends/openai.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""OpenAIBackend — driver for the OpenAI Chat Completions API.
+
+PR 1: blocking (non-streaming) API only.  Tool-arg streaming reassembly is
+deferred to a follow-up PR.
+"""
+
+import json
+
+import openai
+
+from ..errors import LLMAuthError, LLMBackendError, LLMRateLimitError
+from ..messages import (
+    Message, TextBlock, ToolResultBlock, ToolUseBlock,
+)
+from .base import AssistantTurn, _ToolLoopBackend
+
+
+class OpenAIBackend(_ToolLoopBackend):
+    name = "openai"
+    default_model = "gpt-4o"
+
+    def __init__(self, api_key: str | None, base_url: str | None = None):
+        self._api_key = api_key
+        self._base_url = base_url
+        self._client = None  # lazy
+
+    def _build_client(self):
+        kwargs = {}
+        if self._api_key is not None:
+            kwargs["api_key"] = self._api_key
+        if self._base_url is not None:
+            kwargs["base_url"] = self._base_url
+        self._client = openai.OpenAI(**kwargs)
+        return self._client
+
+    def _ensure_client(self):
+        if self._client is None:
+            self._build_client()
+        return self._client
+
+    # ---- Translation: ToolSpec -> OpenAI tool schema ----
+
+    @staticmethod
+    def _spec_to_native(spec) -> dict:
+        return {
+            "type": "function",
+            "function": {
+                "name": spec.name,
+                "description": spec.description,
+                "parameters": spec.input_schema,
+            },
+        }
+
+    # ---- Translation: our Message list -> OpenAI messages= ----
+
+    @classmethod
+    def _history_to_native(cls, system_prompt: str,
+                            history: list[Message]) -> list[dict]:
+        out = [{"role": "system", "content": system_prompt}]
+        for m in history:
+            if m.role == "user":
+                # Could be a plain text user message OR a tool_result-only user
+                # message.  OpenAI represents tool results as separate
+                # role="tool" messages, so split them out.
+                text_parts = [b.text for b in m.content
+                              if isinstance(b, TextBlock)]
+                if text_parts:
+                    out.append({"role": "user",
+                                "content": "\n".join(text_parts)})
+                for b in m.content:
+                    if isinstance(b, ToolResultBlock):
+                        content = b.output
+                        if b.is_error:
+                            content = "[error]\n" + content
+                        out.append({"role": "tool",
+                                    "tool_call_id": b.tool_use_id,
+                                    "content": content})
+            elif m.role == "assistant":
+                text_parts = [b.text for b in m.content
+                              if isinstance(b, TextBlock)]
+                tool_uses = [b for b in m.content
+                             if isinstance(b, ToolUseBlock)]
+                msg = {"role": "assistant",
+                       "content": "\n".join(text_parts) if text_parts else None}
+                if tool_uses:
+                    msg["tool_calls"] = [{
+                        "id": b.id,
+                        "type": "function",
+                        "function": {"name": b.name,
+                                      "arguments": json.dumps(b.args)},
+                    } for b in tool_uses]
+                out.append(msg)
+        return out
+
+    # ---- Translation: OpenAI response -> our ContentBlock list ----
+
+    @staticmethod
+    def _response_to_blocks(message) -> list:
+        out = []
+        if message.content:
+            out.append(TextBlock(text=message.content))
+        for tc in (message.tool_calls or []):
+            try:
+                args = json.loads(tc.function.arguments)
+            except json.JSONDecodeError:
+                args = {"_raw": tc.function.arguments}
+            out.append(ToolUseBlock(id=tc.id, name=tc.function.name,
+                                     args=args))
+        return out
+
+    # ---- Stop-reason translation ----
+
+    @staticmethod
+    def _stop_reason(finish_reason: str) -> str:
+        return "tool_use" if finish_reason == "tool_calls" else "end_turn"
+
+    # ---- Main entrypoint ----
+
+    def _send_request(self, *, system_prompt, history, tools, model,
+                      on_text=None) -> AssistantTurn:
+        client = self._ensure_client()
+        try:
+            resp = client.chat.completions.create(
+                model=model,
+                messages=self._history_to_native(system_prompt, history),
+                tools=[self._spec_to_native(t) for t in tools],
+            )
+        except openai.AuthenticationError as e:
+            raise LLMAuthError(
+                "OpenAI auth failed. Set OPENAI_API_KEY or pass api_key=... "
+                "to the backend.") from e
+        except openai.RateLimitError as e:
+            raise LLMRateLimitError(str(e)) from e
+        except openai.APIConnectionError as e:
+            raise LLMBackendError(f"Network error: {e}") from e
+        except openai.APIStatusError as e:
+            raise LLMBackendError(f"OpenAI API error: {e}") from e
+        choice = resp.choices[0]
+        blocks = self._response_to_blocks(choice.message)
+        text_total = "".join(b.text for b in blocks if isinstance(b, TextBlock))
+        if text_total and on_text is not None:
+            on_text(text_total)
+        return AssistantTurn(blocks=blocks,
+                              stop_reason=self._stop_reason(choice.finish_reason))
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_backends_openai -v'
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Re-run the registry tests, which should now pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_backends_registry -v'
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add toksearch/llm/backends/openai.py tests/test_llm_backends_openai.py
+git commit -m "Add OpenAIBackend with mocked SDK tests"
+```
+
+---
+
+## Task 16: Add the CLI (`toksearch chat` + `toksearch query`)
+
+**Files:**
+- Create: `toksearch/llm/cli.py`
+- Create: `tests/test_llm_cli.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_llm_cli.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for the toksearch chat / toksearch query CLI.
+
+The Session class is mocked so the CLI tests verify wiring (subcommand
+dispatch, flag plumbing, slash-command handling) without going near a real
+backend.
+"""
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+
+class TestCliQuery(unittest.TestCase):
+    def _run_cli(self, argv, send_returns=None, stdin_text=""):
+        from toksearch.llm import cli
+        fake_session = mock.MagicMock()
+        fake_session.send.return_value = send_returns or mock.MagicMock(
+            stop_reason="end_turn", final_text="ok")
+        buf = io.StringIO()
+        exit_code = None
+        with mock.patch.object(sys, "argv", argv), \
+                mock.patch.object(cli, "build_session",
+                                  return_value=fake_session) as build, \
+                mock.patch.object(sys, "stdin",
+                                  new=io.StringIO(stdin_text)), \
+                redirect_stdout(buf):
+            try:
+                cli.main()
+            except SystemExit as e:
+                exit_code = e.code
+        return fake_session, build, buf.getvalue(), exit_code
+
+    def test_query_dispatches_send(self):
+        sess, _, _, _ = self._run_cli(
+            ["toksearch", "query", "hello"])
+        sess.send.assert_called_once()
+        prompt = sess.send.call_args.args[0]
+        self.assertEqual(prompt, "hello")
+
+    def test_query_backend_flag_forwarded_to_build(self):
+        _, build, _, _ = self._run_cli(
+            ["toksearch", "query", "--backend", "openai", "hi"])
+        # build_session called with args namespace; check the attribute
+        ns = build.call_args.args[0]
+        self.assertEqual(ns.backend, "openai")
+
+    def test_query_max_iterations_flag(self):
+        _, build, _, _ = self._run_cli(
+            ["toksearch", "query", "-n", "3", "hi"])
+        ns = build.call_args.args[0]
+        self.assertEqual(ns.max_iterations, 3)
+
+
+class TestCliChatSlashCommands(unittest.TestCase):
+    def _run_chat(self, stdin_text):
+        from toksearch.llm import cli
+        fake_session = mock.MagicMock()
+        fake_session.send.return_value = mock.MagicMock(
+            stop_reason="end_turn", final_text="agent says hi")
+        buf = io.StringIO()
+        exit_code = None
+        with mock.patch.object(sys, "argv", ["toksearch", "chat"]), \
+                mock.patch.object(cli, "build_session",
+                                  return_value=fake_session), \
+                mock.patch.object(sys, "stdin",
+                                  new=io.StringIO(stdin_text)), \
+                redirect_stdout(buf):
+            try:
+                cli.main()
+            except SystemExit as e:
+                exit_code = e.code
+        return fake_session, buf.getvalue(), exit_code
+
+    def test_chat_sends_each_nonempty_line(self):
+        sess, out, _ = self._run_chat("hello\nhow are you?\n")
+        self.assertEqual(sess.send.call_count, 2)
+
+    def test_slash_quit_exits_loop(self):
+        sess, out, _ = self._run_chat("hello\n/quit\nignored\n")
+        self.assertEqual(sess.send.call_count, 1)
+
+    def test_slash_reset_calls_session_reset(self):
+        sess, out, _ = self._run_chat("/reset\n")
+        sess.reset.assert_called_once()
+
+    def test_slash_help_prints(self):
+        sess, out, _ = self._run_chat("/help\n")
+        self.assertIn("/help", out)
+        self.assertIn("/reset", out)
+        self.assertIn("/quit", out)
+
+    def test_eof_exits_cleanly(self):
+        # Empty stdin = immediate EOF
+        sess, out, exit_code = self._run_chat("")
+        self.assertIn(exit_code, (None, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_cli -v'
+```
+
+Expected: `ModuleNotFoundError: No module named 'toksearch.llm.cli'`.
+
+- [ ] **Step 3: Implement `cli.py`**
+
+Create `toksearch/llm/cli.py`:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Command-line interface for toksearch.llm.
+
+Subcommands:
+- ``toksearch query "<prompt>"`` — one-shot; runs a single turn and prints output.
+- ``toksearch chat`` — interactive REPL (plain ``input()``; prompt_toolkit-based
+  UI is deferred to a follow-up PR).
+
+The CLI delegates everything substantive to ``Session``.  ``build_session(args)``
+is the seam tests mock to avoid constructing a real backend.
+"""
+
+import argparse
+import sys
+
+from .config import load_config
+from .errors import LLMConfigError, LLMError
+from .presets import resolve_preset
+from .backends import get_backend_class
+from .session import Session
+
+
+def build_session(args) -> Session:
+    """Construct a Session from parsed CLI args."""
+    cfg = load_config()
+    backend_name = args.backend or cfg.backend or "anthropic"
+    preset = resolve_preset(backend_name, cfg)
+    backend_cls = get_backend_class(preset.backend)
+    api_key = _resolve_api_key(preset, cfg)
+    backend = backend_cls(api_key=api_key, base_url=preset.base_url)
+    return Session(
+        backend=backend,
+        model=args.model or preset.model,
+        max_iterations=args.max_iterations or cfg.max_iterations,
+    )
+
+
+def _resolve_api_key(preset, cfg) -> str | None:
+    if preset.backend == "anthropic":
+        return cfg.anthropic_api_key
+    if preset.backend == "openai":
+        return cfg.openai_api_key
+    return None
+
+
+# ----------------------------------------------------------------------
+# `toksearch query`
+# ----------------------------------------------------------------------
+
+def _print_tool_call(call):
+    print(f"\n[{call.name}] {call.thought or ''}".rstrip())
+    code = call.args.get("code")
+    if code:
+        for line in code.splitlines():
+            print(f"  {line}")
+
+
+def _print_tool_result(result):
+    label = "[output]" if not result.is_error else "[error]"
+    body = result.output or ""
+    for line in body.splitlines():
+        print(f"  {line}")
+    if not body:
+        print(f"{label} (empty)")
+
+
+def do_query(args):
+    session = build_session(args)
+    try:
+        result = session.send(
+            args.query,
+            on_text=lambda t: print(t, end="", flush=True),
+            on_tool_call=_print_tool_call,
+            on_tool_result=_print_tool_result,
+        )
+    except LLMError as e:
+        print(f"\nerror: {e}", file=sys.stderr)
+        sys.exit(1)
+    print()  # final newline
+    sys.exit(0 if result.stop_reason == "end_turn" else 2)
+
+
+# ----------------------------------------------------------------------
+# `toksearch chat`
+# ----------------------------------------------------------------------
+
+_HELP_TEXT = """\
+Slash commands:
+  /help   show this help
+  /reset  clear history and namespace
+  /quit   exit the chat (ctrl-D also works)
+"""
+
+
+def do_chat(args):
+    session = build_session(args)
+    print(f"toksearch chat (backend: {session.backend.name}, "
+          f"model: {session.model})")
+    print("Type /help for commands. Ctrl-D to exit.\n")
+    while True:
+        try:
+            line = input("you> ").strip()
+        except EOFError:
+            print()
+            return
+        if not line:
+            continue
+        if line == "/quit":
+            return
+        if line == "/help":
+            print(_HELP_TEXT)
+            continue
+        if line == "/reset":
+            session.reset()
+            print("(session cleared)")
+            continue
+        try:
+            session.send(
+                line,
+                on_tool_call=_print_tool_call,
+                on_tool_result=_print_tool_result,
+            )
+        except LLMError as e:
+            print(f"error: {e}", file=sys.stderr)
+            continue
+        print()  # spacer between turns
+
+
+# ----------------------------------------------------------------------
+# main
+# ----------------------------------------------------------------------
+
+def _add_common(p):
+    p.add_argument("--backend", default=None,
+                   help="Backend / preset name (anthropic, openai, or a user "
+                        "preset from ~/.fdp/config.toml).")
+    p.add_argument("--model", default=None,
+                   help="Override the preset's default model.")
+    p.add_argument("-n", "--max-iterations", type=int, default=None,
+                   help="Cap on tool-call rounds per turn.")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="toksearch")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    qp = sub.add_parser("query", help="One-shot natural-language query.")
+    qp.add_argument("query", help="The prompt (quote it on the shell).")
+    _add_common(qp)
+    qp.set_defaults(func=do_query)
+
+    cp = sub.add_parser("chat", help="Interactive conversation.")
+    _add_common(cp)
+    cp.set_defaults(func=do_chat)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest test_llm_cli -v'
+```
+
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add toksearch/llm/cli.py tests/test_llm_cli.py
+git commit -m "Add toksearch chat / toksearch query CLI"
+```
+
+---
+
+## Task 17: Wire up the public package surface and console script
+
+**Files:**
+- Modify: `toksearch/llm/__init__.py`
+- Modify: `setup.py`
+- Modify: `pyproject.toml`
+- Modify: `tests/test_llm_package.py`
+
+- [ ] **Step 1: Update the package `__init__.py` with public re-exports**
+
+Replace `toksearch/llm/__init__.py` with:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""toksearch.llm — Conversational LLM interface for TokSearch.
+
+See ``docs/superpowers/specs/2026-05-18-toksearch-llm-design.md``.
+
+Quickstart
+==========
+
+::
+
+    from toksearch.llm import Session
+    from toksearch.llm.backends.anthropic import AnthropicBackend
+
+    sess = Session(backend=AnthropicBackend(api_key="sk-..."))
+    result = sess.send("Fetch ip for shot 200000 and report peak in MA.",
+                       on_tool_call=lambda c: print(c.name, c.thought),
+                       on_tool_result=lambda r: print(r.output))
+    print(result.final_text)
+"""
+
+from .errors import (
+    LLMError,
+    LLMConfigError,
+    LLMAuthError,
+    LLMBackendError,
+    LLMRateLimitError,
+    LLMUserAbort,
+)
+from .events import TextDelta, ToolCall, ToolResult, TurnComplete
+from .config import Config, load_config
+from .presets import Preset, BUILTIN_PRESETS, resolve_preset
+from .session import Session
+
+__all__ = [
+    "Session",
+    "Config", "load_config",
+    "Preset", "BUILTIN_PRESETS", "resolve_preset",
+    "TextDelta", "ToolCall", "ToolResult", "TurnComplete",
+    "LLMError", "LLMConfigError", "LLMAuthError",
+    "LLMBackendError", "LLMRateLimitError", "LLMUserAbort",
+]
+```
+
+- [ ] **Step 2: Update `setup.py`**
+
+In `setup.py`, find the `package_data` line and update it to include `cli.py`
+metadata-as-data only if necessary. Then add an `entry_points` argument to
+`setup(...)` immediately after the `scripts=[...]` line:
+
+Replace:
+
+```python
+    scripts=['scripts/toksearch_submit', 'scripts/toksearch_shape', 'scripts/toksearch_example.py'],
+    # this package will read some included files in runtime, avoid installing it as .zip
+    zip_safe=False,
+```
+
+with:
+
+```python
+    scripts=['scripts/toksearch_submit', 'scripts/toksearch_shape', 'scripts/toksearch_example.py'],
+    entry_points={
+        "console_scripts": [
+            "toksearch = toksearch.llm.cli:main",
+        ],
+    },
+    # this package will read some included files in runtime, avoid installing it as .zip
+    zip_safe=False,
+```
+
+- [ ] **Step 3: Update `pyproject.toml` with the `[llm]` optional extra**
+
+Add to the end of `pyproject.toml`:
+
+```toml
+[project]
+name = "toksearch"
+dynamic = ["version"]
+
+[project.optional-dependencies]
+llm = ["anthropic>=0.34", "openai>=1.50", "matplotlib"]
+```
+
+Note: `[project]` may already exist; if so, only add the `optional-dependencies`
+table. Do NOT duplicate the `name`/`dynamic` keys.
+
+- [ ] **Step 4: Re-run pip install to register the console script**
+
+```bash
+pixi run build
+```
+
+Expected: editable install picks up the new entry point. Verify:
+
+```bash
+pixi run which toksearch
+pixi run toksearch query --help
+```
+
+Expected: the `toksearch` script exists; `--help` shows the `query` and `chat`
+subcommands.
+
+- [ ] **Step 5: Extend `test_llm_package.py` with the public-surface check**
+
+Replace `tests/test_llm_package.py` with:
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Public-surface tests for toksearch.llm."""
+
+import unittest
+
+
+class TestPublicSurface(unittest.TestCase):
+    def test_session_importable(self):
+        from toksearch.llm import Session  # noqa: F401
+
+    def test_event_types_importable(self):
+        from toksearch.llm import (
+            TextDelta, ToolCall, ToolResult, TurnComplete,
+        )  # noqa: F401
+
+    def test_error_types_importable(self):
+        from toksearch.llm import (
+            LLMError, LLMConfigError, LLMAuthError,
+            LLMBackendError, LLMRateLimitError, LLMUserAbort,
+        )  # noqa: F401
+
+    def test_config_and_presets_importable(self):
+        from toksearch.llm import (
+            Config, load_config, Preset, BUILTIN_PRESETS, resolve_preset,
+        )  # noqa: F401
+
+
+class TestConsoleScript(unittest.TestCase):
+    def test_cli_main_callable(self):
+        from toksearch.llm.cli import main
+        self.assertTrue(callable(main))
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 6: Run the full LLM test suite**
+
+```bash
+pixi run bash -c 'cd tests && python -m unittest discover -p "test_llm*" -v'
+```
+
+Expected: all LLM tests pass (errors, events, messages, config, presets,
+tools, prompts, backends_base, backends_fake, backends_registry,
+backends_anthropic, backends_openai, session, cli, package).
+
+- [ ] **Step 7: Run the full project test suite to ensure nothing else broke**
+
+```bash
+pixi run bash -c 'cd tests && ./testit --mock --noptdata --nod3drdb'
+```
+
+Expected: all tests pass. (`--mock --noptdata --nod3drdb` skips integration-only
+tests in the existing suite.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add toksearch/llm/__init__.py setup.py pyproject.toml tests/test_llm_package.py
+git commit -m "Wire toksearch.llm public surface and console script"
+```
+
+---
+
+## Task 18: Manual smoke test (operator-run, not automated)
+
+**Files:** none modified.
+
+These steps require a live `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`).  Skip
+if absent; the unit tests cover wiring.
+
+- [ ] **Step 1: Verify `toksearch query` works end-to-end with Anthropic**
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... pixi run toksearch query --backend anthropic \
+    "In Python, set x = 1 + 1 and report the value."
+```
+
+Expected: per-iteration tool-call lines (`[run_python] ...` then `[output] ...`),
+then a final text response mentioning `2`.
+
+- [ ] **Step 2: Verify `toksearch chat` REPL works**
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... pixi run toksearch chat --backend anthropic
+```
+
+Expected: greeting line, then `you> ` prompt. Type `/help` to see the slash
+commands. Type a few prompts that build state across turns (e.g. "set x = 5"
+then "what is x squared?"). Verify that the second turn references the
+namespace set in the first. Type `/reset` to clear; type `/quit` to exit.
+
+- [ ] **Step 3: Verify `toksearch query` works end-to-end with OpenAI**
+
+```bash
+OPENAI_API_KEY=sk-... pixi run toksearch query --backend openai \
+    "In Python, compute and print 2**10."
+```
+
+Expected: per-iteration tool-call lines, final text mentioning `1024`.
+
+- [ ] **Step 4: Verify backend selection from env**
+
+```bash
+FDP_LLM_BACKEND=openai OPENAI_API_KEY=sk-... pixi run toksearch query \
+    "What is 7 * 6?"
+```
+
+Expected: same as Step 3 — the env var picks OpenAI without a `--backend` flag.
+
+If any step fails, the failure should be in `cli.py` wiring or the backend
+translation layer.  Both are covered by unit tests; a new smoke failure means
+we missed a case worth adding to the unit suite.
+
+---
+
+## Self-Review Notes
+
+Coverage against the PR 1 scope:
+- ✓ `Session` class with sync `send()` and event callbacks → Task 13.
+- ✓ Event types (`TextDelta`, `ToolCall`, `ToolResult`, `TurnComplete`) → Task 3.
+- ✓ Provider-neutral history (`Message`, `ContentBlock` family) → Task 4.
+- ✓ `LLMError` hierarchy → Task 2.
+- ✓ `Config` + `load_config()` with TOML and env overlay → Task 5.
+- ✓ Built-in `anthropic` / `openai` presets + `resolve_preset` → Task 6.
+- ✓ `ToolSpec`, `run_python`, `lookup_docs`, skill discovery → Tasks 7-8.
+- ✓ System-prompt assembly → Task 9.
+- ✓ `Backend` ABC, `AssistantTurn`, `Callbacks`, `_ToolLoopBackend` → Task 10.
+- ✓ `FakeBackend` testing seam → Task 11.
+- ✓ Backend registry with lazy lookup → Task 12.
+- ✓ `AnthropicBackend` (also serves AmSC via preset `base_url`) → Task 14.
+- ✓ `OpenAIBackend` → Task 15.
+- ✓ `toksearch chat` + `toksearch query` CLI with `/help` `/reset` `/quit` → Task 16.
+- ✓ Console script + `[llm]` optional extra → Task 17.
+- ✓ Public `toksearch.llm` surface → Task 17.
+
+Explicitly deferred (called out at top of plan):
+- Streaming text deltas (incremental on_text); `_send_request` is blocking.
+- `prompt_toolkit`-based REPL; plain `input()` only in PR 1.
+- Slash commands `/save`, `/history`, `/namespace`, `/backend`, `/model`.
+- `--confirm` CLI flag (but the `confirm` callable on `Session.send` ships).
+- Entry-point discovery for namespace/skills/presets contributors (PR 2).
+- `ClaudeSDKBackend` (PR 3).
+- AmSC preset registration (PR 4; users can still use AmSC by defining a user
+  preset in `~/.fdp/config.toml`).
+- Connectivity test command (`toksearch llm test`).
+- Anthropic `cache_control` on system prompt.
+- Retry-with-backoff in `_send_request` (deferred along with streaming).
+
+Each deferred item is additive against the PR 1 surface — no refactor required
+to add it later.

--- a/docs/superpowers/specs/2026-05-18-toksearch-llm-design.md
+++ b/docs/superpowers/specs/2026-05-18-toksearch-llm-design.md
@@ -1,0 +1,573 @@
+# toksearch.llm — Conversational LLM interface for TokSearch
+
+**Status:** Draft for review
+**Date:** 2026-05-18
+**Owner:** sammuli
+**Supersedes:** `toksearch_d3d/agents/claude_toksearch_agent.py` (current)
+
+## Motivation
+
+The current LLM-driven query capability (`toksearch_d3d.agents.claude_toksearch_agent`,
+exposed via `fdp query "..."`) works but has three structural limits:
+
+1. **One-shot only.** A single prompt produces one answer; there is no conversational
+   follow-up. Useful exploratory workflows ("plot Ip for this shot", "now overlay another
+   shot", "save it as PNG") would require either re-fetching from scratch each time or
+   stitching together unrelated `fdp query` invocations.
+2. **Locked to one LLM provider.** Hardcoded to the AmSC Anthropic-compatible endpoint
+   with model `claude-sonnet-4-6` and `~/amsc_api_key`. No way to use a direct Anthropic
+   API key, an OpenAI key, or a Claude Max plan.
+3. **Lives in `toksearch_d3d`** despite being a generic capability. The same agent
+   pattern is useful for any TokSearch user (MAST via `ZarrSignal`, future devices), but
+   the current location couples it to DIII-D-specific install paths.
+
+This spec replaces the current implementation with a library-first, multi-backend,
+conversational design that lives in core `toksearch` and lets device packages
+(`toksearch_d3d`, future siblings) plug in additively.
+
+## Goals
+
+- **Conversational.** Multi-turn dialog over a persistent Python namespace so follow-up
+  turns iterate on cached results instead of re-fetching.
+- **Provider-agnostic.** Anthropic, OpenAI, AmSC (Anthropic-compatible), and Claude Max
+  (via Claude Agent SDK) backends, behind a uniform `Session` API. AmSC and any other
+  Anthropic-compatible site endpoint are configured as **presets**, not separate classes.
+- **Library-first.** Python `Session` class is the primary API; CLI commands (`toksearch
+  chat`, `toksearch query`, `fdp chat`, `fdp query`) are thin wrappers.
+- **Multi-device per session.** A single session can mix DIII-D and MAST data (or any
+  other device whose package is installed); contributors auto-discover via Python entry
+  points.
+- **Show-then-run transparency.** The REPL displays the agent's code and one-sentence
+  rationale before executing, with auto-approve as the default and ctrl-C to interrupt.
+  Optional `--confirm` flag for prompt-before-execute.
+- **Design for future on-disk persistence** without implementing it now — keep history
+  in a provider-neutral, JSON-serializable shape.
+
+## Non-goals
+
+- A fully sandboxed code-execution environment (same blast radius as Claude Code's Bash
+  tool; `exec()` runs in-process).
+- Claude-Code-like generic agent capabilities (Read/Edit/Bash/Glob/Grep). The Claude
+  Agent SDK backend is **strictly a way to bill the Claude Max plan** while keeping
+  identical behavior to the raw-API backends. Users who want full Claude Code should
+  run `claude` directly; the `fdp skills install` machinery already exists for that.
+- Auto-save / resume of session history (designed-for but not implemented).
+- Image / multimedia output in the terminal (REPL surfaces saved-file paths; a future
+  Jupyter wrapper can inline figures).
+
+## High-level design
+
+### Architecture
+
+Four layers, top to bottom:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  CLI                                                             │
+│  toksearch chat | toksearch query | fdp chat | fdp query         │
+└────────────────────────────┬─────────────────────────────────────┘
+                             │
+┌────────────────────────────▼─────────────────────────────────────┐
+│  Session  (toksearch.llm.session)                                │
+│  - owns history, namespace, tool registry, backend instance      │
+│  - sync send() with optional event callbacks                     │
+└──────────┬──────────────────────────────────────┬────────────────┘
+           │                                      │
+┌──────────▼──────────────┐         ┌─────────────▼────────────────┐
+│  Backend (ABC)          │         │  Tools                       │
+│  - run_conversation(    │         │  - run_python (exec in       │
+│       session, prompt,  │◄────────│    persistent namespace)     │
+│       callbacks, ...)   │         │  - lookup_docs (read SKILL.md│
+└─┬───────────────────┬───┘         │    from registered skill     │
+  │                   │             │    dirs)                     │
+  │                   │             └──────────────────────────────┘
+┌─▼─────────────┐  ┌──▼──────────────────┐
+│_ToolLoopBackend│  │ ClaudeSDKBackend   │
+│ Anthropic │ OpenAI│ (Claude Agent SDK +│
+│ (AmSC = Anthropic │  in-process MCP    │
+│  preset)          │  for run_python)   │
+└───────────────────┘  └─────────────────┘
+```
+
+- **Session** owns all state; backends are stateless adapters.
+- **`_ToolLoopBackend`** holds the shared tool-loop logic for raw API providers; subclasses
+  implement only the provider-specific request/response translation.
+- **`ClaudeSDKBackend`** is structurally different: the Claude Agent SDK drives its own
+  tool loop in the `claude` subprocess; we expose `run_python` and `lookup_docs` as
+  custom **in-process MCP tools** so the persistent namespace is shared.
+
+### Package layout
+
+```
+toksearch/llm/                  # core repo
+├── __init__.py                 # public re-exports
+├── session.py                  # Session class
+├── events.py                   # TextDelta, ToolCall, ToolResult, TurnComplete
+├── messages.py                 # provider-neutral history representation
+├── tools.py                    # run_python, lookup_docs, ToolSpec
+├── prompts.py                  # kernel system prompt + catalog assembly
+├── errors.py                   # LLMError hierarchy
+├── config.py                   # Config dataclass + load_config()
+├── discovery.py                # entry-point discovery for namespace/skills/presets
+├── presets.py                  # backend presets registry
+├── cli.py                      # `toksearch chat` / `toksearch query`
+└── backends/
+    ├── __init__.py             # backend registry, get_backend()
+    ├── base.py                 # Backend ABC, _ToolLoopBackend
+    ├── anthropic.py            # also serves AmSC via preset
+    ├── openai.py               # OpenAI Chat Completions
+    └── claude_sdk.py           # Claude Agent SDK
+
+toksearch_d3d/                  # device contributor
+├── toksearch_d3d/llm/
+│   └── __init__.py             # skills_path, AMSC_PRESET, namespace marker
+├── toksearch_d3d/skills/       # unchanged
+└── pyproject.toml              # entry points registering the contributor
+```
+
+### Public API (Python)
+
+```python
+from toksearch.llm import Session, TextDelta, ToolCall, ToolResult, TurnComplete
+
+session = Session(
+    backend="anthropic",        # name or Backend instance; default from config/env
+    model=None,                  # backend's default if None
+    max_iterations=20,
+    extra_namespace=None,        # dict merged into the run_python namespace
+    packages=None,               # override entry-point discovery (None = all installed)
+    extra_skill_dirs=None,       # additional skill directories
+    config=None,                 # explicit Config; default loads from ~/.fdp/config.toml
+)
+
+result: TurnComplete = session.send(
+    "plot Ip for shot 200000",
+    on_text=lambda t: print(t, end=""),
+    on_tool_call=lambda c: print(f"[{c.name}] {c.thought}"),
+    on_tool_result=lambda r: ...,
+    on_event=None,               # catch-all alternative
+    confirm=None,                # None = auto-approve; callable returning bool to gate
+)
+
+session.history     # list[Message] — provider-neutral
+session.namespace   # dict — the run_python persistent namespace
+session.reset()     # clear history + namespace
+```
+
+### CLI
+
+```
+toksearch chat [--backend NAME] [--model NAME] [--package NAME ...] [--confirm]
+toksearch query "<prompt>" [--backend NAME] [--max-iterations N] [--quiet] [--debug]
+
+fdp chat ...      # shim: setup_environment() + re-exec `toksearch chat`
+fdp query ...     # shim: setup_environment() + re-exec `toksearch query`
+                  # (preserves existing flags byte-for-byte)
+```
+
+In `fdp chat`, the REPL prints each `run_python` invocation (code + thought) before
+executing it, then prints the captured output, then the agent's text response. Slash
+commands (`/help`, `/reset`, `/history`, `/namespace`, `/backend`, `/model`, `/save`,
+`/quit`) operate on the live Session.
+
+## Detailed design
+
+### Events
+
+All four event types are frozen dataclasses. The Session dispatches them to the
+appropriate `on_<kind>` callback (and to `on_event` if provided).
+
+```python
+@dataclass(frozen=True)
+class TextDelta:
+    text: str
+
+@dataclass(frozen=True)
+class ToolCall:
+    id: str
+    name: str
+    args: dict
+    thought: str | None      # populated for run_python; None for lookup_docs
+
+@dataclass(frozen=True)
+class ToolResult:
+    id: str
+    output: str
+    is_error: bool
+
+@dataclass(frozen=True)
+class TurnComplete:
+    stop_reason: Literal["end_turn", "max_iterations", "interrupted"]
+    final_text: str
+```
+
+### History — `Message` and `ContentBlock`
+
+Provider-neutral so the same shape works for Anthropic, OpenAI, and Claude SDK; also so
+future on-disk persistence can serialize without provider-specific objects.
+
+```python
+@dataclass
+class Message:
+    role: Literal["user", "assistant"]
+    content: list[ContentBlock]
+
+# Tagged union; one variant per kind:
+@dataclass
+class TextBlock:        kind = "text";        text: str
+
+@dataclass
+class ToolUseBlock:     kind = "tool_use";    id: str; name: str; args: dict
+
+@dataclass
+class ToolResultBlock:  kind = "tool_result"; tool_use_id: str
+                        output: str; is_error: bool
+```
+
+Backends translate to/from their native shapes on the boundary; the Session sees only
+this union.
+
+### Tools
+
+Two `ToolSpec`s registered with the Session at construction. Both are
+backend-agnostic; backends translate the `input_schema` to native form.
+
+**`run_python`**
+
+- Schema: `{"code": str (required), "thought": str (required)}`.
+- Handler executes `exec(code, session.namespace)` with stdout/stderr captured.
+- The namespace persists for the Session's lifetime; pre-populated with `toksearch`,
+  `plt` (`matplotlib.pyplot`), `pd` (`pandas`), `np` (`numpy`), plus everything
+  contributed via entry-point discovery (e.g., `toksearch_d3d`) and anything in
+  `extra_namespace`.
+- `KeyboardInterrupt` during execution: caught, returns `(interrupted)` as the tool
+  result with `is_error=True` so the model can react.
+- Other exceptions: traceback written to stderr; tool result has `is_error=True`.
+
+**`lookup_docs`**
+
+- Schema: `{"skill_name": str (required, enum populated from discovered skills)}`.
+- Handler returns the SKILL.md body for the named skill.
+- Skill discovery: union of `toksearch/skills/` (built-in) and every directory pointed
+  to by a registered `toksearch.llm.skills` entry point, plus any `extra_skill_dirs`
+  passed at Session construction.
+
+### System prompt
+
+Small kernel + dynamic catalog assembled at Session init:
+
+```
+You are a TokSearch expert. Use the run_python tool to execute code that fetches
+and analyzes fusion data. The namespace persists across tool calls in this
+session — variables from earlier calls are available in later ones.
+
+You have access to fusion data via the following installed packages:
+- toksearch (core): Pipeline, MdsSignal, ZarrSignal, fetch_dataset
+- toksearch_d3d: DIII-D signals (PtDataSignal, ImasSignal), FDP/Pelican data access
+  [...one line per contributor...]
+
+Available documentation skills (call lookup_docs(skill_name=...) to read):
+- toksearch-pipeline: core pipeline workflow
+- toksearch-mds: MDSplus signal class
+- toksearch-d3d-ptdata: DIII-D PTData signals
+  [...one line per discovered skill...]
+
+Rules:
+- Do not include import statements; common modules are pre-imported.
+- If code raises an error, read the traceback, fix it, and try again.
+- When you have a result, store it in a variable named `result` or describe it
+  in plain text. Do not call any tool to "finish" — just stop emitting tool calls.
+```
+
+Per-contributor descriptions come from a module-level `__llm_description__` attribute
+on the package object resolved by the `toksearch.llm.namespace` entry point.
+
+### Backends
+
+#### `Backend` ABC
+
+```python
+class Backend(ABC):
+    name: str
+    default_model: str
+
+    @abstractmethod
+    def run_conversation(
+        self,
+        session: "Session",
+        new_user_message: str,
+        callbacks: Callbacks,
+        max_iterations: int,
+    ) -> TurnComplete: ...
+```
+
+The backend advances the conversation by one user message's worth of work, dispatching
+callbacks along the way, and returns when the assistant has either stopped emitting
+tool calls (`end_turn`), been interrupted, or hit `max_iterations`.
+
+#### `_ToolLoopBackend` (Anthropic, OpenAI, AmSC)
+
+Implements the standard loop:
+
+```
+1. Append the user message to history.
+2. Loop up to max_iterations:
+   a. Call self._send_request(system_prompt, history, tools, model, on_text)
+      → returns AssistantTurn(blocks, stop_reason).
+   b. Append the assistant turn to session.history.
+   c. For each tool_use block:
+      - Fire on_tool_call.
+      - If confirm is set and returns False: return TurnComplete("interrupted").
+      - session._execute_tool(block) → ToolOutput.
+      - Fire on_tool_result.
+      - Append a user-role tool_result message to history.
+   d. If stop_reason != "tool_use": return TurnComplete(stop_reason, final_text).
+3. Return TurnComplete("max_iterations", ...).
+```
+
+Subclasses implement only `_send_request()` and the translation to/from `ContentBlock`.
+
+**`AnthropicBackend`**: uses `anthropic.Anthropic(api_key=..., base_url=...)`. Adds
+`cache_control: ephemeral` to the system prompt block. Streams text deltas via
+`client.messages.stream(...)`. Native tool/result schema maps to `ContentBlock`
+near-identity.
+
+**`OpenAIBackend`**: uses `openai.OpenAI(api_key=...)`. Translates our `ToolSpec` to
+`{"type": "function", "function": {"name", "description", "parameters"}}`. Accumulates
+streamed partial tool-arg JSON across chunks before emitting a single `ToolCall`.
+Prepends `[error]\n` to tool results when `is_error=True` since OpenAI has no native
+flag.
+
+**AmSC**: not a separate class. Registered as a preset (see Presets below).
+
+#### `ClaudeSDKBackend` (Claude Max plan)
+
+Uses `claude_agent_sdk.ClaudeSDKClient` configured with `ClaudeAgentOptions`:
+
+- `system_prompt`: the Session's system prompt (same content as raw backends).
+- `mcp_servers`: an in-process MCP server (created via `create_sdk_mcp_server`) exposing
+  `run_python` and `lookup_docs`. The server's tool handlers call back into the
+  Session's namespace directly — no out-of-process MCP transport.
+- `allowed_tools`: `["mcp__toksearch__run_python", "mcp__toksearch__lookup_docs"]`.
+  Claude Code's built-in Read/Edit/Bash/Glob/Grep are **disabled** by default. This is
+  deliberate — see Non-goals.
+- `permission_mode`: `"bypassPermissions"`. We surface code via callbacks before the
+  tool runs; the SDK's own permission prompts would be redundant.
+
+The client is constructed lazily on first `send()` and reused across the Session's
+lifetime. `connect()` failure (e.g. `claude` CLI not authenticated) raises `LLMAuthError`
+with explicit remediation.
+
+`run_conversation` calls `client.query(new_user_message)`, iterates messages from
+`client.receive_response()`, translates each into a `ContentBlock` appended to
+`session.history`, dispatches the matching callback, and returns `TurnComplete` when a
+`ResultMessage` arrives.
+
+### Backend selection
+
+Precedence (highest first):
+
+1. Explicit kwarg: `Session(backend="openai")` or `Session(backend=MyBackend(...))`.
+2. CLI flag: `--backend openai`.
+3. Env var: `FDP_LLM_BACKEND=openai`.
+4. Config file: `~/.fdp/config.toml` → `[llm] backend = "openai"`.
+5. Default: `"amsc"` (preserves the current `fdp query` behavior for existing users).
+
+Backend names resolve through the **preset** layer first: a preset can override
+`backend` (the implementation class), `base_url`, `model`, and `api_key_file`.
+
+### Presets
+
+```python
+@dataclass(frozen=True)
+class Preset:
+    backend: str                # which Backend class to instantiate
+    model: str | None = None
+    base_url: str | None = None
+    api_key_file: str | None = None
+    api_key_env: str | None = None
+    extra: dict | None = None   # backend-specific kwargs
+```
+
+Built-in presets in core toksearch:
+- `anthropic` → `AnthropicBackend`, `model="claude-sonnet-4-6"`,
+  `api_key_env="ANTHROPIC_API_KEY"`.
+- `openai` → `OpenAIBackend`, `model="gpt-4o"`, `api_key_env="OPENAI_API_KEY"`.
+- `claude-max` → `ClaudeSDKBackend`, no key.
+
+Site presets via entry points (`toksearch.llm.presets`):
+- `amsc` → `AnthropicBackend`, `model="claude-sonnet-4-6"`,
+  `base_url="https://api.i2-core.american-science-cloud.org"`,
+  `api_key_file="~/amsc_api_key"`. Registered by `toksearch_d3d`.
+
+User presets via `~/.fdp/config.toml`:
+
+```toml
+[llm.presets.mysite]
+backend = "anthropic"
+base_url = "https://llm.mysite.gov"
+api_key_env = "MYSITE_KEY"
+model = "claude-sonnet-4-6"
+```
+
+### Entry-point discovery
+
+Three groups, all consumed at Session construction:
+
+- **`toksearch.llm.namespace`** — values are import strings resolving to a Python module
+  or object. The Session injects them into the `run_python` namespace under the entry
+  point's name. A module-level `__llm_description__` attribute, if present, is used in
+  the system-prompt catalog.
+- **`toksearch.llm.skills`** — values resolve to a `Path` (or callable returning a Path)
+  to a directory containing `SKILL.md` subdirectories. Added to the skill registry.
+- **`toksearch.llm.presets`** — values resolve to a `Preset` instance. Added to the
+  preset registry.
+
+Discovery happens once per process; results cached on the `discovery` module.
+`Session(packages=[...])` restricts the namespace + skills entry points to the named
+subset; presets are always loaded.
+
+### Configuration
+
+`~/.fdp/config.toml` (XDG-friendly fallback to `~/.config/fdp/config.toml`):
+
+```toml
+[llm]
+backend = "amsc"               # default backend / preset name
+model = "claude-sonnet-4-6"    # override preset's model
+max_iterations = 20
+
+# Optional credentials (env vars take precedence)
+anthropic_api_key = "..."
+openai_api_key = "..."
+
+[llm.presets.mysite]
+# user-defined presets, see above
+```
+
+Loaded by `toksearch.llm.config.load_config()` with env-var overlay then CLI-flag
+overlay. No secrets are committed to the repo; the file lives in the user's home.
+
+### Error handling
+
+Custom hierarchy:
+
+```
+LLMError
+├── LLMConfigError          # bad config, unknown backend, unknown model
+├── LLMAuthError            # 401/403, missing key, claude CLI not authenticated
+├── LLMBackendError         # 5xx, network failures after retries, MCP transport failure
+├── LLMRateLimitError       # 429 after honoring Retry-After up to 60s
+└── LLMUserAbort            # KeyboardInterrupt between tool calls
+```
+
+Tool exceptions are **not** errors at the Session/backend level — they're captured into
+`is_error=True` tool results and returned to the model, matching current behavior.
+
+`_ToolLoopBackend._send_request` retries 5xx and connection errors up to 3× with
+exponential backoff (1s, 2s, 4s). Auth errors and 4xx (other than 429) do not retry.
+
+REPL handles each exception class with a one-line user message; one-shot `query` exits
+non-zero with the same message on stderr.
+
+### Connectivity test
+
+`toksearch llm test [--backend NAME]` sends a one-token request and asserts a response
+is received. Cached in `~/.fdp/.last_check` per backend; `chat`/`query` runs it
+automatically once per 24h. Failures print remediation and abort.
+
+### CLI subprocess / re-exec
+
+The current `fdp query` runs the agent in a subprocess to ensure libfdpio + XRootD see
+FDP env vars at C-library load time. For `fdp chat` (long-running REPL with terminal
+control), a piped subprocess is awkward.
+
+Solution: `fdp` shims set the FDP env vars, set `FDP_LLM_ENV_READY=1`, then
+`os.execvpe(sys.executable, [sys.executable, "-m", "toksearch.llm.cli", subcommand,
+*args], os.environ)`. The new process starts fresh (C deps see env at load), keeps
+direct terminal control (no pipe), and uses `FDP_LLM_ENV_READY` to detect that env is
+already set on re-entry. `toksearch chat` invoked directly (no `fdp`) does no re-exec.
+
+## Testing
+
+Test seam: a `FakeBackend` that takes a scripted list of `AssistantTurn`s and returns
+them in order. Lets Session-level tests run without any LLM.
+
+```
+tests/
+├── test_llm_session.py          # Session behavior with FakeBackend
+├── test_llm_tools.py            # run_python, lookup_docs
+├── test_llm_discovery.py        # entry-point discovery, packages= filter
+├── test_llm_presets.py          # preset resolution, env-var precedence
+├── test_llm_backends/
+│   ├── test_anthropic.py        # request shape, response translation, caching
+│   ├── test_openai.py           # tool schema translation, tool-arg streaming
+│   └── test_claude_sdk.py       # MCP server registration, tool plumbing
+├── test_llm_cli.py              # subcommand dispatch, /commands, re-exec guard
+└── test_llm_integration.py      # @pytest.mark.integration, real API
+```
+
+Existing `test_fdp_query.py` cases continue to pass — `fdp query` behavior is preserved.
+
+## Migration plan
+
+Five sequential PRs, none blocking earlier ones from shipping:
+
+1. **`toksearch` PR 1 — library core.** Adds `toksearch/llm/` with Session, events,
+   messages, tools, prompts, errors, config, `AnthropicBackend`, `OpenAIBackend`, CLI
+   subcommands, `FakeBackend`, tests. No entry-point discovery yet — Session takes
+   explicit `packages=` and `extra_skill_dirs=`. Adds `[llm]` optional-dep extra
+   (`anthropic`, `openai`, `prompt-toolkit`). Installs `toksearch` console script.
+2. **`toksearch` PR 2 — discovery.** Adds entry-point discovery for `namespace`,
+   `skills`, and `presets`. Core registers itself as the `toksearch` namespace
+   contributor; built-in presets (`anthropic`, `openai`). `Session(packages=...)`
+   becomes an override.
+3. **`toksearch` PR 3 — Claude Agent SDK backend.** Adds `claude_sdk.py` and the
+   in-process MCP server. Adds optional dep on `claude-agent-sdk` + `mcp` (only required
+   if the user selects the `claude-max` backend; importing `toksearch.llm` without the
+   extras prints a clear hint).
+4. **`toksearch_d3d` PR 4 — contributor wiring.** Declares the three entry points
+   (`toksearch_d3d` namespace, `toksearch_d3d/skills` skill dir, `amsc` preset).
+   Replaces `toksearch_d3d/agents/claude_toksearch_agent.py` with a deprecation shim
+   that calls `toksearch.llm`. Updates `fdp.cli` to re-exec into `toksearch.llm.cli`
+   for both `chat` and `query`. Bumps `toksearch>=<release>` accordingly.
+5. **`toksearch_d3d` PR 5 — cleanup.** Removes the deprecation shim and `agents/`
+   entirely after one release.
+
+## Risks
+
+- **Dependency surface in core toksearch.** Adding `anthropic`/`openai`/`claude-agent-sdk`
+  as optional extras keeps the core install lean for users who don't want the LLM stack.
+- **Entry-point discovery cost.** ~10ms at Session init on modern Python; not a concern.
+- **Two-repo coordination.** PR ordering is strict; toksearch_d3d PR 4 cannot land until
+  toksearch PRs 1–3 are released. Standard practice.
+- **Naming collisions** between contributors are detected at Session init with a clear
+  error message.
+- **`exec()` blast radius.** Same as Claude Code's Bash tool: the agent can in principle
+  read/write any file in your filesystem and hit any network endpoint. Documented; not
+  sandboxed. Show-then-run mitigates accidental damage; `--confirm` is available for
+  high-risk sessions.
+- **Streaming complexity** (especially OpenAI tool-arg streaming). ~50 LoC of accumulator
+  logic per backend. Worth it for REPL UX; not free.
+
+## Out of scope (explicit non-features)
+
+- Auto-save and resume of session history. The Message schema is designed to be
+  serializable; future work will add `/load` and a session-store. `/save` is implemented
+  now as a forcing function for the schema.
+- Persistent namespace serialization across sessions. Many toksearch objects don't
+  pickle reliably; design will need separate thought.
+- Multimodal output in the REPL (figures inline). Future Jupyter wrapper.
+- Subagents, hooks, the broader Claude Agent SDK feature set. If a user needs them,
+  they should run `claude` directly.
+- Sandboxing of `run_python`. Same posture as Claude Code's Bash tool.
+
+## Open questions
+
+- **Slash-command syntax in the REPL.** `/reset` vs `\reset` vs `:reset`. Defaulting to
+  `/` for muscle memory with chat UIs; happy to revisit.
+- **Default `max_iterations`.** Current is 10; this design proposes 20. Conversational
+  flow tends to need more rounds than one-shot. May want to tune after first usage.
+- **Whether to keep `--api-key-file` on `fdp query`** for backward compatibility, or
+  deprecate in favor of `--backend amsc --config <file>`. Leaning toward keep-and-route
+  internally.

--- a/pixi.lock
+++ b/pixi.lock
@@ -17,6 +17,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.3-py312h5d8c7f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anthropic-0.102.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py312h4c3975b_2.conda
@@ -51,6 +54,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.3.0-hbca2aae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bottleneck-1.6.0-np2py312hfb8c2c5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
@@ -66,12 +71,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.12-py312hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
@@ -79,12 +91,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetds-1.5.17-hc9ddbf2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_17.conda
@@ -97,10 +110,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.5.0-py310hb823017_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
@@ -113,6 +128,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jiter-0.13.0-py312h0ccc70a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.13.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.0.0-pyhcf101f3_3.conda
@@ -133,6 +149,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.16-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
@@ -149,44 +166,58 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-7_h8e06fc2_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.5-default_h746c552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/ga-fdp/linux-64/libfdpio2-2.0.1-0_944c09e.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_117.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_17.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.39.0-hdb79228_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.39.0-hdbdcf42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.73.1-h3288cfb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-7_h8876d29_netlib.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.5-hf7376ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.31-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hb9b0907_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-23.0.0-h7376487_2_cuda.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.4-hd5a49e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_117.conda
@@ -195,20 +226,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-devel-2.15.3-h49c6c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.9-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py312he3d6523_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/ga-fdp/linux-64/mdsplus-xrdcl-1.0.0-py312ha0f1011_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.0-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
@@ -219,8 +258,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.16.5-py312hf79963d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/openai-2.37.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openblas-0.3.31-pthreads_h6ec200e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-25.0.1-h5755bd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.2.2-h19cb568_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
@@ -231,6 +273,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.5.1-pyhcf101f3_0.conda
@@ -248,8 +291,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-23.0.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-23.0.0-py312hfa4fb80_0_cuda.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pymssql-2.3.12-py312h8285ef7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py312h50ac2ff_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyspark-4.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_2_cpython.conda
@@ -262,6 +309,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hfb55c3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ray-core-2.53.0-py312h53ad4da_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
@@ -270,6 +319,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.6.2-he8a4886_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.0-py312h54fa4ab_1.conda
@@ -277,6 +327,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.0-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sh-2.2.2-pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -286,16 +337,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py312h4c3975b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.25.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.14-h69e2008_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
@@ -304,10 +361,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.1.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
@@ -316,6 +383,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/ga-fdp/linux-64/xrdcl-pelican-fdp-0.1.0-hc11ce1e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xrootd-5.9.2-py312h00f1e7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -324,6 +393,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: ./
   docs:
@@ -539,6 +609,52 @@ packages:
   purls: []
   size: 584660
   timestamp: 1768327524772
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+  sha256: cc9fbc50d4ee7ee04e49ee119243e6f1765750f0fd0b4d270d5ef35461b643b1
+  md5: 52be5139047efadaeeb19c6a5103f92a
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/annotated-doc?source=hash-mapping
+  size: 14222
+  timestamp: 1762868213144
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+  sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
+  md5: 2934f256a8acfe48f6ebb4fce6cde29c
+  depends:
+  - python >=3.9
+  - typing-extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/annotated-types?source=hash-mapping
+  size: 18074
+  timestamp: 1733247158254
+- conda: https://conda.anaconda.org/conda-forge/noarch/anthropic-0.102.0-pyhd8ed1ab_0.conda
+  sha256: 43f2fbcd58c58d46653346a629847c1aedf9e6c59008a2edf58b903fd06f4559
+  md5: f1c21259ecb05f231abfef2b55c6b4fd
+  depends:
+  - anyio >=3.5.0,<5
+  - cached-property
+  - distro >=1.7.0,<2
+  - docstring_parser >=0.15,<1
+  - httpx >=0.25.0,<1
+  - jiter >=0.4.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.10,<4.0.0
+  - sniffio
+  - tokenizers >=0.13.0
+  - typing-extensions >=4.7,<5
+  - typing_extensions >=4.14,<5
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/anthropic?source=hash-mapping
+  size: 306645
+  timestamp: 1778705079367
 - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
   sha256: eb0c4e2b24f1fbefaf96ce6c992c6bd64340bc3c06add4d7415ab69222b201da
   md5: 11a2b8c732d215d977998ccd69a9d5e8
@@ -1035,6 +1151,33 @@ packages:
   - pkg:pypi/bottleneck?source=hash-mapping
   size: 157720
   timestamp: 1762775764398
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
+  sha256: e511644d691f05eb12ebe1e971fd6dc3ae55a4df5c253b4e1788b789bdf2dfa6
+  md5: 8ccf913aaba749a5496c17629d859ed1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.2.0 hb03c661_1
+  - libbrotlidec 1.2.0 hb03c661_1
+  - libbrotlienc 1.2.0 hb03c661_1
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20103
+  timestamp: 1764017231353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
+  sha256: 64b137f30b83b1dd61db6c946ae7511657eead59fdf74e84ef0ded219605aa94
+  md5: af39b9a8711d4a8d437b52c1d78eb6a1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.2.0 hb03c661_1
+  - libbrotlienc 1.2.0 hb03c661_1
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 21021
+  timestamp: 1764017221344
 - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py310hba01987_1.conda
   sha256: f036fe554d902549f86689a9650a0996901d5c9242b0a1e3fbfe6dbccd2ae011
   md5: 393fca4557fbd2c4d995dcb89f569048
@@ -1252,6 +1395,22 @@ packages:
   purls: []
   size: 31646
   timestamp: 1770252240343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
+  sha256: 62447faf7e8eb691e407688c0b4b7c230de40d5ecf95bf301111b4d05c5be473
+  md5: 43c2bc96af3ae5ed9e8a10ded942aa50
+  depends:
+  - numpy >=1.25
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/contourpy?source=hash-mapping
+  size: 320386
+  timestamp: 1769155979897
 - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.12-py312hd8ed1ab_2.conda
   noarch: generic
   sha256: ccb90d95bac9f1f4f6629a4addb44d36433e4ad1fe4ac87a864f90ff305dbf6d
@@ -1263,6 +1422,48 @@ packages:
   purls: []
   size: 46644
   timestamp: 1769471040321
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+  sha256: bb47aec5338695ff8efbddbc669064a3b10fe34ad881fb8ad5d64fbfa6910ed1
+  md5: 4c2a8fef270f6c69591889b93f9f55c1
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/cycler?source=hash-mapping
+  size: 14778
+  timestamp: 1764466758386
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+  sha256: 7684da83306bb69686c0506fb09aa7074e1a55ade50c3a879e4e5df6eebb1009
+  md5: af491aae930edc096b58466c51c4126c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=13
+  - libntlm >=1.8,<2.0a0
+  - libstdcxx >=13
+  - libxcrypt >=4.4.36
+  - openssl >=3.5.5,<4.0a0
+  license: BSD-3-Clause-Attribution
+  license_family: BSD
+  purls: []
+  size: 210103
+  timestamp: 1771943128249
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+  sha256: 8bb557af1b2b7983cf56292336a1a1853f26555d9c6cecf1e5b2b96838c9da87
+  md5: ce96f2f470d39bd96ce03945af92e280
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - libglib >=2.86.2,<3.0a0
+  - libexpat >=2.7.3,<3.0a0
+  license: AFL-2.1 OR GPL-2.0-or-later
+  purls: []
+  size: 447649
+  timestamp: 1764536047944
 - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
   sha256: f20121b67149ff80bf951ccae7442756586d8789204cd08ade59397b22bfd098
   md5: ee1b48795ceb07311dd3e665dd4f5f33
@@ -1312,6 +1513,28 @@ packages:
   - pkg:pypi/deprecated?source=compressed-mapping
   size: 15896
   timestamp: 1768934186726
+- conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+  sha256: 5603c7d0321963bb9b4030eadabc3fd7ca6103a38475b4e0ed13ed6d97c86f4e
+  md5: 0a2014fd9860f8b1eaa0b1f3d3771a08
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/distro?source=hash-mapping
+  size: 41773
+  timestamp: 1734729953882
+- conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.18.0-pyhd8ed1ab_0.conda
+  sha256: 0994f88d4257dbfcbf67f10c886d84a531e13e6d36dee3a77ddcca6ffc37d7ca
+  md5: b0c7c29a60c82d57c5b4c4c38f0642c8
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/docstring-parser?source=compressed-mapping
+  size: 23903
+  timestamp: 1778609891474
 - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
   sha256: d58e97d418f71703e822c422af5b9c431e3621a0ecdc8b0334c1ca33e076dfe7
   md5: c56a7fa5597ad78b62e1f5d21f7f8b8f
@@ -1324,6 +1547,18 @@ packages:
   - pkg:pypi/donfig?source=hash-mapping
   size: 22491
   timestamp: 1734368817583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+  sha256: 40cdd1b048444d3235069d75f9c8e1f286db567f6278a93b4f024e5642cfaecc
+  md5: dbe3ec0f120af456b3477743ffd99b74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 71809
+  timestamp: 1765193127016
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
   sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
   md5: 8e662bd460bda79b1ea39194e3c4c9ab
@@ -1388,21 +1623,22 @@ packages:
   purls: []
   size: 1620504
   timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
-  sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
-  md5: 8f5b0b297b59e1ac160ad4beec99dbee
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
+  sha256: aa4a44dba97151221100a637c7f4bde619567afade9c0265f8e1c8eed8d7bd8c
+  md5: 867127763fbe935bab59815b6e0b7b5c
   depends:
   - __glibc >=2.17,<3.0.a0
-  - freetype >=2.12.1,<3.0a0
-  - libexpat >=2.6.3,<3.0a0
-  - libgcc >=13
-  - libuuid >=2.38.1,<3.0a0
+  - libexpat >=2.7.4,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libuuid >=2.41.3,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 265599
-  timestamp: 1730283881107
+  size: 270705
+  timestamp: 1771382710863
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
   md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -1426,6 +1662,23 @@ packages:
   purls: []
   size: 4059
   timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py312h8a5da7c_0.conda
+  sha256: d235ae7075642044ceb3d922ef2a710a82665755ac9bbb7e8dad7daa72bc6d87
+  md5: 294fb524171e2a2748cb7fe708aba826
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=14
+  - munkres
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/fonttools?source=compressed-mapping
+  size: 3007892
+  timestamp: 1778770568019
 - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
   sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
   md5: d3549fd50d450b6d9e7dddff25dd2110
@@ -1455,16 +1708,16 @@ packages:
   purls: []
   size: 3139099
   timestamp: 1776534845420
-- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
-  sha256: bf8e4dffe46f7d25dc06f31038cacb01672c47b9f45201f065b0f4d00ab0a83e
-  md5: 4afc585cd97ba8a23809406cd8a9eda8
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+  sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
+  md5: 8462b5322567212beeb025f3519fb3e2
   depends:
-  - libfreetype 2.14.1 ha770c72_0
-  - libfreetype6 2.14.1 h73754d4_0
+  - libfreetype 2.14.3 ha770c72_0
+  - libfreetype6 2.14.3 h73754d4_0
   license: GPL-2.0-only OR FTL
   purls: []
-  size: 173114
-  timestamp: 1757945422243
+  size: 173839
+  timestamp: 1774298173462
 - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
   sha256: f4e0e6cd241bc24afb2d6d08e5d2ba170fad2475e522bdf297b7271bba268be6
   md5: 63e20cf7b7460019b423fc06abb96c60
@@ -1639,26 +1892,45 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 95967
   timestamp: 1756364871835
-- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
-  sha256: 92015faf283f9c0a8109e2761042cd47ae7a4505e24af42a53bc3767cb249912
-  md5: d170a70fc1d5c605fcebdf16851bd54a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.0-h6083320_0.conda
+  sha256: 232c95b56d16d33d8256026a3b1ad34f7f9a75c179d388854be0fd624ddba9e3
+  md5: e194f6a2f498f0c7b1e6498bd0b12645
   depends:
   - __glibc >=2.17,<3.0.a0
   - cairo >=1.18.4,<2.0a0
   - graphite2 >=1.3.14,<2.0a0
-  - icu >=78.2,<79.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
+  - icu >=78.3,<79.0a0
+  - libexpat >=2.7.5,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
   - libgcc >=14
-  - libglib >=2.86.3,<3.0a0
+  - libglib >=2.86.4,<3.0a0
   - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 2035859
-  timestamp: 1769445400168
+  size: 2333599
+  timestamp: 1776778392713
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.5.0-py310hb823017_0.conda
+  noarch: python
+  sha256: b0f16f161bae4bdef033d56678a9eda4d07f5aa300db19d58e5e73acb3028b3d
+  md5: 0afe6c4582ddd164317cc4acf7f47c54
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  - openssl >=3.5.6,<4.0a0
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/hf-xet?source=hash-mapping
+  size: 3515963
+  timestamp: 1778054285216
 - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
   sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
   md5: 0a802cb9888dd14eeefc611f05c40b6e
@@ -1702,6 +1974,28 @@ packages:
   - pkg:pypi/httpx?source=hash-mapping
   size: 63082
   timestamp: 1733663449209
+- conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.15.0-pyhd8ed1ab_0.conda
+  sha256: 71d200fe916b614061dd987cc94c2c373541210564cd74233e0cebf4114b8ac1
+  md5: b00e94a6d39ef6b787215a824aa3bedb
+  depends:
+  - filelock >=3.10.0
+  - fsspec >=2023.5.0
+  - hf-xet >=1.4.3,<2.0.0
+  - httpx >=0.23.0,<1
+  - packaging >=20.9
+  - python >=3.10
+  - pyyaml >=5.1
+  - requests
+  - tqdm >=4.42.1
+  - typer >=0.20.0
+  - typing-extensions >=3.7.4.3
+  - typing_extensions >=4.1.0
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/huggingface-hub?source=compressed-mapping
+  size: 418023
+  timestamp: 1778854456651
 - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
   sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
   md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
@@ -1899,6 +2193,22 @@ packages:
   - pkg:pypi/jinja2?source=compressed-mapping
   size: 120685
   timestamp: 1764517220861
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jiter-0.13.0-py312h0ccc70a_0.conda
+  sha256: 82c24124cecbd997550b7e5d9598d43e9c86d7e4266b11c8a98e05c64ee05f89
+  md5: 1bc837710f8bba29c214d0852ee81fdc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/jiter?source=hash-mapping
+  size: 308006
+  timestamp: 1770047930797
 - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
   sha256: 301539229d7be6420c084490b8145583291123f0ce6b92f56be5948a2c83a379
   md5: 615de2a4d97af50c350e5cf160149e77
@@ -2237,6 +2547,21 @@ packages:
   purls: []
   size: 134088
   timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
+  sha256: eec7654c2d68f06590862c6e845cc70987b6d6559222b6f0e619dea4268f5dd5
+  md5: cd74a9525dc74bbbf93cf8aa2fa9eb5b
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/kiwisolver?source=hash-mapping
+  size: 77120
+  timestamp: 1773067050308
 - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
   md5: 3f43953b7d3fb3aaa1d0d0723d91e368
@@ -2510,6 +2835,19 @@ packages:
   purls: []
   size: 50122
   timestamp: 1763440541127
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.5-default_h746c552_1.conda
+  sha256: 7f479f796ba05f22324fb484f53da6f9948395499d7558cc4ff5ec24e91448b1
+  md5: af8c5fb71cb5aa4861365af2784fc9ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libllvm22 >=22.1.5,<22.2.0a0
+  - libstdcxx >=14
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 12827971
+  timestamp: 1778479852868
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
   sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
   md5: c965a5aa0d5c1c37ffc62dff36e28400
@@ -2563,6 +2901,18 @@ packages:
   purls: []
   size: 73490
   timestamp: 1761979956660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
+  sha256: 7d3187c11b7ae66c5595a8afd5a7ce352a490527fdf6614cab129bc7f2c16ba3
+  md5: d8d16b9b32a3c5df7e5b3350e2cbe058
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpciaccess >=0.19,<0.20.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 311505
+  timestamp: 1778975798004
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -2576,6 +2926,28 @@ packages:
   purls: []
   size: 134676
   timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+  sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
+  md5: c151d5eb730e9b7480e6d48c0fc44048
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 44840
+  timestamp: 1731330973553
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_2.conda
+  sha256: f6e7095260305dc05238062142fb8db4b940346329b5b54894a90610afa6749f
+  md5: b513eb83b3137eca1192c34bf4f013a7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libegl 1.7.0 ha4b6fd6_2
+  - libgl-devel 1.7.0 ha4b6fd6_2
+  - xorg-libx11
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 30380
+  timestamp: 1731331017249
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
   sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   md5: 172bf1cd1ff8629f2b1179945ed45055
@@ -2610,6 +2982,19 @@ packages:
   purls: []
   size: 76643
   timestamp: 1763549731408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
+  sha256: ea33c40977ea7a2c3658c522230058395bc2ee0d89d99f0711390b6a1ee80d12
+  md5: a3b390520c563d78cc58974de95a03e5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.0.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 77241
+  timestamp: 1777846112704
 - conda: https://conda.anaconda.org/ga-fdp/linux-64/libfdpio2-2.0.1-0_944c09e.conda
   sha256: e6706d6b2b5d0f1c0323b7d539b1f58a07a037416784e96bedcc7a61d5ffb649
   md5: 4cb581a4f97be9b1451e11a81859118e
@@ -2635,29 +3020,29 @@ packages:
   purls: []
   size: 58592
   timestamp: 1769456073053
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
-  sha256: 4641d37faeb97cf8a121efafd6afd040904d4bca8c46798122f417c31d5dfbec
-  md5: f4084e4e6577797150f9b04a4560ceb0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+  sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
+  md5: e289f3d17880e44b633ba911d57a321b
   depends:
-  - libfreetype6 >=2.14.1
+  - libfreetype6 >=2.14.3
   license: GPL-2.0-only OR FTL
   purls: []
-  size: 7664
-  timestamp: 1757945417134
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
-  sha256: 4a7af818a3179fafb6c91111752954e29d3a2a950259c14a2fc7ba40a8b03652
-  md5: 8e7251989bca326a28f4a5ffbd74557a
+  size: 8049
+  timestamp: 1774298163029
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+  sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
+  md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libpng >=1.6.50,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libpng >=1.6.55,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
   constrains:
-  - freetype >=2.14.1
+  - freetype >=2.14.3
   license: GPL-2.0-only OR FTL
   purls: []
-  size: 386739
-  timestamp: 1757945416744
+  size: 384575
+  timestamp: 1774298162622
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
   sha256: 43860222cf3abf04ded0cf24541a105aa388e0e1d4d6ca46258e186d4e87ae3e
   md5: 3c281169ea25b987311400d7a7e28445
@@ -2717,22 +3102,76 @@ packages:
   purls: []
   size: 2480824
   timestamp: 1770252563579
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_0.conda
-  sha256: 82d6c2ee9f548c84220fb30fb1b231c64a53561d6e485447394f0a0eeeffe0e6
-  md5: 034bea55a4feef51c98e8449938e9cee
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+  sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
+  md5: 928b8be80851f5d8ffb016f9c81dae7a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libffi >=3.5.2,<3.6.0a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  - libglx 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 134712
+  timestamp: 1731330998354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_2.conda
+  sha256: e281356c0975751f478c53e14f3efea6cd1e23c3069406d10708d6c409525260
+  md5: 53e7cbb2beb03d69a478631e23e340e9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgl 1.7.0 ha4b6fd6_2
+  - libglx-devel 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 113911
+  timestamp: 1731331012126
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
+  sha256: 33eb5d5310a5c2c0a4707a0afa644801c2e08c8f70c45e1f62f354116dfe0970
+  md5: 17d484ab9c8179c6a6e5b7dbb5065afc
+  depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - pcre2 >=10.47,<10.48.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libiconv >=1.18,<2.0a0
   constrains:
-  - glib 2.86.3 *_0
+  - glib >2.66
   license: LGPL-2.1-or-later
   purls: []
-  size: 3946542
-  timestamp: 1765221858705
+  size: 4754097
+  timestamp: 1778508800134
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+  sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
+  md5: 434ca7e50e40f4918ab701e3facd59a0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 132463
+  timestamp: 1731330968309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+  sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
+  md5: c8013e438185f33b13814c5c488acd5c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 75504
+  timestamp: 1731330988898
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
+  sha256: 0a930e0148ab6e61089bbcdba25a2e17ee383e7de82e7af10cc5c12c82c580f3
+  md5: 27ac5ae872a21375d980bd4a6f99edf3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglx 1.7.0 ha4b6fd6_2
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-xorgproto
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 26388
+  timestamp: 1731331003255
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
   sha256: b961b5dd9761907a7179678b58a69bb4fc16b940eb477f635aea3aec0a3f17a6
   md5: 51b78c6a757575c0d12f4401ffc67029
@@ -2813,9 +3252,9 @@ packages:
   purls: []
   size: 790176
   timestamp: 1754908768807
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-  sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
-  md5: 8397539e3a0bbd1695584fb4f927485a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+  sha256: 10056646c28115b174de81a44e23e3a0a3b95b5347d2e6c45cc6d49d35294256
+  md5: 6178c6f2fb254558238ef4e6c56fb782
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -2823,8 +3262,8 @@ packages:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
   purls: []
-  size: 633710
-  timestamp: 1762094827865
+  size: 633831
+  timestamp: 1775962768273
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-7_h8876d29_netlib.conda
   build_number: 7
   sha256: 4de5b6aef4b2d42b4f71c6a3673118f99e323aed2ba2a66a3ed435b574010b1e
@@ -2843,6 +3282,22 @@ packages:
   purls: []
   size: 2901209
   timestamp: 1763440547062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.5-hf7376ad_1.conda
+  sha256: 094198dc5c7fbd85e3719d192d5b77c3f0dccf657dfd9ba0c79e391f11f7ace2
+  md5: 6adc0202fa7fcf0a5fce8c31ef2ed866
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 44241856
+  timestamp: 1778417624650
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
   sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
   md5: c7c83eecbb72d88b940c249af56c8b17
@@ -2895,6 +3350,16 @@ packages:
   purls: []
   size: 33731
   timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+  sha256: 3b3f19ced060013c2dd99d9d46403be6d319d4601814c772a3472fe2955612b0
+  md5: 7c7927b404672409d9917d49bff5f2d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 33418
+  timestamp: 1734670021371
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.31-pthreads_h94d23a6_0.conda
   sha256: 166217a610185f9e22b3f4e0f80174d81240d6cfac8026b2f0158ff4f32b289a
   md5: 97ad7535866bf922275706c519b5c21d
@@ -2910,6 +3375,16 @@ packages:
   purls: []
   size: 5937816
   timestamp: 1768555660623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
+  sha256: 215086c108d80349e96051ad14131b751d17af3ed2cb5a34edd62fa89bfe8ead
+  md5: 7df50d44d4a14d6c31a2c54f2cd92157
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 50757
+  timestamp: 1731330993524
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hb9b0907_1.conda
   sha256: ba9b09066f9abae9b4c98ffedef444bbbf4c068a094f6c77d70ef6f006574563
   md5: 1c0320794855f457dea27d35c4c71e23
@@ -2954,17 +3429,42 @@ packages:
   purls: []
   size: 1391834
   timestamp: 1770440597070
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
-  sha256: 36ade759122cdf0f16e2a2562a19746d96cf9c863ffaa812f2f5071ebbe9c03c
-  md5: 5f13ffc7d30ffec87864e678df9957b4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
+  sha256: f41721636a7c2e51bc2c642e1127955ab9c81145470714fdaac44d4d09e4af41
+  md5: 33082e13b4769b48cfeb648e15bfe3fc
   depends:
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libzlib >=1.3.1,<2.0a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 29147
+  timestamp: 1773533027610
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+  sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
+  md5: eba48a68a1a2b9d3c0d9511548db85db
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 317669
-  timestamp: 1770691470744
+  size: 317729
+  timestamp: 1776315175087
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.4-hd5a49e9_0.conda
+  sha256: 076742d4a9fa88711c5fc6726b967e6a03b5060e669aa03288c684a7ae03583b
+  md5: 2772b7ab7bc43f24e9585a714761a255
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - openldap >=2.6.13,<2.7.0a0
+  - openssl >=3.5.6,<4.0a0
+  license: PostgreSQL
+  purls: []
+  size: 2754709
+  timestamp: 1778786234149
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
   sha256: 0ef142ac31e6fd59b4af89ac800acb6deb3fbd9cc4ccf070c03cc2c784dc7296
   md5: 07479fc04ba3ddd5d9f760ef1635cfa7
@@ -3038,6 +3538,17 @@ packages:
   purls: []
   size: 942808
   timestamp: 1768147973361
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+  sha256: 54cdcd3214313b62c2a8ee277e6f42150d9b748264c1b70d958bf735e420ef8d
+  md5: 7dc38adcbf71e6b38748e919e16e0dce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  size: 954962
+  timestamp: 1777986471789
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -3139,6 +3650,22 @@ packages:
   purls: []
   size: 40311
   timestamp: 1766271528534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
+  sha256: a68280d57dfd29e3d53400409a39d67c4b9515097eba733aa6fe00c880620e2b
+  md5: 31ad065eda3c2d88f8215b1289df9c89
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  constrains:
+  - libvulkan-headers 1.4.341.0.*
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 199795
+  timestamp: 1770077125520
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
   sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
   md5: aea31d2e5b1091feca96fcfe945c3cf9
@@ -3175,6 +3702,23 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
+  sha256: d2195b5fbcb0af1ff7b345efdf89290c279b8d1d74f325ae0ac98148c375863c
+  md5: 2bca1fbb221d9c3c8e3a155784bbc2e9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - xkeyboard-config
+  - xorg-libxau >=1.0.12,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  purls: []
+  size: 837922
+  timestamp: 1764794163823
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
   sha256: 3bc5551720c58591f6ea1146f7d1539c734ed1c40e7b9f5cb8cb7e900c509aba
   md5: 995d8c8bad2a3cc8db14675a153dec2b
@@ -3225,6 +3769,19 @@ packages:
   purls: []
   size: 80529
   timestamp: 1776376762779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
+  sha256: 0694760a3e62bdc659d90a14ae9c6e132b525a7900e59785b18a08bb52a5d7e5
+  md5: 87e6096ec6d542d1c1f8b33245fe8300
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 245434
+  timestamp: 1757963724977
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
@@ -3282,6 +3839,18 @@ packages:
   license_family: MIT
   size: 64736
   timestamp: 1754951288511
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+  sha256: 0c4c35376fe920714390d46e4b8d31c876d65f18e1655899e0763ec25f2a902f
+  md5: 6d03368f2b2b0a5fb6839df53b2eb5e0
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/markdown-it-py?source=hash-mapping
+  size: 69017
+  timestamp: 1778169663339
 - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py310h3406613_0.conda
   sha256: b3894b37cab530d1adab5b9ce39a1b9f28040403cc0042b77e04a2f227a447de
   md5: 8854df4fb4e37cc3ea0a024e48c9c180
@@ -3312,6 +3881,50 @@ packages:
   - pkg:pypi/markupsafe?source=hash-mapping
   size: 25321
   timestamp: 1759055268795
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.9-py312h7900ff3_0.conda
+  sha256: cdd59bb1a52b09979f11c68909d53120b2e749edd1992853a74e1604db19c8b0
+  md5: 579c6a324b197594fabc9240bddf2d8b
+  depends:
+  - matplotlib-base >=3.10.9,<3.10.10.0a0
+  - pyside6 >=6.7.2
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - tornado >=5
+  license: PSF-2.0
+  license_family: PSF
+  purls: []
+  size: 17831
+  timestamp: 1777000588302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py312he3d6523_0.conda
+  sha256: c7e133837376e53e6a52719c205a3067c42f05769bc3e8307417f8d817dfc63e
+  md5: 7d499b5b6d150f133800dc3a582771c7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.23
+  - numpy >=1.23,<3
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.12,<3.13.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.12.* *_cp312
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/matplotlib?source=hash-mapping
+  size: 8336056
+  timestamp: 1777000573501
 - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
   sha256: 9d690334de0cd1d22c51bc28420663f4277cfa60d34fa5cad1ce284a13f1d603
   md5: 00e120ce3e40bad7bfc78861ce3c4a25
@@ -3368,6 +3981,8 @@ packages:
   - python >=3.9
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/mdurl?source=hash-mapping
   size: 14465
   timestamp: 1733255681319
 - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
@@ -3551,6 +4166,17 @@ packages:
   - pkg:pypi/multidict?source=compressed-mapping
   size: 99537
   timestamp: 1765460650128
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+  sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
+  md5: 37293a85a0f4f77bbd9cf7aaefc62609
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/munkres?source=hash-mapping
+  size: 15851
+  timestamp: 1749895533014
 - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
   sha256: 1b66960ee06874ddceeebe375d5f17fb5f393d025a09e15b830ad0c4fffb585b
   md5: 00f5b8dafa842e0c27c1cd7296aa4875
@@ -3731,6 +4357,26 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 7484186
   timestamp: 1707225809722
+- conda: https://conda.anaconda.org/conda-forge/noarch/openai-2.37.0-pyhd8ed1ab_0.conda
+  sha256: 39ef64c3df69f9310d0edd74a6509465b032a7bbdf3e85550bd91d23d363179f
+  md5: 0f745932682e8b942a0f396661610a65
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.10
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  - typing_extensions >=4.14,<5
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/openai?source=compressed-mapping
+  size: 464670
+  timestamp: 1778891909413
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openblas-0.3.31-pthreads_h6ec200e_0.conda
   sha256: 030219c939832ffc6092ca2a83f2182ee26adf66c0089c9bceb34484eeb887a0
   md5: 5d4794b11a5af3c1e7f990026d08a9cf
@@ -3772,6 +4418,36 @@ packages:
   purls: []
   size: 117033638
   timestamp: 1762057253080
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+  sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
+  md5: 11b3379b191f63139e29c0d19dee24cd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpng >=1.6.50,<1.7.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.1,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 355400
+  timestamp: 1758489294972
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+  sha256: 21c4f6c7f41dc9bec2ea2f9c80440d9a4d45a6f2ac13243e658f10dcf1044146
+  md5: 680608784722880fbfe1745067570b00
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cyrus-sasl >=2.1.28,<3.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.6,<4.0a0
+  license: OLDAP-2.8
+  license_family: BSD
+  purls: []
+  size: 786149
+  timestamp: 1775741359582
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
   sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
   md5: f61eb8cd60ff9057122a3d338b99c00f
@@ -3966,6 +4642,29 @@ packages:
   - pkg:pypi/pexpect?source=hash-mapping
   size: 53561
   timestamp: 1733302019362
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
+  sha256: fa291f8915114733dc1df9f1627b8c63c517217c1eee1a6ede2ceb5e368cf27a
+  md5: 9e5609720e31213d4f39afe377f6217e
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - lcms2 >=2.18,<3.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - openjpeg >=2.5.4,<3.0a0
+  - python_abi 3.12.* *_cp312
+  - tk >=8.6.13,<8.7.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - zlib-ng >=2.3.3,<2.4.0a0
+  license: HPND
+  purls:
+  - pkg:pypi/pillow?source=hash-mapping
+  size: 1039561
+  timestamp: 1775060059882
 - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
   sha256: 8e1497814a9997654ed7990a79c054ea5a42545679407acbc6f7e809c73c9120
   md5: 67bdec43082fd8a9cffb9484420b39a2
@@ -4204,6 +4903,39 @@ packages:
   - pkg:pypi/pycparser?source=hash-mapping
   size: 110100
   timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
+  sha256: 69700e31165df070e9716315e042196aa92525dae5deb5107785847ab9f4189f
+  md5: 729843edafc0899b3348bd3f19525b9d
+  depends:
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  - python >=3.10
+  - annotated-types >=0.6.0
+  - pydantic-core ==2.46.4
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic?source=hash-mapping
+  size: 346511
+  timestamp: 1778103405862
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py312h868fb18_0.conda
+  sha256: b8260660d064fb947f4b573ec4a782696bc8b19042452eaa4e9bb1152b540555
+  md5: dfb9a57535eb8c35c6744da7043063f0
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1895409
+  timestamp: 1778084226169
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -4250,8 +4982,35 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyparsing?source=hash-mapping
   size: 110893
   timestamp: 1769003998136
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py312h50ac2ff_1.conda
+  sha256: 6f9e4fd9f6aa1d82a524384399c956c0c79c6c5df5ae42e241eb59f42c11ffbf
+  md5: 90f891bc96f673acbff89f6f405aef10
+  depends:
+  - python
+  - qt6-main 6.11.1.*
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - libopengl >=1.7.0,<2.0a0
+  - libclang13 >=22.1.5
+  - libxslt >=1.1.43,<2.0a0
+  - qt6-main >=6.11.1,<6.12.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libgl >=1.7.0,<2.0a0
+  - python_abi 3.12.* *_cp312
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls:
+  - pkg:pypi/pyside6?source=compressed-mapping
+  size: 13797566
+  timestamp: 1778933891067
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac
@@ -4494,6 +5253,90 @@ packages:
   - pkg:pypi/pyzmq?source=hash-mapping
   size: 212218
   timestamp: 1757387023399
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  purls: []
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_0.conda
+  sha256: 787d9a8eb7bb993e4a543901b8edade35c1c8e75d67cadb65c56a8f9c38119a5
+  md5: cdae26862f9e4c674b8443fd267f2401
+  depends:
+  - libxcb
+  - xcb-util
+  - xcb-util-wm
+  - xcb-util-keysyms
+  - xcb-util-image
+  - xcb-util-renderutil
+  - xcb-util-cursor
+  - libgl-devel
+  - libegl-devel
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - alsa-lib >=1.2.15.3,<1.3.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - double-conversion >=3.4.0,<3.5.0a0
+  - dbus >=1.16.2,<2.0a0
+  - libglib >=2.88.1,<3.0a0
+  - libsqlite >=3.53.1,<4.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - harfbuzz >=14.2.0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - xorg-libxcomposite >=0.4.7,<1.0a0
+  - openssl >=3.5.6,<4.0a0
+  - xcb-util-cursor >=0.1.6,<0.2.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - wayland >=1.25.0,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libpq >=18.3,<19.0a0
+  - libegl >=1.7.0,<2.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - libxkbcommon >=1.13.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - fontconfig >=2.17.1,<3.0a0
+  - fonts-conda-ecosystem
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libcups >=2.3.3,<2.4.0a0
+  - libgl >=1.7.0,<2.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  constrains:
+  - qt ==6.11.1
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 60185269
+  timestamp: 1778597122245
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ray-core-2.53.0-py312h53ad4da_0.conda
   sha256: 2f7b56427fd3d474bf646f5cb34dd9ef0540eb557e5b0bbe32682cb7ac4ab68b
   md5: 379be3b1dd3c6e0778674485c870b89d
@@ -4624,6 +5467,21 @@ packages:
   - pkg:pypi/rfc3987-syntax?source=hash-mapping
   size: 22913
   timestamp: 1752876729969
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+  sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
+  md5: 0242025a3c804966bf71aa04eee82f66
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.10
+  - typing_extensions >=4.0.0,<5.0.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/rich?source=hash-mapping
+  size: 208577
+  timestamp: 1775991661559
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py310hd8f68c5_0.conda
   sha256: ac1132a9344c77e19bbbdb966668cf73a861ceec7b075858a52c8e961fb8ea9d
   md5: 61ff3f8e00c63bb66903636d0197e962
@@ -4741,6 +5599,17 @@ packages:
   - pkg:pypi/sh?source=hash-mapping
   size: 40408
   timestamp: 1740612044934
+- conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+  sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
+  md5: 83ea3a2ddb7a75c1b09cea582aa4f106
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/shellingham?source=hash-mapping
+  size: 15018
+  timestamp: 1762858315311
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -4855,10 +5724,33 @@ packages:
   purls: []
   size: 3301196
   timestamp: 1769460227866
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+  sha256: ee27a9f82c0c6f91d75deed478516307148cd18e2d7916abce3e0fefba0b5f62
+  md5: f9ee564f977ae6e533537a3f148db136
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - huggingface_hub >=0.16.4,<2.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.4,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/tokenizers?source=hash-mapping
+  size: 2465644
+  timestamp: 1764695075374
 - pypi: ./
   name: toksearch
-  version: 2.5.1+1.gcf1867d.dirty
-  sha256: 9b9da588ead7e6dbfb494663eb7a3054851b401ad10426565f23bdf305694e0f
+  version: 2.6.0+19.gd483cca.dirty
+  sha256: 5ce1aefc2a3f59c376462e700864a2ac839c221d9d7199a3eb016109899ca32b
+  requires_dist:
+  - anthropic>=0.34 ; extra == 'llm'
+  - openai>=1.50 ; extra == 'llm'
+  - matplotlib ; extra == 'llm'
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
   sha256: 62940c563de45790ba0f076b9f2085a842a65662268b02dd136a8e9b1eaf47a8
   md5: 72e780e9aa2d0a3295f59b1874e3768b
@@ -4897,6 +5789,18 @@ packages:
   - pkg:pypi/tornado?source=compressed-mapping
   size: 850918
   timestamp: 1765458857375
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
+  sha256: 9ef8e47cf00e4d6dcc114eb32a1504cc18206300572ef14d76634ba29dfe1eb6
+  md5: e5ce43272193b38c2e9037446c1d9206
+  depends:
+  - python >=3.10
+  - __unix
+  - python
+  license: MPL-2.0 and MIT
+  purls:
+  - pkg:pypi/tqdm?source=hash-mapping
+  size: 94132
+  timestamp: 1770153424136
 - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   md5: 019a7385be9af33791c989871317e1ed
@@ -4908,6 +5812,22 @@ packages:
   - pkg:pypi/traitlets?source=hash-mapping
   size: 110051
   timestamp: 1733367480074
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.25.1-pyhcf101f3_0.conda
+  sha256: 18fc3a27bc995318d09142fe16d01ea454e76f377bf8f68db03b8b18f11085ed
+  md5: ef114c2eb2ff19f6bf616c81f4710841
+  depends:
+  - annotated-doc >=0.0.2
+  - click >=8.2.1
+  - python >=3.10
+  - rich >=13.8.0
+  - shellingham >=1.3.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typer?source=hash-mapping
+  size: 118013
+  timestamp: 1777583624586
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
   sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
   md5: edd329d7d3a4ab45dcf905899a7a6115
@@ -4918,6 +5838,19 @@ packages:
   purls: []
   size: 91383
   timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
+  sha256: 8b90d2f19f9458b8c58a55e1fcdc1d90c1603a847a47654d8a454549413ba60a
+  md5: 53f5409c5cfd6c5a66417d68e3f0a864
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.12.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typing-inspection?source=hash-mapping
+  size: 20935
+  timestamp: 1777105465795
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
   md5: 0caa1af407ecff61170c9437a808404d
@@ -4948,6 +5881,20 @@ packages:
   purls: []
   size: 119135
   timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
+  sha256: 895bbfe9ee25c98c922799de901387d842d7c01cae45c346879865c6a907f229
+  md5: 0b6c506ec1f272b685240e70a29261b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/unicodedata2?source=hash-mapping
+  size: 410641
+  timestamp: 1770909099497
 - conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.14-h69e2008_0.conda
   sha256: dd5fe5cdd5538e253116b67323ce3024dd42a5b0f161b5201380ed1736abd334
   md5: c6c242d6c61f6fc3ee50f64c4771d8d7
@@ -5008,6 +5955,20 @@ packages:
   license_family: APACHE
   size: 115863
   timestamp: 1763021771394
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
+  sha256: ea374d57a8fcda281a0a89af0ee49a2c2e99cc4ac97cf2e2db7064e74e764bdb
+  md5: 996583ea9c796e5b915f7d7580b51ea6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 334139
+  timestamp: 1773959575393
 - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
   sha256: e298b508b2473c4227206800dfb14c39e4b14fd79d4636132e9e1e4244cdf4aa
   md5: c3197f8c0d5b955c904616b716aca093
@@ -5127,6 +6088,90 @@ packages:
   - pkg:pypi/xarray?source=compressed-mapping
   size: 1010206
   timestamp: 1769665430320
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+  sha256: ad8cab7e07e2af268449c2ce855cbb51f43f4664936eff679b1f3862e6e4b01d
+  md5: fdc27cb255a7a2cc73b7919a968b48f0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20772
+  timestamp: 1750436796633
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+  sha256: c2be9cae786fdb2df7c2387d2db31b285cf90ab3bfabda8fa75a596c3d20fc67
+  md5: 4d1fc190b99912ed557a8236e958c559
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.13
+  - libxcb >=1.17.0,<2.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20829
+  timestamp: 1763366954390
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+  sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
+  md5: a0901183f08b6c7107aab109733a3c91
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 24551
+  timestamp: 1718880534789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+  sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
+  md5: ad748ccca349aec3e91743e08b5e2b50
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 14314
+  timestamp: 1718846569232
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+  sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
+  md5: 0e0cbe0564d03a99afd5fd7b362feecd
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 16978
+  timestamp: 1718848865819
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+  sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
+  md5: 608e0ef8256b81d04456e8d211eee3e8
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 51689
+  timestamp: 1718844051451
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
+  sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
+  md5: b56e0c8432b56decafae7e78c5f29ba5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 399291
+  timestamp: 1772021302485
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   md5: fb901ff28063514abb6046c9ec2c4a45
@@ -5174,6 +6219,47 @@ packages:
   purls: []
   size: 15321
   timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+  sha256: 048c103000af9541c919deef03ae7c5e9c570ffb4024b42ecb58dbde402e373a
+  md5: f2ba4192d38b6cef2bb2c25029071d90
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 14415
+  timestamp: 1770044404696
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+  sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
+  md5: 2ccd714aa2242315acaf0a67faea780b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 32533
+  timestamp: 1730908305254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+  sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
+  md5: b5fcc7172d22516e1f965490e65e33a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 13217
+  timestamp: 1727891438799
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
   sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
   md5: 1dafce8548e38671bea82e3f5c6ce22f
@@ -5277,6 +6363,30 @@ packages:
   purls: []
   size: 32808
   timestamp: 1727964811275
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+  sha256: 64db17baaf36fa03ed8fae105e2e671a7383e22df4077486646f7dbf12842c9f
+  md5: 665d152b9c6e78da404086088077c844
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 18701
+  timestamp: 1769434732453
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
+  sha256: 7a8c64938428c2bfd016359f9cb3c44f94acc256c6167dbdade9f2a1f5ca7a36
+  md5: aa8d21be4b461ce612d8f5fb791decae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 570010
+  timestamp: 1766154256151
 - conda: https://conda.anaconda.org/ga-fdp/linux-64/xrdcl-pelican-fdp-0.1.0-hc11ce1e_1.tar.bz2
   sha256: 5a988c032c397d1251008517567fbde8c596608c16b943d3ef876bbdf76ed673
   md5: d29bf6c68e9f2de2d985cc8ff75debbe
@@ -5422,6 +6532,18 @@ packages:
   purls: []
   size: 95931
   timestamp: 1774072620848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
+  sha256: ea4e50c465d70236408cb0bfe0115609fd14db1adcd8bd30d8918e0291f8a75f
+  md5: 2aadb0d17215603a82a2a6b0afd9a4cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 122618
+  timestamp: 1770167931827
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
   md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,6 +23,9 @@ zarr = "3.*"
 c-compiler = "*"
 setuptools = "*"
 pip = "*"
+anthropic = ">=0.34"
+openai = ">=1.50"
+matplotlib = "*"
 
 [tasks]
 build = "pip install -e . --no-deps"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,13 @@ versionfile_source = "toksearch/_version.py"
 versionfile_build = "toksearch/_version.py"
 tag_prefix = "release-"
 parentdir_prefix = "toksearch-"
+
+[project]
+name = "toksearch"
+dynamic = ["version"]
+
+[project.scripts]
+toksearch = "toksearch.llm.cli:main"
+
+[project.optional-dependencies]
+llm = ["anthropic>=0.34", "openai>=1.50", "matplotlib"]

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,11 @@ setup(
     package_data={'toksearch': ['skills/*/SKILL.md']},
     packages=packages,
     scripts=['scripts/toksearch_submit', 'scripts/toksearch_shape', 'scripts/toksearch_example.py'],
+    entry_points={
+        "console_scripts": [
+            "toksearch = toksearch.llm.cli:main",
+        ],
+    },
     # this package will read some included files in runtime, avoid installing it as .zip
     zip_safe=False,
       

--- a/tests/test_llm_backends_anthropic.py
+++ b/tests/test_llm_backends_anthropic.py
@@ -1,0 +1,138 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for AnthropicBackend.
+
+The anthropic SDK is mocked at the module-attribute level (``backend._client``)
+so tests don't need the SDK installed and don't make network calls.
+"""
+
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+# Install a stub `anthropic` module before any imports of the backend so the
+# `import anthropic` inside backend.__init__ resolves to our stub.
+_stub_anthropic = types.ModuleType("anthropic")
+_stub_anthropic.Anthropic = mock.MagicMock
+_stub_anthropic.AuthenticationError = type("AuthenticationError", (Exception,), {})
+_stub_anthropic.RateLimitError = type("RateLimitError", (Exception,), {})
+_stub_anthropic.APIStatusError = type("APIStatusError", (Exception,), {})
+_stub_anthropic.APIConnectionError = type("APIConnectionError", (Exception,), {})
+sys.modules.setdefault("anthropic", _stub_anthropic)
+
+from toksearch.llm.backends.anthropic import AnthropicBackend  # noqa: E402
+from toksearch.llm.backends.base import AssistantTurn  # noqa: E402
+from toksearch.llm.errors import LLMAuthError  # noqa: E402
+from toksearch.llm.messages import TextBlock, ToolUseBlock  # noqa: E402
+from toksearch.llm.tools import ToolSpec, ToolOutput  # noqa: E402
+
+
+def _make_response(text=None, tool_use=None, stop_reason="end_turn"):
+    """Build a fake anthropic.types.Message-shaped response."""
+    blocks = []
+    if text is not None:
+        blocks.append(mock.MagicMock(type="text", text=text))
+    if tool_use is not None:
+        b = mock.MagicMock(type="tool_use")
+        b.id = tool_use["id"]
+        b.name = tool_use["name"]
+        b.input = tool_use["input"]
+        blocks.append(b)
+    resp = mock.MagicMock()
+    resp.content = blocks
+    resp.stop_reason = stop_reason
+    return resp
+
+
+class TestAnthropicSendRequest(unittest.TestCase):
+    def setUp(self):
+        self.backend = AnthropicBackend(api_key="sk-test")
+        self.backend._client = mock.MagicMock()
+
+    def test_text_response_becomes_assistant_turn(self):
+        self.backend._client.messages.create.return_value = _make_response(
+            text="hi", stop_reason="end_turn")
+        turn = self.backend._send_request(
+            system_prompt="sys", history=[], tools=[], model="claude-x")
+        self.assertEqual(turn.stop_reason, "end_turn")
+        self.assertEqual(len(turn.blocks), 1)
+        self.assertIsInstance(turn.blocks[0], TextBlock)
+        self.assertEqual(turn.blocks[0].text, "hi")
+
+    def test_tool_use_response_becomes_tool_use_block(self):
+        self.backend._client.messages.create.return_value = _make_response(
+            tool_use={"id": "t1", "name": "run_python",
+                      "input": {"code": "1+1", "thought": "x"}},
+            stop_reason="tool_use")
+        turn = self.backend._send_request(
+            system_prompt="sys", history=[], tools=[], model="claude-x")
+        self.assertEqual(turn.stop_reason, "tool_use")
+        self.assertEqual(len(turn.blocks), 1)
+        b = turn.blocks[0]
+        self.assertIsInstance(b, ToolUseBlock)
+        self.assertEqual(b.id, "t1")
+        self.assertEqual(b.name, "run_python")
+        self.assertEqual(b.args, {"code": "1+1", "thought": "x"})
+
+    def test_tools_translated_to_anthropic_schema(self):
+        spec = ToolSpec(
+            name="echo",
+            description="echo",
+            input_schema={"type": "object",
+                          "properties": {"x": {"type": "string"}}},
+            handler=lambda a, s: ToolOutput(text="x"),
+        )
+        self.backend._client.messages.create.return_value = _make_response(
+            text="", stop_reason="end_turn")
+        self.backend._send_request(
+            system_prompt="sys", history=[], tools=[spec], model="claude-x")
+        kwargs = self.backend._client.messages.create.call_args.kwargs
+        sent_tools = kwargs["tools"]
+        self.assertEqual(sent_tools[0]["name"], "echo")
+        self.assertEqual(sent_tools[0]["description"], "echo")
+        self.assertEqual(sent_tools[0]["input_schema"],
+                         {"type": "object",
+                          "properties": {"x": {"type": "string"}}})
+
+
+class TestAnthropicAuthError(unittest.TestCase):
+    def test_auth_error_translated_to_llm_auth_error(self):
+        # Build a fresh exception type and patch it onto the anthropic module
+        # so the backend's `except anthropic.AuthenticationError` matches it
+        # regardless of whether the real SDK is installed.
+        import anthropic as _anthropic
+        fake_auth = type("FakeAuth", (Exception,), {})
+        backend = AnthropicBackend(api_key="x")
+        backend._client = mock.MagicMock()
+        with mock.patch.object(_anthropic, "AuthenticationError", fake_auth):
+            backend._client.messages.create.side_effect = fake_auth("401")
+            with self.assertRaises(LLMAuthError):
+                backend._send_request(system_prompt="s", history=[],
+                                       tools=[], model="m")
+
+
+class TestAnthropicBaseUrl(unittest.TestCase):
+    def test_base_url_passed_to_client(self):
+        with mock.patch.object(_stub_anthropic, "Anthropic") as ctor:
+            AnthropicBackend(api_key="x",
+                              base_url="https://custom.example")._build_client()
+            self.assertEqual(
+                ctor.call_args.kwargs["base_url"],
+                "https://custom.example")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_backends_base.py
+++ b/tests/test_llm_backends_base.py
@@ -1,0 +1,181 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Backend ABC and _ToolLoopBackend shared loop.
+
+We construct a minimal subclass (``ScriptedToolLoopBackend``) that returns
+pre-scripted ``AssistantTurn``s from ``_send_request``, which lets us verify
+the loop's behavior (tool execution, history appending, max_iterations, etc.)
+without any provider SDK.
+"""
+
+import unittest
+from types import SimpleNamespace
+from typing import Iterable
+
+from toksearch.llm.backends.base import (
+    Backend,
+    AssistantTurn,
+    Callbacks,
+    _ToolLoopBackend,
+)
+from toksearch.llm.events import TurnComplete
+from toksearch.llm.messages import (
+    Message, TextBlock, ToolUseBlock, ToolResultBlock,
+)
+from toksearch.llm.tools import ToolSpec, ToolOutput
+
+
+def _ok_tool(name="echo"):
+    """A trivial tool that returns its input as text."""
+    return ToolSpec(
+        name=name,
+        description="echo",
+        input_schema={"type": "object",
+                      "properties": {"x": {"type": "string"}}},
+        handler=lambda args, sess: ToolOutput(text=args["x"], is_error=False),
+    )
+
+
+class ScriptedToolLoopBackend(_ToolLoopBackend):
+    """A _ToolLoopBackend whose _send_request returns scripted turns."""
+
+    name = "scripted"
+    default_model = "scripted-1"
+
+    def __init__(self, turns: Iterable[AssistantTurn]):
+        self._turns = list(turns)
+
+    def _send_request(self, *, system_prompt, history, tools, model,
+                      on_text=None):
+        return self._turns.pop(0)
+
+
+def _make_session(tools=None):
+    """Minimal Session-shaped stub for the loop to drive."""
+    s = SimpleNamespace()
+    s.history = []
+    s.namespace = {}
+    s.system_prompt = "sys"
+    s.model = "scripted-1"
+    s.tool_specs = tools or []
+    s._tools_by_name = {t.name: t for t in s.tool_specs}
+    def append_user(msg):
+        s.history.append(Message(role="user", content=[TextBlock(text=msg)]))
+    def append_assistant(blocks):
+        s.history.append(Message(role="assistant", content=list(blocks)))
+    def append_tool_result(tool_use_id, output, is_error):
+        s.history.append(Message(role="user", content=[
+            ToolResultBlock(tool_use_id=tool_use_id,
+                            output=output, is_error=is_error)]))
+    def execute_tool(block: ToolUseBlock) -> ToolOutput:
+        return s._tools_by_name[block.name].handler(block.args, s)
+    s._append_user = append_user
+    s._append_assistant = append_assistant
+    s._append_tool_result = append_tool_result
+    s._execute_tool = execute_tool
+    return s
+
+
+class TestBackendABC(unittest.TestCase):
+    def test_backend_is_abstract(self):
+        with self.assertRaises(TypeError):
+            Backend()
+
+
+class TestToolLoop(unittest.TestCase):
+    def test_end_turn_with_only_text(self):
+        backend = ScriptedToolLoopBackend([
+            AssistantTurn(blocks=[TextBlock(text="all done")],
+                          stop_reason="end_turn"),
+        ])
+        sess = _make_session()
+        cbs = Callbacks()
+        result = backend.run_conversation(sess, "hello", cbs, max_iterations=5)
+        self.assertEqual(result.stop_reason, "end_turn")
+        self.assertEqual(result.final_text, "all done")
+        # History: user prompt + assistant turn
+        self.assertEqual(len(sess.history), 2)
+        self.assertEqual(sess.history[0].role, "user")
+        self.assertEqual(sess.history[1].role, "assistant")
+
+    def test_tool_use_then_end(self):
+        tool = _ok_tool("echo")
+        backend = ScriptedToolLoopBackend([
+            AssistantTurn(blocks=[ToolUseBlock(id="t1", name="echo",
+                                               args={"x": "hi"})],
+                          stop_reason="tool_use"),
+            AssistantTurn(blocks=[TextBlock(text="ok")],
+                          stop_reason="end_turn"),
+        ])
+        sess = _make_session(tools=[tool])
+        calls, results = [], []
+        cbs = Callbacks(on_tool_call=calls.append,
+                        on_tool_result=results.append)
+        out = backend.run_conversation(sess, "go", cbs, max_iterations=5)
+        self.assertEqual(out.stop_reason, "end_turn")
+        # One tool call, one tool result fired
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].name, "echo")
+        self.assertEqual(results[0].output, "hi")
+        # History: user, assistant(tool_use), user(tool_result), assistant(text)
+        self.assertEqual([m.role for m in sess.history],
+                         ["user", "assistant", "user", "assistant"])
+
+    def test_max_iterations_caps_loop(self):
+        # Backend keeps emitting tool_use forever
+        tool = _ok_tool("echo")
+        forever = [AssistantTurn(blocks=[ToolUseBlock(id=f"t{i}", name="echo",
+                                                      args={"x": str(i)})],
+                                 stop_reason="tool_use")
+                   for i in range(10)]
+        backend = ScriptedToolLoopBackend(forever)
+        sess = _make_session(tools=[tool])
+        out = backend.run_conversation(sess, "go", Callbacks(),
+                                        max_iterations=3)
+        self.assertEqual(out.stop_reason, "max_iterations")
+
+    def test_confirm_false_aborts(self):
+        tool = _ok_tool("echo")
+        backend = ScriptedToolLoopBackend([
+            AssistantTurn(blocks=[ToolUseBlock(id="t1", name="echo",
+                                               args={"x": "hi"})],
+                          stop_reason="tool_use"),
+        ])
+        sess = _make_session(tools=[tool])
+        cbs = Callbacks(confirm=lambda call: False)
+        out = backend.run_conversation(sess, "go", cbs, max_iterations=5)
+        self.assertEqual(out.stop_reason, "interrupted")
+
+    def test_on_event_catch_all_fires_for_everything(self):
+        tool = _ok_tool("echo")
+        backend = ScriptedToolLoopBackend([
+            AssistantTurn(blocks=[ToolUseBlock(id="t1", name="echo",
+                                               args={"x": "hi"})],
+                          stop_reason="tool_use"),
+            AssistantTurn(blocks=[TextBlock(text="done")],
+                          stop_reason="end_turn"),
+        ])
+        sess = _make_session(tools=[tool])
+        events = []
+        cbs = Callbacks(on_event=events.append)
+        backend.run_conversation(sess, "go", cbs, max_iterations=5)
+        kinds = [type(e).__name__ for e in events]
+        # ToolCall, ToolResult, TurnComplete at minimum (text deltas optional)
+        self.assertIn("ToolCall", kinds)
+        self.assertIn("ToolResult", kinds)
+        self.assertIn("TurnComplete", kinds)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_backends_fake.py
+++ b/tests/test_llm_backends_fake.py
@@ -1,0 +1,81 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for FakeBackend (the testing seam)."""
+
+import unittest
+from types import SimpleNamespace
+
+from toksearch.llm.backends.base import AssistantTurn, Callbacks
+from toksearch.llm.backends.fake import FakeBackend
+from toksearch.llm.messages import (
+    Message, TextBlock, ToolUseBlock, ToolResultBlock,
+)
+from toksearch.llm.tools import ToolSpec, ToolOutput
+
+
+def _stub_session(tools=None):
+    s = SimpleNamespace()
+    s.history = []
+    s.namespace = {}
+    s.system_prompt = "sys"
+    s.model = "fake-1"
+    s.tool_specs = tools or []
+    s._tools_by_name = {t.name: t for t in s.tool_specs}
+    s._append_user = lambda msg: s.history.append(
+        Message(role="user", content=[TextBlock(text=msg)]))
+    s._append_assistant = lambda blocks: s.history.append(
+        Message(role="assistant", content=list(blocks)))
+    s._append_tool_result = lambda tid, out, err: s.history.append(
+        Message(role="user", content=[ToolResultBlock(
+            tool_use_id=tid, output=out, is_error=err)]))
+    s._execute_tool = lambda block: s._tools_by_name[block.name].handler(
+        block.args, s)
+    return s
+
+
+class TestFakeBackend(unittest.TestCase):
+    def test_simple_text_response(self):
+        backend = FakeBackend(scripted_turns=[
+            AssistantTurn(blocks=[TextBlock(text="hi")],
+                          stop_reason="end_turn"),
+        ])
+        sess = _stub_session()
+        out = backend.run_conversation(sess, "hello", Callbacks(),
+                                        max_iterations=5)
+        self.assertEqual(out.stop_reason, "end_turn")
+        self.assertEqual(out.final_text, "hi")
+
+    def test_recording_inspects_calls(self):
+        record = []
+        backend = FakeBackend(scripted_turns=[
+            AssistantTurn(blocks=[TextBlock(text="ok")],
+                          stop_reason="end_turn"),
+        ], record=record)
+        sess = _stub_session()
+        backend.run_conversation(sess, "do thing", Callbacks(),
+                                  max_iterations=5)
+        self.assertEqual(len(record), 1)
+        self.assertEqual(record[0]["user_message"], "do thing")
+        self.assertEqual(record[0]["model"], "fake-1")
+
+    def test_script_exhausted_raises(self):
+        backend = FakeBackend(scripted_turns=[])
+        sess = _stub_session()
+        with self.assertRaises(RuntimeError):
+            backend.run_conversation(sess, "hello", Callbacks(),
+                                      max_iterations=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_backends_openai.py
+++ b/tests/test_llm_backends_openai.py
@@ -1,0 +1,125 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for OpenAIBackend.
+
+The openai SDK is mocked at the module-attribute level so tests don't need
+the SDK installed and don't make network calls.
+"""
+
+import json
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+# Stub openai module + its error types
+_stub_openai = types.ModuleType("openai")
+_stub_openai.OpenAI = mock.MagicMock
+_stub_openai.AuthenticationError = type("AuthenticationError", (Exception,), {})
+_stub_openai.RateLimitError = type("RateLimitError", (Exception,), {})
+_stub_openai.APIConnectionError = type("APIConnectionError", (Exception,), {})
+_stub_openai.APIStatusError = type("APIStatusError", (Exception,), {})
+sys.modules.setdefault("openai", _stub_openai)
+
+from toksearch.llm.backends.openai import OpenAIBackend  # noqa: E402
+from toksearch.llm.errors import LLMAuthError  # noqa: E402
+from toksearch.llm.messages import TextBlock, ToolUseBlock  # noqa: E402
+from toksearch.llm.tools import ToolSpec, ToolOutput  # noqa: E402
+
+
+def _make_chat_response(text=None, tool_calls=None, finish_reason="stop"):
+    """Build a fake openai chat completion response."""
+    msg = mock.MagicMock()
+    msg.content = text
+    msg.tool_calls = []
+    for tc in (tool_calls or []):
+        m = mock.MagicMock()
+        m.id = tc["id"]
+        m.type = "function"
+        m.function.name = tc["name"]
+        m.function.arguments = json.dumps(tc["args"])
+        msg.tool_calls.append(m)
+    choice = mock.MagicMock()
+    choice.message = msg
+    choice.finish_reason = finish_reason
+    resp = mock.MagicMock()
+    resp.choices = [choice]
+    return resp
+
+
+class TestOpenAISendRequest(unittest.TestCase):
+    def setUp(self):
+        self.backend = OpenAIBackend(api_key="sk-test")
+        self.backend._client = mock.MagicMock()
+
+    def test_text_response_becomes_assistant_turn(self):
+        self.backend._client.chat.completions.create.return_value = (
+            _make_chat_response(text="hello", finish_reason="stop"))
+        turn = self.backend._send_request(
+            system_prompt="sys", history=[], tools=[], model="gpt-4o")
+        self.assertEqual(turn.stop_reason, "end_turn")
+        self.assertEqual(len(turn.blocks), 1)
+        self.assertIsInstance(turn.blocks[0], TextBlock)
+        self.assertEqual(turn.blocks[0].text, "hello")
+
+    def test_tool_call_response(self):
+        self.backend._client.chat.completions.create.return_value = (
+            _make_chat_response(text=None,
+                                tool_calls=[{"id": "t1", "name": "run_python",
+                                             "args": {"code": "1+1",
+                                                      "thought": "x"}}],
+                                finish_reason="tool_calls"))
+        turn = self.backend._send_request(
+            system_prompt="sys", history=[], tools=[], model="gpt-4o")
+        self.assertEqual(turn.stop_reason, "tool_use")
+        # Should produce one ToolUseBlock (no TextBlock since content is None)
+        tool_blocks = [b for b in turn.blocks if isinstance(b, ToolUseBlock)]
+        self.assertEqual(len(tool_blocks), 1)
+        self.assertEqual(tool_blocks[0].args,
+                         {"code": "1+1", "thought": "x"})
+
+    def test_tools_translated_to_openai_schema(self):
+        spec = ToolSpec(
+            name="echo",
+            description="echo",
+            input_schema={"type": "object",
+                          "properties": {"x": {"type": "string"}}},
+            handler=lambda a, s: ToolOutput(text="x"),
+        )
+        self.backend._client.chat.completions.create.return_value = (
+            _make_chat_response(text="", finish_reason="stop"))
+        self.backend._send_request(
+            system_prompt="sys", history=[], tools=[spec], model="gpt-4o")
+        kwargs = self.backend._client.chat.completions.create.call_args.kwargs
+        sent_tools = kwargs["tools"]
+        self.assertEqual(sent_tools[0]["type"], "function")
+        self.assertEqual(sent_tools[0]["function"]["name"], "echo")
+        self.assertEqual(sent_tools[0]["function"]["parameters"],
+                         {"type": "object",
+                          "properties": {"x": {"type": "string"}}})
+
+    def test_auth_error_translated_to_llm_auth_error(self):
+        import openai as _openai
+        fake_auth = type("FakeAuth", (Exception,), {})
+        with mock.patch.object(_openai, "AuthenticationError", fake_auth):
+            self.backend._client.chat.completions.create.side_effect = (
+                fake_auth("401"))
+            with self.assertRaises(LLMAuthError):
+                self.backend._send_request(system_prompt="s", history=[],
+                                            tools=[], model="m")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_backends_registry.py
+++ b/tests/test_llm_backends_registry.py
@@ -1,0 +1,39 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the backend registry."""
+
+import unittest
+
+from toksearch.llm.errors import LLMConfigError
+
+
+class TestBackendRegistry(unittest.TestCase):
+    def test_get_backend_class_anthropic(self):
+        from toksearch.llm.backends import get_backend_class
+        from toksearch.llm.backends.anthropic import AnthropicBackend
+        self.assertIs(get_backend_class("anthropic"), AnthropicBackend)
+
+    def test_get_backend_class_openai(self):
+        from toksearch.llm.backends import get_backend_class
+        from toksearch.llm.backends.openai import OpenAIBackend
+        self.assertIs(get_backend_class("openai"), OpenAIBackend)
+
+    def test_unknown_raises(self):
+        from toksearch.llm.backends import get_backend_class
+        with self.assertRaises(LLMConfigError):
+            get_backend_class("nonexistent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_cli.py
+++ b/tests/test_llm_cli.py
@@ -1,0 +1,114 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the toksearch chat / toksearch query CLI.
+
+The Session class is mocked so the CLI tests verify wiring (subcommand
+dispatch, flag plumbing, slash-command handling) without going near a real
+backend.
+"""
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+
+class TestCliQuery(unittest.TestCase):
+    def _run_cli(self, argv, send_returns=None, stdin_text=""):
+        from toksearch.llm import cli
+        fake_session = mock.MagicMock()
+        fake_session.send.return_value = send_returns or mock.MagicMock(
+            stop_reason="end_turn", final_text="ok")
+        buf = io.StringIO()
+        exit_code = None
+        with mock.patch.object(sys, "argv", argv), \
+                mock.patch.object(cli, "build_session",
+                                  return_value=fake_session) as build, \
+                mock.patch.object(sys, "stdin",
+                                  new=io.StringIO(stdin_text)), \
+                redirect_stdout(buf):
+            try:
+                cli.main()
+            except SystemExit as e:
+                exit_code = e.code
+        return fake_session, build, buf.getvalue(), exit_code
+
+    def test_query_dispatches_send(self):
+        sess, _, _, _ = self._run_cli(
+            ["toksearch", "query", "hello"])
+        sess.send.assert_called_once()
+        prompt = sess.send.call_args.args[0]
+        self.assertEqual(prompt, "hello")
+
+    def test_query_backend_flag_forwarded_to_build(self):
+        _, build, _, _ = self._run_cli(
+            ["toksearch", "query", "--backend", "openai", "hi"])
+        # build_session called with args namespace; check the attribute
+        ns = build.call_args.args[0]
+        self.assertEqual(ns.backend, "openai")
+
+    def test_query_max_iterations_flag(self):
+        _, build, _, _ = self._run_cli(
+            ["toksearch", "query", "-n", "3", "hi"])
+        ns = build.call_args.args[0]
+        self.assertEqual(ns.max_iterations, 3)
+
+
+class TestCliChatSlashCommands(unittest.TestCase):
+    def _run_chat(self, stdin_text):
+        from toksearch.llm import cli
+        fake_session = mock.MagicMock()
+        fake_session.send.return_value = mock.MagicMock(
+            stop_reason="end_turn", final_text="agent says hi")
+        buf = io.StringIO()
+        exit_code = None
+        with mock.patch.object(sys, "argv", ["toksearch", "chat"]), \
+                mock.patch.object(cli, "build_session",
+                                  return_value=fake_session), \
+                mock.patch.object(sys, "stdin",
+                                  new=io.StringIO(stdin_text)), \
+                redirect_stdout(buf):
+            try:
+                cli.main()
+            except SystemExit as e:
+                exit_code = e.code
+        return fake_session, buf.getvalue(), exit_code
+
+    def test_chat_sends_each_nonempty_line(self):
+        sess, out, _ = self._run_chat("hello\nhow are you?\n")
+        self.assertEqual(sess.send.call_count, 2)
+
+    def test_slash_quit_exits_loop(self):
+        sess, out, _ = self._run_chat("hello\n/quit\nignored\n")
+        self.assertEqual(sess.send.call_count, 1)
+
+    def test_slash_reset_calls_session_reset(self):
+        sess, out, _ = self._run_chat("/reset\n")
+        sess.reset.assert_called_once()
+
+    def test_slash_help_prints(self):
+        sess, out, _ = self._run_chat("/help\n")
+        self.assertIn("/help", out)
+        self.assertIn("/reset", out)
+        self.assertIn("/quit", out)
+
+    def test_eof_exits_cleanly(self):
+        # Empty stdin = immediate EOF
+        sess, out, exit_code = self._run_chat("")
+        self.assertIn(exit_code, (None, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_cli.py
+++ b/tests/test_llm_cli.py
@@ -110,5 +110,43 @@ class TestCliChatSlashCommands(unittest.TestCase):
         self.assertIn(exit_code, (None, 0))
 
 
+class TestResolveApiKey(unittest.TestCase):
+    """Verify _resolve_api_key consults preset.api_key_env / api_key_file."""
+
+    def test_api_key_env_consulted(self):
+        from toksearch.llm.cli import _resolve_api_key
+        from toksearch.llm.presets import Preset
+        from toksearch.llm.config import Config
+        preset = Preset(backend="anthropic", api_key_env="MYSITE_TEST_KEY")
+        with mock.patch.dict("os.environ",
+                             {"MYSITE_TEST_KEY": "sk-from-env"}):
+            self.assertEqual(_resolve_api_key(preset, Config()),
+                             "sk-from-env")
+
+    def test_api_key_file_consulted(self):
+        import tempfile
+        from pathlib import Path
+        from toksearch.llm.cli import _resolve_api_key
+        from toksearch.llm.presets import Preset
+        from toksearch.llm.config import Config
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("sk-from-file\n")
+            key_path = Path(f.name)
+        try:
+            preset = Preset(backend="anthropic", api_key_file=str(key_path))
+            self.assertEqual(_resolve_api_key(preset, Config()),
+                             "sk-from-file")
+        finally:
+            key_path.unlink()
+
+    def test_fallback_to_config(self):
+        from toksearch.llm.cli import _resolve_api_key
+        from toksearch.llm.presets import Preset
+        from toksearch.llm.config import Config
+        preset = Preset(backend="anthropic")  # no api_key_env, no api_key_file
+        cfg = Config(anthropic_api_key="sk-from-cfg")
+        self.assertEqual(_resolve_api_key(preset, cfg), "sk-from-cfg")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -1,0 +1,96 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Config and load_config()."""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from toksearch.llm.config import Config, load_config
+
+
+class TestConfigDefaults(unittest.TestCase):
+    def test_default_backend_is_none(self):
+        cfg = Config()
+        self.assertIsNone(cfg.backend)
+
+    def test_default_max_iterations(self):
+        cfg = Config()
+        self.assertEqual(cfg.max_iterations, 20)
+
+    def test_anthropic_key_default(self):
+        cfg = Config()
+        self.assertIsNone(cfg.anthropic_api_key)
+
+
+class TestLoadConfig(unittest.TestCase):
+    def setUp(self):
+        # Isolate env so test order doesn't matter
+        self._saved_env = {k: os.environ.pop(k, None)
+                           for k in ("FDP_LLM_BACKEND",
+                                     "ANTHROPIC_API_KEY",
+                                     "OPENAI_API_KEY")}
+
+    def tearDown(self):
+        for k, v in self._saved_env.items():
+            if v is not None:
+                os.environ[k] = v
+
+    def test_no_file_no_env_returns_defaults(self):
+        cfg = load_config(config_path=Path("/does/not/exist"))
+        self.assertIsNone(cfg.backend)
+        self.assertEqual(cfg.max_iterations, 20)
+
+    def test_loads_from_toml(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write('[llm]\nbackend = "openai"\nmax_iterations = 5\n'
+                    'anthropic_api_key = "sk-file"\n')
+            path = Path(f.name)
+        try:
+            cfg = load_config(config_path=path)
+            self.assertEqual(cfg.backend, "openai")
+            self.assertEqual(cfg.max_iterations, 5)
+            self.assertEqual(cfg.anthropic_api_key, "sk-file")
+        finally:
+            path.unlink()
+
+    def test_env_overrides_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write('[llm]\nbackend = "openai"\nanthropic_api_key = "sk-file"\n')
+            path = Path(f.name)
+        try:
+            with mock.patch.dict(os.environ, {"FDP_LLM_BACKEND": "anthropic",
+                                              "ANTHROPIC_API_KEY": "sk-env"}):
+                cfg = load_config(config_path=path)
+            self.assertEqual(cfg.backend, "anthropic")
+            self.assertEqual(cfg.anthropic_api_key, "sk-env")
+        finally:
+            path.unlink()
+
+    def test_malformed_toml_raises_config_error(self):
+        from toksearch.llm.errors import LLMConfigError
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write("this is not [valid toml")
+            path = Path(f.name)
+        try:
+            with self.assertRaises(LLMConfigError):
+                load_config(config_path=path)
+        finally:
+            path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_errors.py
+++ b/tests/test_llm_errors.py
@@ -1,0 +1,56 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the LLMError hierarchy."""
+
+import unittest
+
+from toksearch.llm.errors import (
+    LLMError,
+    LLMConfigError,
+    LLMAuthError,
+    LLMBackendError,
+    LLMRateLimitError,
+    LLMUserAbort,
+)
+
+
+class TestErrorHierarchy(unittest.TestCase):
+    def test_all_inherit_from_llm_error(self):
+        for cls in (LLMConfigError, LLMAuthError, LLMBackendError,
+                    LLMRateLimitError, LLMUserAbort):
+            self.assertTrue(issubclass(cls, LLMError),
+                            f"{cls.__name__} must inherit LLMError")
+
+    def test_llm_error_inherits_from_exception(self):
+        self.assertTrue(issubclass(LLMError, Exception))
+
+    def test_user_abort_inherits_from_keyboard_interrupt(self):
+        # LLMUserAbort is raised in response to user ctrl-C, so it should
+        # also pass `except KeyboardInterrupt` for shells that explicitly
+        # filter on that type.
+        self.assertTrue(issubclass(LLMUserAbort, KeyboardInterrupt))
+
+    def test_raise_and_catch_via_base(self):
+        with self.assertRaises(LLMError):
+            raise LLMAuthError("bad key")
+
+    def test_message_is_preserved(self):
+        try:
+            raise LLMBackendError("503 service unavailable")
+        except LLMBackendError as e:
+            self.assertEqual(str(e), "503 service unavailable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_events.py
+++ b/tests/test_llm_events.py
@@ -1,0 +1,70 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the event dataclasses dispatched by Session.send()."""
+
+import unittest
+
+from toksearch.llm.events import (
+    TextDelta,
+    ToolCall,
+    ToolResult,
+    TurnComplete,
+)
+
+
+class TestEvents(unittest.TestCase):
+    def test_text_delta_holds_text(self):
+        e = TextDelta(text="hello")
+        self.assertEqual(e.text, "hello")
+
+    def test_tool_call_fields(self):
+        e = ToolCall(id="abc", name="run_python",
+                     args={"code": "x = 1", "thought": "set x"},
+                     thought="set x")
+        self.assertEqual(e.id, "abc")
+        self.assertEqual(e.name, "run_python")
+        self.assertEqual(e.args, {"code": "x = 1", "thought": "set x"})
+        self.assertEqual(e.thought, "set x")
+
+    def test_tool_call_thought_optional(self):
+        e = ToolCall(id="abc", name="lookup_docs",
+                     args={"skill_name": "toksearch-pipeline"},
+                     thought=None)
+        self.assertIsNone(e.thought)
+
+    def test_tool_result_fields(self):
+        e = ToolResult(id="abc", output="42", is_error=False)
+        self.assertFalse(e.is_error)
+        self.assertEqual(e.output, "42")
+
+    def test_turn_complete_fields(self):
+        e = TurnComplete(stop_reason="end_turn", final_text="done")
+        self.assertEqual(e.stop_reason, "end_turn")
+        self.assertEqual(e.final_text, "done")
+
+    def test_events_are_frozen(self):
+        e = TextDelta(text="hi")
+        with self.assertRaises(Exception):  # FrozenInstanceError or AttributeError
+            e.text = "bye"
+
+    def test_events_compare_by_value(self):
+        a = TextDelta(text="hi")
+        b = TextDelta(text="hi")
+        c = TextDelta(text="bye")
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, c)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -1,0 +1,90 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end integration tests for toksearch.llm against real provider APIs.
+
+These tests are skipped by default; they only run when:
+
+  1. ``TOKSEARCH_INTEGRATION`` is set to ``"yes"`` in the environment.
+     ``tests/testit.py`` sets this for you unless you pass ``--mock``.
+  2. The relevant API key env var is set (``ANTHROPIC_API_KEY`` for the
+     Anthropic backend, ``OPENAI_API_KEY`` for the OpenAI backend).
+
+Each backend gets one trivial prompt that exercises the full loop:
+``run_python`` tool call, namespace persistence, end_turn.  Failure here means
+the wire format / tool-result encoding diverged from what the provider
+actually expects — something the mocked unit tests cannot catch.
+
+Cost note: each test does one short prompt + one tool round-trip, ~a few
+hundred tokens.  Cheap, but not free.
+"""
+
+import os
+import unittest
+
+from toksearch.llm import Session
+from toksearch.llm.events import TurnComplete
+
+
+_INTEGRATION_ON = os.environ.get("TOKSEARCH_INTEGRATION") == "yes"
+_HAS_ANTHROPIC = bool(os.environ.get("ANTHROPIC_API_KEY"))
+_HAS_OPENAI = bool(os.environ.get("OPENAI_API_KEY"))
+
+
+PROMPT = (
+    "Use the run_python tool to compute 2 + 2 and print the result. "
+    "Then report the answer in your final text response."
+)
+
+
+def _assert_simple_arithmetic(tc: TurnComplete, sess: Session):
+    """Common assertions for the trivial '2 + 2' prompt across backends."""
+    assert tc.stop_reason == "end_turn", f"unexpected stop_reason: {tc.stop_reason}"
+    # The agent should have called run_python at least once.
+    tool_uses = [
+        b for m in sess.history if m.role == "assistant"
+        for b in m.content if getattr(b, "kind", None) == "tool_use"
+    ]
+    assert any(b.name == "run_python" for b in tool_uses), (
+        f"no run_python call in history; got tool uses: "
+        f"{[b.name for b in tool_uses]}")
+    # The answer "4" should appear in the final text.
+    assert "4" in tc.final_text, (
+        f"final_text did not mention 4: {tc.final_text!r}")
+
+
+@unittest.skipUnless(_INTEGRATION_ON and _HAS_ANTHROPIC,
+                     "TOKSEARCH_INTEGRATION=yes and ANTHROPIC_API_KEY required")
+class TestAnthropicIntegration(unittest.TestCase):
+    def test_simple_arithmetic_end_to_end(self):
+        from toksearch.llm.backends.anthropic import AnthropicBackend
+        backend = AnthropicBackend(api_key=os.environ["ANTHROPIC_API_KEY"])
+        sess = Session(backend=backend, max_iterations=5)
+        result = sess.send(PROMPT)
+        _assert_simple_arithmetic(result, sess)
+
+
+@unittest.skipUnless(_INTEGRATION_ON and _HAS_OPENAI,
+                     "TOKSEARCH_INTEGRATION=yes and OPENAI_API_KEY required")
+class TestOpenAIIntegration(unittest.TestCase):
+    def test_simple_arithmetic_end_to_end(self):
+        from toksearch.llm.backends.openai import OpenAIBackend
+        backend = OpenAIBackend(api_key=os.environ["OPENAI_API_KEY"])
+        sess = Session(backend=backend, max_iterations=5)
+        result = sess.send(PROMPT)
+        _assert_simple_arithmetic(result, sess)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_messages.py
+++ b/tests/test_llm_messages.py
@@ -1,0 +1,99 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the provider-neutral Message / ContentBlock types."""
+
+import unittest
+
+from toksearch.llm.messages import (
+    Message,
+    TextBlock,
+    ToolUseBlock,
+    ToolResultBlock,
+    block_to_dict,
+    dict_to_block,
+    message_to_dict,
+    dict_to_message,
+)
+
+
+class TestContentBlocks(unittest.TestCase):
+    def test_text_block_kind(self):
+        b = TextBlock(text="hi")
+        self.assertEqual(b.kind, "text")
+        self.assertEqual(b.text, "hi")
+
+    def test_tool_use_block_kind(self):
+        b = ToolUseBlock(id="t1", name="run_python", args={"code": "1"})
+        self.assertEqual(b.kind, "tool_use")
+
+    def test_tool_result_block_kind(self):
+        b = ToolResultBlock(tool_use_id="t1", output="1", is_error=False)
+        self.assertEqual(b.kind, "tool_result")
+
+
+class TestMessage(unittest.TestCase):
+    def test_user_text_message(self):
+        m = Message(role="user", content=[TextBlock(text="hello")])
+        self.assertEqual(m.role, "user")
+        self.assertEqual(len(m.content), 1)
+
+    def test_assistant_mixed_content(self):
+        m = Message(role="assistant", content=[
+            TextBlock(text="let me run code"),
+            ToolUseBlock(id="t1", name="run_python",
+                         args={"code": "x = 1", "thought": "set x"}),
+        ])
+        self.assertEqual(len(m.content), 2)
+
+
+class TestSerialization(unittest.TestCase):
+    """Round-trip support for future /save persistence."""
+
+    def test_text_block_round_trip(self):
+        b = TextBlock(text="hi")
+        d = block_to_dict(b)
+        self.assertEqual(d, {"kind": "text", "text": "hi"})
+        self.assertEqual(dict_to_block(d), b)
+
+    def test_tool_use_block_round_trip(self):
+        b = ToolUseBlock(id="t1", name="run_python", args={"code": "x"})
+        d = block_to_dict(b)
+        self.assertEqual(d, {"kind": "tool_use", "id": "t1",
+                             "name": "run_python", "args": {"code": "x"}})
+        self.assertEqual(dict_to_block(d), b)
+
+    def test_tool_result_block_round_trip(self):
+        b = ToolResultBlock(tool_use_id="t1", output="ok", is_error=False)
+        d = block_to_dict(b)
+        self.assertEqual(d, {"kind": "tool_result", "tool_use_id": "t1",
+                             "output": "ok", "is_error": False})
+        self.assertEqual(dict_to_block(d), b)
+
+    def test_message_round_trip(self):
+        m = Message(role="assistant", content=[
+            TextBlock(text="a"),
+            ToolUseBlock(id="t1", name="run_python", args={"code": "1"}),
+        ])
+        d = message_to_dict(m)
+        self.assertEqual(d["role"], "assistant")
+        self.assertEqual(len(d["content"]), 2)
+        self.assertEqual(dict_to_message(d), m)
+
+    def test_dict_to_block_rejects_unknown_kind(self):
+        with self.assertRaises(ValueError):
+            dict_to_block({"kind": "bogus"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_package.py
+++ b/tests/test_llm_package.py
@@ -2,6 +2,15 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Smoke test: the toksearch.llm package and its backends subpackage import."""
 

--- a/tests/test_llm_package.py
+++ b/tests/test_llm_package.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Smoke test: the toksearch.llm package and its backends subpackage import."""
+"""Public-surface tests for toksearch.llm."""
 
 import unittest
 
@@ -23,6 +23,33 @@ class TestPackageImports(unittest.TestCase):
 
     def test_import_toksearch_llm_backends(self):
         import toksearch.llm.backends  # noqa: F401
+
+
+class TestPublicSurface(unittest.TestCase):
+    def test_session_importable(self):
+        from toksearch.llm import Session  # noqa: F401
+
+    def test_event_types_importable(self):
+        from toksearch.llm import (
+            TextDelta, ToolCall, ToolResult, TurnComplete,
+        )  # noqa: F401
+
+    def test_error_types_importable(self):
+        from toksearch.llm import (
+            LLMError, LLMConfigError, LLMAuthError,
+            LLMBackendError, LLMRateLimitError, LLMUserAbort,
+        )  # noqa: F401
+
+    def test_config_and_presets_importable(self):
+        from toksearch.llm import (
+            Config, load_config, Preset, BUILTIN_PRESETS, resolve_preset,
+        )  # noqa: F401
+
+
+class TestConsoleScript(unittest.TestCase):
+    def test_cli_main_callable(self):
+        from toksearch.llm.cli import main
+        self.assertTrue(callable(main))
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_package.py
+++ b/tests/test_llm_package.py
@@ -1,0 +1,20 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Smoke test: the toksearch.llm package and its backends subpackage import."""
+
+import unittest
+
+
+class TestPackageImports(unittest.TestCase):
+    def test_import_toksearch_llm(self):
+        import toksearch.llm  # noqa: F401
+
+    def test_import_toksearch_llm_backends(self):
+        import toksearch.llm.backends  # noqa: F401
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_presets.py
+++ b/tests/test_llm_presets.py
@@ -1,0 +1,66 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Preset resolution."""
+
+import unittest
+
+from toksearch.llm.config import Config
+from toksearch.llm.errors import LLMConfigError
+from toksearch.llm.presets import Preset, resolve_preset, BUILTIN_PRESETS
+
+
+class TestPreset(unittest.TestCase):
+    def test_builtin_anthropic_exists(self):
+        self.assertIn("anthropic", BUILTIN_PRESETS)
+        p = BUILTIN_PRESETS["anthropic"]
+        self.assertEqual(p.backend, "anthropic")
+        self.assertEqual(p.api_key_env, "ANTHROPIC_API_KEY")
+
+    def test_builtin_openai_exists(self):
+        self.assertIn("openai", BUILTIN_PRESETS)
+        p = BUILTIN_PRESETS["openai"]
+        self.assertEqual(p.backend, "openai")
+        self.assertEqual(p.api_key_env, "OPENAI_API_KEY")
+
+
+class TestResolvePreset(unittest.TestCase):
+    def test_resolves_builtin(self):
+        p = resolve_preset("anthropic", Config())
+        self.assertEqual(p.backend, "anthropic")
+
+    def test_unknown_preset_raises(self):
+        with self.assertRaises(LLMConfigError):
+            resolve_preset("nonexistent", Config())
+
+    def test_user_preset_overrides_builtin(self):
+        cfg = Config(user_presets={"anthropic": {"model": "custom-model"}})
+        p = resolve_preset("anthropic", cfg)
+        # User preset is shallow-merged onto built-in; model is overridden.
+        self.assertEqual(p.model, "custom-model")
+        # Other fields fall through from built-in.
+        self.assertEqual(p.backend, "anthropic")
+
+    def test_user_only_preset(self):
+        cfg = Config(user_presets={"mysite": {"backend": "anthropic",
+                                              "base_url": "https://x.example",
+                                              "model": "claude-sonnet-4-6",
+                                              "api_key_env": "MY_KEY"}})
+        p = resolve_preset("mysite", cfg)
+        self.assertEqual(p.backend, "anthropic")
+        self.assertEqual(p.base_url, "https://x.example")
+        self.assertEqual(p.api_key_env, "MY_KEY")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_prompts.py
+++ b/tests/test_llm_prompts.py
@@ -1,0 +1,55 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for system-prompt assembly."""
+
+import unittest
+
+from toksearch.llm.tools import Skill
+from toksearch.llm.prompts import build_system_prompt
+
+
+class TestBuildSystemPrompt(unittest.TestCase):
+    def test_contains_kernel_text(self):
+        sp = build_system_prompt(skills={}, namespace_entries=[])
+        self.assertIn("TokSearch", sp)
+        self.assertIn("run_python", sp)
+
+    def test_lists_namespace_entries(self):
+        sp = build_system_prompt(
+            skills={},
+            namespace_entries=[("toksearch_d3d", "DIII-D signal classes")],
+        )
+        self.assertIn("toksearch_d3d", sp)
+        self.assertIn("DIII-D signal classes", sp)
+
+    def test_lists_skills_in_catalog(self):
+        sp = build_system_prompt(
+            skills={"foo": Skill(name="foo", description="Foo skill", body=""),
+                    "bar": Skill(name="bar", description="Bar skill", body="")},
+            namespace_entries=[],
+        )
+        self.assertIn("foo", sp)
+        self.assertIn("Foo skill", sp)
+        self.assertIn("bar", sp)
+        self.assertIn("Bar skill", sp)
+
+    def test_empty_catalogs_omit_sections(self):
+        sp = build_system_prompt(skills={}, namespace_entries=[])
+        # Should still be a non-empty kernel prompt without empty bullet lists.
+        self.assertNotIn("\n-\n", sp)
+        self.assertNotIn(" - :", sp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_session.py
+++ b/tests/test_llm_session.py
@@ -1,0 +1,124 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session-level tests using FakeBackend.
+
+The Session class is responsible for: building the system prompt, owning the
+namespace and history, registering tools, dispatching to the backend, and
+providing reset/introspection.
+"""
+
+import unittest
+
+from toksearch.llm.backends.base import AssistantTurn
+from toksearch.llm.backends.fake import FakeBackend
+from toksearch.llm.messages import TextBlock, ToolUseBlock
+from toksearch.llm.session import Session
+
+
+def _text(s):
+    return AssistantTurn(blocks=[TextBlock(text=s)], stop_reason="end_turn")
+
+
+def _tool_use(name, args, id_="t1"):
+    return AssistantTurn(
+        blocks=[ToolUseBlock(id=id_, name=name, args=args)],
+        stop_reason="tool_use",
+    )
+
+
+class TestSessionBasics(unittest.TestCase):
+    def test_send_returns_turn_complete(self):
+        backend = FakeBackend(scripted_turns=[_text("hello")])
+        sess = Session(backend=backend)
+        out = sess.send("hi")
+        self.assertEqual(out.stop_reason, "end_turn")
+        self.assertEqual(out.final_text, "hello")
+
+    def test_namespace_pre_populated(self):
+        backend = FakeBackend(scripted_turns=[_text("ok")])
+        sess = Session(backend=backend)
+        # toksearch and numpy are required; pandas and matplotlib are optional
+        # in the test env (they live in the [llm] extra).
+        self.assertIn("toksearch", sess.namespace)
+        self.assertIn("np", sess.namespace)
+
+    def test_extra_namespace_merged(self):
+        backend = FakeBackend(scripted_turns=[_text("ok")])
+        sess = Session(backend=backend, extra_namespace={"answer": 42})
+        self.assertEqual(sess.namespace["answer"], 42)
+
+
+class TestSessionPersistence(unittest.TestCase):
+    def test_namespace_persists_across_send_calls(self):
+        backend = FakeBackend(scripted_turns=[
+            _tool_use("run_python", {"code": "x = 99", "thought": "set"}),
+            _text("set"),
+            _tool_use("run_python", {"code": "print(x)", "thought": "read"}, id_="t2"),
+            _text("read"),
+        ])
+        sess = Session(backend=backend)
+        sess.send("set x")
+        sess.send("read x")
+        self.assertEqual(sess.namespace["x"], 99)
+
+    def test_reset_clears_namespace_and_history(self):
+        backend = FakeBackend(scripted_turns=[
+            _tool_use("run_python", {"code": "x = 1", "thought": "set"}),
+            _text("done"),
+        ])
+        sess = Session(backend=backend)
+        sess.send("set x")
+        self.assertIn("x", sess.namespace)
+        self.assertGreater(len(sess.history), 0)
+        sess.reset()
+        self.assertNotIn("x", sess.namespace)
+        self.assertEqual(len(sess.history), 0)
+        # Standard names are still there
+        self.assertIn("toksearch", sess.namespace)
+
+
+class TestSessionCallbacks(unittest.TestCase):
+    def test_on_tool_call_fires_before_result(self):
+        backend = FakeBackend(scripted_turns=[
+            _tool_use("run_python", {"code": "print('hi')", "thought": "x"}),
+            _text("done"),
+        ])
+        sess = Session(backend=backend)
+        order = []
+        sess.send("go",
+                  on_tool_call=lambda c: order.append(("call", c.name)),
+                  on_tool_result=lambda r: order.append(("result", r.output)))
+        self.assertEqual(order[0][0], "call")
+        self.assertEqual(order[1][0], "result")
+        self.assertIn("hi", order[1][1])
+
+    def test_confirm_false_aborts(self):
+        backend = FakeBackend(scripted_turns=[
+            _tool_use("run_python", {"code": "print('x')", "thought": "x"}),
+        ])
+        sess = Session(backend=backend)
+        out = sess.send("go", confirm=lambda call: False)
+        self.assertEqual(out.stop_reason, "interrupted")
+
+
+class TestSessionTools(unittest.TestCase):
+    def test_run_python_and_lookup_docs_registered(self):
+        backend = FakeBackend(scripted_turns=[_text("ok")])
+        sess = Session(backend=backend)
+        names = {t.name for t in sess.tool_specs}
+        self.assertEqual(names, {"run_python", "lookup_docs"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_tools.py
+++ b/tests/test_llm_tools.py
@@ -1,0 +1,93 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for tools.py — ToolSpec, ToolOutput, and tool handlers.
+
+Tool handlers take ``(args: dict, session)``.  These tests pass a duck-typed
+stub with a ``.namespace`` attribute; the real ``Session`` class is tested in
+``test_llm_session.py``.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from toksearch.llm.tools import (
+    ToolSpec,
+    ToolOutput,
+    RUN_PYTHON,
+)
+
+
+def _stub_session(namespace: dict | None = None):
+    return SimpleNamespace(namespace=namespace if namespace is not None else {})
+
+
+class TestToolSpec(unittest.TestCase):
+    def test_run_python_spec_shape(self):
+        self.assertEqual(RUN_PYTHON.name, "run_python")
+        self.assertIn("code", RUN_PYTHON.input_schema["properties"])
+        self.assertIn("thought", RUN_PYTHON.input_schema["properties"])
+        self.assertEqual(set(RUN_PYTHON.input_schema["required"]),
+                         {"code", "thought"})
+
+
+class TestRunPython(unittest.TestCase):
+    def test_simple_expression_no_output(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler({"code": "x = 1 + 1", "thought": "test"}, s)
+        self.assertFalse(out.is_error)
+        self.assertEqual(s.namespace["x"], 2)
+
+    def test_stdout_captured(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler({"code": "print('hi')", "thought": "x"}, s)
+        self.assertFalse(out.is_error)
+        self.assertIn("hi", out.text)
+
+    def test_stderr_captured(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler({"code": "import sys; sys.stderr.write('warn\\n')",
+                                  "thought": "x"}, s)
+        self.assertFalse(out.is_error)
+        self.assertIn("warn", out.text)
+
+    def test_exception_becomes_error(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler({"code": "1/0", "thought": "boom"}, s)
+        self.assertTrue(out.is_error)
+        self.assertIn("ZeroDivisionError", out.text)
+        # Traceback contains the offending line:
+        self.assertIn("Traceback", out.text)
+
+    def test_namespace_persists_across_calls(self):
+        s = _stub_session()
+        RUN_PYTHON.handler({"code": "x = 42", "thought": "set"}, s)
+        out = RUN_PYTHON.handler({"code": "print(x * 2)", "thought": "read"}, s)
+        self.assertIn("84", out.text)
+
+    def test_no_output_message(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler({"code": "x = 1", "thought": "x"}, s)
+        self.assertEqual(out.text, "(no output)")
+
+    def test_keyboard_interrupt_returns_interrupted(self):
+        s = _stub_session()
+        out = RUN_PYTHON.handler(
+            {"code": "raise KeyboardInterrupt()", "thought": "x"}, s)
+        self.assertTrue(out.is_error)
+        self.assertTrue(out.interrupted)
+        self.assertEqual(out.text, "(interrupted)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_tools.py
+++ b/tests/test_llm_tools.py
@@ -19,6 +19,7 @@ stub with a ``.namespace`` attribute; the real ``Session`` class is tested in
 """
 
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 
 from toksearch.llm.tools import (
@@ -87,6 +88,84 @@ class TestRunPython(unittest.TestCase):
         self.assertTrue(out.is_error)
         self.assertTrue(out.interrupted)
         self.assertEqual(out.text, "(interrupted)")
+
+
+class TestLookupDocs(unittest.TestCase):
+    """``lookup_docs`` reads SKILL.md bodies from the Session's skill registry.
+
+    The handler accesses ``session.skills`` (a dict[name -> Skill]) which the
+    real Session builds at __init__ from ``extra_skill_dirs`` + the core
+    ``toksearch/skills/`` directory.  These tests stub that mapping.
+    """
+
+    def _stub_session(self, skills):
+        return SimpleNamespace(skills=skills)
+
+    def test_unknown_skill_is_error(self):
+        from toksearch.llm.tools import LOOKUP_DOCS
+        s = self._stub_session({})
+        out = LOOKUP_DOCS.handler({"skill_name": "missing"}, s)
+        self.assertTrue(out.is_error)
+        self.assertIn("missing", out.text)
+
+    def test_known_skill_returns_body(self):
+        from toksearch.llm.tools import LOOKUP_DOCS, Skill
+        s = self._stub_session({"foo": Skill(name="foo",
+                                             description="d",
+                                             body="Hello body.")})
+        out = LOOKUP_DOCS.handler({"skill_name": "foo"}, s)
+        self.assertFalse(out.is_error)
+        self.assertEqual(out.text, "Hello body.")
+
+    def test_lookup_docs_spec_shape(self):
+        from toksearch.llm.tools import LOOKUP_DOCS
+        self.assertEqual(LOOKUP_DOCS.name, "lookup_docs")
+        self.assertIn("skill_name", LOOKUP_DOCS.input_schema["properties"])
+        self.assertEqual(LOOKUP_DOCS.input_schema["required"], ["skill_name"])
+
+
+class TestDiscoverSkills(unittest.TestCase):
+    def test_returns_empty_for_nonexistent_dirs(self):
+        from toksearch.llm.tools import discover_skills
+        skills = discover_skills([Path("/nonexistent")])
+        self.assertEqual(skills, {})
+
+    def test_parses_skill_with_frontmatter(self):
+        from toksearch.llm.tools import discover_skills, parse_skill_md
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            sk = root / "myskill"
+            sk.mkdir()
+            (sk / "SKILL.md").write_text(
+                "---\nname: myskill\ndescription: My skill\n---\n\n"
+                "Body content here.\n")
+            skills = discover_skills([root])
+            self.assertIn("myskill", skills)
+            self.assertEqual(skills["myskill"].description, "My skill")
+            self.assertIn("Body content here", skills["myskill"].body)
+
+    def test_skips_dirs_without_skill_md(self):
+        from toksearch.llm.tools import discover_skills
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "not_a_skill").mkdir()
+            self.assertEqual(discover_skills([root]), {})
+
+    def test_parse_skill_md_no_frontmatter(self):
+        from toksearch.llm.tools import parse_skill_md
+        import tempfile
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md",
+                                          delete=False) as f:
+            f.write("Just body, no frontmatter.\n")
+            path = Path(f.name)
+        try:
+            fm, body = parse_skill_md(path)
+            self.assertEqual(fm, {})
+            self.assertIn("Just body", body)
+        finally:
+            path.unlink()
 
 
 if __name__ == "__main__":

--- a/toksearch/llm/__init__.py
+++ b/toksearch/llm/__init__.py
@@ -2,6 +2,15 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """toksearch.llm — Conversational LLM interface for TokSearch.
 
 Public re-exports are wired up at the end of PR 1; see

--- a/toksearch/llm/__init__.py
+++ b/toksearch/llm/__init__.py
@@ -1,0 +1,9 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""toksearch.llm — Conversational LLM interface for TokSearch.
+
+Public re-exports are wired up at the end of PR 1; see
+``docs/superpowers/specs/2026-05-18-toksearch-llm-design.md``.
+"""

--- a/toksearch/llm/__init__.py
+++ b/toksearch/llm/__init__.py
@@ -13,6 +13,41 @@
 # limitations under the License.
 """toksearch.llm — Conversational LLM interface for TokSearch.
 
-Public re-exports are wired up at the end of PR 1; see
-``docs/superpowers/specs/2026-05-18-toksearch-llm-design.md``.
+See ``docs/superpowers/specs/2026-05-18-toksearch-llm-design.md``.
+
+Quickstart
+==========
+
+::
+
+    from toksearch.llm import Session
+    from toksearch.llm.backends.anthropic import AnthropicBackend
+
+    sess = Session(backend=AnthropicBackend(api_key="sk-..."))
+    result = sess.send("Fetch ip for shot 200000 and report peak in MA.",
+                       on_tool_call=lambda c: print(c.name, c.thought),
+                       on_tool_result=lambda r: print(r.output))
+    print(result.final_text)
 """
+
+from .errors import (
+    LLMError,
+    LLMConfigError,
+    LLMAuthError,
+    LLMBackendError,
+    LLMRateLimitError,
+    LLMUserAbort,
+)
+from .events import TextDelta, ToolCall, ToolResult, TurnComplete
+from .config import Config, load_config
+from .presets import Preset, BUILTIN_PRESETS, resolve_preset
+from .session import Session
+
+__all__ = [
+    "Session",
+    "Config", "load_config",
+    "Preset", "BUILTIN_PRESETS", "resolve_preset",
+    "TextDelta", "ToolCall", "ToolResult", "TurnComplete",
+    "LLMError", "LLMConfigError", "LLMAuthError",
+    "LLMBackendError", "LLMRateLimitError", "LLMUserAbort",
+]

--- a/toksearch/llm/backends/__init__.py
+++ b/toksearch/llm/backends/__init__.py
@@ -2,4 +2,13 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Backend implementations for toksearch.llm."""

--- a/toksearch/llm/backends/__init__.py
+++ b/toksearch/llm/backends/__init__.py
@@ -11,4 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Backend implementations for toksearch.llm."""
+"""Backend registry and class lookup for toksearch.llm."""
+
+from ..errors import LLMConfigError
+
+
+def get_backend_class(name: str):
+    """Resolve a backend-class name (e.g. 'anthropic', 'openai') to its class.
+
+    Imports the concrete class lazily so the import of ``toksearch.llm.backends``
+    doesn't require ``anthropic`` / ``openai`` SDKs to be installed.
+    """
+    if name == "anthropic":
+        from .anthropic import AnthropicBackend
+        return AnthropicBackend
+    if name == "openai":
+        from .openai import OpenAIBackend
+        return OpenAIBackend
+    raise LLMConfigError(
+        f"Unknown backend: {name!r}. Known: anthropic, openai. "
+        "(claude-max is added in PR 3.)")

--- a/toksearch/llm/backends/__init__.py
+++ b/toksearch/llm/backends/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""Backend implementations for toksearch.llm."""

--- a/toksearch/llm/backends/anthropic.py
+++ b/toksearch/llm/backends/anthropic.py
@@ -1,0 +1,136 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""AnthropicBackend — driver for the Anthropic Messages API.
+
+Also serves AmSC and any other Anthropic-compatible endpoint via the
+``base_url`` constructor argument (set by preset resolution).
+
+PR 1 uses the blocking, non-streaming API.  Streaming text deltas are deferred
+to a follow-up PR.
+"""
+
+import anthropic
+
+from ..errors import LLMAuthError, LLMBackendError, LLMRateLimitError
+from ..messages import (
+    Message, TextBlock, ToolResultBlock, ToolUseBlock,
+)
+from .base import AssistantTurn, _ToolLoopBackend
+
+
+class AnthropicBackend(_ToolLoopBackend):
+    name = "anthropic"
+    default_model = "claude-sonnet-4-6"
+
+    def __init__(
+        self,
+        api_key: str | None,
+        base_url: str | None = None,
+        max_tokens: int = 4096,
+    ):
+        self._api_key = api_key
+        self._base_url = base_url
+        self._max_tokens = max_tokens
+        self._client = None  # lazy; tests inject a mock
+
+    def _build_client(self):
+        kwargs = {}
+        if self._api_key is not None:
+            kwargs["api_key"] = self._api_key
+        if self._base_url is not None:
+            kwargs["base_url"] = self._base_url
+        self._client = anthropic.Anthropic(**kwargs)
+        return self._client
+
+    def _ensure_client(self):
+        if self._client is None:
+            self._build_client()
+        return self._client
+
+    # ---- Translation: ToolSpec -> Anthropic tool schema ----
+
+    @staticmethod
+    def _spec_to_native(spec) -> dict:
+        return {
+            "name": spec.name,
+            "description": spec.description,
+            "input_schema": spec.input_schema,
+        }
+
+    # ---- Translation: our Message list -> Anthropic messages= ----
+
+    @staticmethod
+    def _history_to_native(history: list[Message]) -> list[dict]:
+        out = []
+        for m in history:
+            native_blocks = []
+            for b in m.content:
+                if isinstance(b, TextBlock):
+                    native_blocks.append({"type": "text", "text": b.text})
+                elif isinstance(b, ToolUseBlock):
+                    native_blocks.append({
+                        "type": "tool_use",
+                        "id": b.id, "name": b.name, "input": b.args,
+                    })
+                elif isinstance(b, ToolResultBlock):
+                    native_blocks.append({
+                        "type": "tool_result",
+                        "tool_use_id": b.tool_use_id,
+                        "content": b.output,
+                        "is_error": b.is_error,
+                    })
+            out.append({"role": m.role, "content": native_blocks})
+        return out
+
+    # ---- Translation: Anthropic response.content -> our ContentBlock list ----
+
+    @staticmethod
+    def _response_to_blocks(content) -> list:
+        out = []
+        for blk in content:
+            if blk.type == "text":
+                out.append(TextBlock(text=blk.text))
+            elif blk.type == "tool_use":
+                out.append(ToolUseBlock(id=blk.id, name=blk.name,
+                                         args=dict(blk.input)))
+        return out
+
+    # ---- Main entrypoint called by _ToolLoopBackend ----
+
+    def _send_request(self, *, system_prompt, history, tools, model,
+                      on_text=None) -> AssistantTurn:
+        client = self._ensure_client()
+        try:
+            resp = client.messages.create(
+                model=model,
+                max_tokens=self._max_tokens,
+                system=system_prompt,
+                messages=self._history_to_native(history),
+                tools=[self._spec_to_native(t) for t in tools],
+            )
+        except anthropic.AuthenticationError as e:
+            raise LLMAuthError(
+                "Anthropic auth failed. Set ANTHROPIC_API_KEY or pass "
+                "api_key=... to the backend.") from e
+        except anthropic.RateLimitError as e:
+            raise LLMRateLimitError(str(e)) from e
+        except anthropic.APIConnectionError as e:
+            raise LLMBackendError(f"Network error: {e}") from e
+        except anthropic.APIStatusError as e:
+            raise LLMBackendError(f"Anthropic API error: {e}") from e
+        blocks = self._response_to_blocks(resp.content)
+        text_total = "".join(b.text for b in blocks if isinstance(b, TextBlock))
+        if text_total and on_text is not None:
+            on_text(text_total)
+        return AssistantTurn(blocks=blocks, stop_reason=resp.stop_reason)

--- a/toksearch/llm/backends/base.py
+++ b/toksearch/llm/backends/base.py
@@ -1,0 +1,154 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Backend ABC and the shared tool-use loop.
+
+``_ToolLoopBackend`` holds the loop that all raw-API backends (Anthropic,
+OpenAI, AmSC-via-preset) share.  Subclasses implement only:
+
+- ``_send_request(system_prompt, history, tools, model, on_text)`` returning
+  an ``AssistantTurn``.
+- Translation helpers between our ``ContentBlock`` / ``ToolSpec`` taxonomy and
+  the provider's native shapes.
+
+Streaming text is deferred to a follow-up PR.  In PR 1, ``_send_request`` is
+expected to be non-streaming; it MAY call ``on_text`` once at the end with the
+full assistant text, but the loop does not require it.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Callable, Literal
+
+from ..events import TextDelta, ToolCall, ToolResult, TurnComplete
+from ..messages import Message, TextBlock, ToolUseBlock, ToolResultBlock
+
+
+@dataclass
+class AssistantTurn:
+    """One assistant round-trip from a backend.
+
+    ``blocks`` is the assistant's content this turn (text + tool_use mixed).
+    ``stop_reason`` mirrors the provider's stop reason; ``"tool_use"`` means
+    the loop should execute tools and call ``_send_request`` again.
+    """
+
+    blocks: list  # list[ContentBlock]
+    stop_reason: Literal["tool_use", "end_turn", "max_tokens", "stop_sequence"]
+
+
+@dataclass
+class Callbacks:
+    on_text: Callable[[str], None] | None = None
+    on_tool_call: Callable[[ToolCall], None] | None = None
+    on_tool_result: Callable[[ToolResult], None] | None = None
+    on_event: Callable[[object], None] | None = None
+    confirm: Callable[[ToolCall], bool] | None = None
+
+    def fire_text(self, text: str) -> None:
+        if self.on_text is not None:
+            self.on_text(text)
+        if self.on_event is not None:
+            self.on_event(TextDelta(text=text))
+
+    def fire_tool_call(self, e: ToolCall) -> None:
+        if self.on_tool_call is not None:
+            self.on_tool_call(e)
+        if self.on_event is not None:
+            self.on_event(e)
+
+    def fire_tool_result(self, e: ToolResult) -> None:
+        if self.on_tool_result is not None:
+            self.on_tool_result(e)
+        if self.on_event is not None:
+            self.on_event(e)
+
+    def fire_turn_complete(self, e: TurnComplete) -> None:
+        if self.on_event is not None:
+            self.on_event(e)
+
+
+class Backend(ABC):
+    """Pluggable LLM provider.
+
+    Subclasses advance the conversation by one user-message worth of work,
+    dispatching ``Callbacks`` events along the way.
+    """
+
+    name: str
+    default_model: str
+
+    @abstractmethod
+    def run_conversation(
+        self,
+        session,
+        new_user_message: str,
+        callbacks: Callbacks,
+        max_iterations: int,
+    ) -> TurnComplete:
+        ...
+
+
+class _ToolLoopBackend(Backend):
+    """Shared tool-use loop for raw-API backends (Anthropic, OpenAI)."""
+
+    @abstractmethod
+    def _send_request(self, *, system_prompt, history, tools, model,
+                      on_text=None) -> AssistantTurn:
+        ...
+
+    def run_conversation(self, session, new_user_message, callbacks,
+                          max_iterations):
+        session._append_user(new_user_message)
+        final_text = ""
+        for _ in range(max_iterations):
+            turn = self._send_request(
+                system_prompt=session.system_prompt,
+                history=session.history,
+                tools=session.tool_specs,
+                model=session.model,
+                on_text=callbacks.fire_text,
+            )
+            session._append_assistant(turn.blocks)
+            tool_use_blocks = [b for b in turn.blocks
+                               if isinstance(b, ToolUseBlock)]
+            text_blocks = [b for b in turn.blocks
+                           if isinstance(b, TextBlock)]
+            if text_blocks:
+                final_text = text_blocks[-1].text
+            for block in tool_use_blocks:
+                call = ToolCall(
+                    id=block.id, name=block.name, args=block.args,
+                    thought=block.args.get("thought")
+                            if block.name == "run_python" else None,
+                )
+                callbacks.fire_tool_call(call)
+                if callbacks.confirm is not None and not callbacks.confirm(call):
+                    result = TurnComplete(stop_reason="interrupted", final_text="")
+                    callbacks.fire_turn_complete(result)
+                    return result
+                output = session._execute_tool(block)
+                event = ToolResult(id=block.id, output=output.text,
+                                    is_error=output.is_error)
+                callbacks.fire_tool_result(event)
+                session._append_tool_result(block.id, output.text,
+                                             output.is_error)
+            if turn.stop_reason != "tool_use":
+                result = TurnComplete(stop_reason="end_turn",
+                                       final_text=final_text)
+                callbacks.fire_turn_complete(result)
+                return result
+        result = TurnComplete(stop_reason="max_iterations",
+                               final_text=final_text)
+        callbacks.fire_turn_complete(result)
+        return result

--- a/toksearch/llm/backends/fake.py
+++ b/toksearch/llm/backends/fake.py
@@ -1,0 +1,55 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""FakeBackend — testing seam for Session-level tests.
+
+Subclasses ``_ToolLoopBackend`` so the standard loop drives it.  ``_send_request``
+pops one scripted ``AssistantTurn`` per call.  Optionally records each
+``_send_request`` invocation for inspection.
+"""
+
+from .base import _ToolLoopBackend, AssistantTurn
+
+
+class FakeBackend(_ToolLoopBackend):
+    name = "fake"
+    default_model = "fake-1"
+
+    def __init__(self, scripted_turns=None, record=None):
+        self._turns = list(scripted_turns or [])
+        self._record = record  # list to append call dicts to, or None
+        self._user_message_pending = None
+
+    def run_conversation(self, session, new_user_message, callbacks,
+                          max_iterations):
+        # Capture the user message so _send_request can record it for the
+        # first call of this conversation.
+        self._user_message_pending = new_user_message
+        return super().run_conversation(session, new_user_message, callbacks,
+                                          max_iterations)
+
+    def _send_request(self, *, system_prompt, history, tools, model,
+                      on_text=None) -> AssistantTurn:
+        if not self._turns:
+            raise RuntimeError("FakeBackend script exhausted")
+        if self._record is not None:
+            self._record.append({
+                "system_prompt": system_prompt,
+                "history": list(history),
+                "tools": list(tools),
+                "model": model,
+                "user_message": self._user_message_pending,
+            })
+            # Only attribute the user_message to the first call per turn
+            self._user_message_pending = None
+        return self._turns.pop(0)

--- a/toksearch/llm/backends/openai.py
+++ b/toksearch/llm/backends/openai.py
@@ -1,0 +1,157 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OpenAIBackend — driver for the OpenAI Chat Completions API.
+
+PR 1: blocking (non-streaming) API only.  Tool-arg streaming reassembly is
+deferred to a follow-up PR.
+"""
+
+import json
+
+import openai
+
+from ..errors import LLMAuthError, LLMBackendError, LLMRateLimitError
+from ..messages import (
+    Message, TextBlock, ToolResultBlock, ToolUseBlock,
+)
+from .base import AssistantTurn, _ToolLoopBackend
+
+
+class OpenAIBackend(_ToolLoopBackend):
+    name = "openai"
+    default_model = "gpt-4o"
+
+    def __init__(self, api_key: str | None, base_url: str | None = None):
+        self._api_key = api_key
+        self._base_url = base_url
+        self._client = None  # lazy
+
+    def _build_client(self):
+        kwargs = {}
+        if self._api_key is not None:
+            kwargs["api_key"] = self._api_key
+        if self._base_url is not None:
+            kwargs["base_url"] = self._base_url
+        self._client = openai.OpenAI(**kwargs)
+        return self._client
+
+    def _ensure_client(self):
+        if self._client is None:
+            self._build_client()
+        return self._client
+
+    # ---- Translation: ToolSpec -> OpenAI tool schema ----
+
+    @staticmethod
+    def _spec_to_native(spec) -> dict:
+        return {
+            "type": "function",
+            "function": {
+                "name": spec.name,
+                "description": spec.description,
+                "parameters": spec.input_schema,
+            },
+        }
+
+    # ---- Translation: our Message list -> OpenAI messages= ----
+
+    @classmethod
+    def _history_to_native(cls, system_prompt: str,
+                            history: list[Message]) -> list[dict]:
+        out = [{"role": "system", "content": system_prompt}]
+        for m in history:
+            if m.role == "user":
+                # Could be a plain text user message OR a tool_result-only user
+                # message.  OpenAI represents tool results as separate
+                # role="tool" messages, so split them out.
+                text_parts = [b.text for b in m.content
+                              if isinstance(b, TextBlock)]
+                if text_parts:
+                    out.append({"role": "user",
+                                "content": "\n".join(text_parts)})
+                for b in m.content:
+                    if isinstance(b, ToolResultBlock):
+                        content = b.output
+                        if b.is_error:
+                            content = "[error]\n" + content
+                        out.append({"role": "tool",
+                                    "tool_call_id": b.tool_use_id,
+                                    "content": content})
+            elif m.role == "assistant":
+                text_parts = [b.text for b in m.content
+                              if isinstance(b, TextBlock)]
+                tool_uses = [b for b in m.content
+                             if isinstance(b, ToolUseBlock)]
+                msg = {"role": "assistant",
+                       "content": "\n".join(text_parts) if text_parts else None}
+                if tool_uses:
+                    msg["tool_calls"] = [{
+                        "id": b.id,
+                        "type": "function",
+                        "function": {"name": b.name,
+                                      "arguments": json.dumps(b.args)},
+                    } for b in tool_uses]
+                out.append(msg)
+        return out
+
+    # ---- Translation: OpenAI response -> our ContentBlock list ----
+
+    @staticmethod
+    def _response_to_blocks(message) -> list:
+        out = []
+        if message.content:
+            out.append(TextBlock(text=message.content))
+        for tc in (message.tool_calls or []):
+            try:
+                args = json.loads(tc.function.arguments)
+            except json.JSONDecodeError:
+                args = {"_raw": tc.function.arguments}
+            out.append(ToolUseBlock(id=tc.id, name=tc.function.name,
+                                     args=args))
+        return out
+
+    # ---- Stop-reason translation ----
+
+    @staticmethod
+    def _stop_reason(finish_reason: str) -> str:
+        return "tool_use" if finish_reason == "tool_calls" else "end_turn"
+
+    # ---- Main entrypoint ----
+
+    def _send_request(self, *, system_prompt, history, tools, model,
+                      on_text=None) -> AssistantTurn:
+        client = self._ensure_client()
+        try:
+            resp = client.chat.completions.create(
+                model=model,
+                messages=self._history_to_native(system_prompt, history),
+                tools=[self._spec_to_native(t) for t in tools],
+            )
+        except openai.AuthenticationError as e:
+            raise LLMAuthError(
+                "OpenAI auth failed. Set OPENAI_API_KEY or pass api_key=... "
+                "to the backend.") from e
+        except openai.RateLimitError as e:
+            raise LLMRateLimitError(str(e)) from e
+        except openai.APIConnectionError as e:
+            raise LLMBackendError(f"Network error: {e}") from e
+        except openai.APIStatusError as e:
+            raise LLMBackendError(f"OpenAI API error: {e}") from e
+        choice = resp.choices[0]
+        blocks = self._response_to_blocks(choice.message)
+        text_total = "".join(b.text for b in blocks if isinstance(b, TextBlock))
+        if text_total and on_text is not None:
+            on_text(text_total)
+        return AssistantTurn(blocks=blocks,
+                              stop_reason=self._stop_reason(choice.finish_reason))

--- a/toksearch/llm/cli.py
+++ b/toksearch/llm/cli.py
@@ -35,6 +35,9 @@ from .session import Session
 def build_session(args) -> Session:
     """Construct a Session from parsed CLI args."""
     cfg = load_config()
+    # Default backend is "anthropic" in PR 1; PR 4 will register the "amsc"
+    # preset (via toksearch_d3d entry point) and the default will move to
+    # "amsc" to preserve the existing fdp query behavior for GA-on-prem users.
     backend_name = args.backend or cfg.backend or "anthropic"
     preset = resolve_preset(backend_name, cfg)
     backend_cls = get_backend_class(preset.backend)
@@ -48,6 +51,28 @@ def build_session(args) -> Session:
 
 
 def _resolve_api_key(preset, cfg) -> str | None:
+    """Resolve the API key for a preset.
+
+    Lookup order:
+      1. ``preset.api_key_env``: read from os.environ.
+      2. ``preset.api_key_file``: read from disk (~ expanded).
+      3. Built-in preset hardcoded fallback (``cfg.anthropic_api_key`` for
+         ``anthropic``, ``cfg.openai_api_key`` for ``openai``).
+      4. None.
+    """
+    import os
+    from pathlib import Path
+    if preset.api_key_env:
+        val = os.environ.get(preset.api_key_env)
+        if val:
+            return val
+    if preset.api_key_file:
+        path = Path(preset.api_key_file).expanduser()
+        if path.exists():
+            try:
+                return path.read_text().strip()
+            except OSError:
+                pass
     if preset.backend == "anthropic":
         return cfg.anthropic_api_key
     if preset.backend == "openai":

--- a/toksearch/llm/cli.py
+++ b/toksearch/llm/cli.py
@@ -1,0 +1,173 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Command-line interface for toksearch.llm.
+
+Subcommands:
+- ``toksearch query "<prompt>"`` — one-shot; runs a single turn and prints output.
+- ``toksearch chat`` — interactive REPL (plain ``input()``; prompt_toolkit-based
+  UI is deferred to a follow-up PR).
+
+The CLI delegates everything substantive to ``Session``.  ``build_session(args)``
+is the seam tests mock to avoid constructing a real backend.
+"""
+
+import argparse
+import sys
+
+from .config import load_config
+from .errors import LLMConfigError, LLMError
+from .presets import resolve_preset
+from .backends import get_backend_class
+from .session import Session
+
+
+def build_session(args) -> Session:
+    """Construct a Session from parsed CLI args."""
+    cfg = load_config()
+    backend_name = args.backend or cfg.backend or "anthropic"
+    preset = resolve_preset(backend_name, cfg)
+    backend_cls = get_backend_class(preset.backend)
+    api_key = _resolve_api_key(preset, cfg)
+    backend = backend_cls(api_key=api_key, base_url=preset.base_url)
+    return Session(
+        backend=backend,
+        model=args.model or preset.model,
+        max_iterations=args.max_iterations or cfg.max_iterations,
+    )
+
+
+def _resolve_api_key(preset, cfg) -> str | None:
+    if preset.backend == "anthropic":
+        return cfg.anthropic_api_key
+    if preset.backend == "openai":
+        return cfg.openai_api_key
+    return None
+
+
+# ----------------------------------------------------------------------
+# `toksearch query`
+# ----------------------------------------------------------------------
+
+def _print_tool_call(call):
+    print(f"\n[{call.name}] {call.thought or ''}".rstrip())
+    code = call.args.get("code")
+    if code:
+        for line in code.splitlines():
+            print(f"  {line}")
+
+
+def _print_tool_result(result):
+    label = "[output]" if not result.is_error else "[error]"
+    body = result.output or ""
+    for line in body.splitlines():
+        print(f"  {line}")
+    if not body:
+        print(f"{label} (empty)")
+
+
+def do_query(args):
+    session = build_session(args)
+    try:
+        result = session.send(
+            args.query,
+            on_text=lambda t: print(t, end="", flush=True),
+            on_tool_call=_print_tool_call,
+            on_tool_result=_print_tool_result,
+        )
+    except LLMError as e:
+        print(f"\nerror: {e}", file=sys.stderr)
+        sys.exit(1)
+    print()  # final newline
+    sys.exit(0 if result.stop_reason == "end_turn" else 2)
+
+
+# ----------------------------------------------------------------------
+# `toksearch chat`
+# ----------------------------------------------------------------------
+
+_HELP_TEXT = """\
+Slash commands:
+  /help   show this help
+  /reset  clear history and namespace
+  /quit   exit the chat (ctrl-D also works)
+"""
+
+
+def do_chat(args):
+    session = build_session(args)
+    print(f"toksearch chat (backend: {session.backend.name}, "
+          f"model: {session.model})")
+    print("Type /help for commands. Ctrl-D to exit.\n")
+    while True:
+        try:
+            line = input("you> ").strip()
+        except EOFError:
+            print()
+            return
+        if not line:
+            continue
+        if line == "/quit":
+            return
+        if line == "/help":
+            print(_HELP_TEXT)
+            continue
+        if line == "/reset":
+            session.reset()
+            print("(session cleared)")
+            continue
+        try:
+            session.send(
+                line,
+                on_tool_call=_print_tool_call,
+                on_tool_result=_print_tool_result,
+            )
+        except LLMError as e:
+            print(f"error: {e}", file=sys.stderr)
+            continue
+        print()  # spacer between turns
+
+
+# ----------------------------------------------------------------------
+# main
+# ----------------------------------------------------------------------
+
+def _add_common(p):
+    p.add_argument("--backend", default=None,
+                   help="Backend / preset name (anthropic, openai, or a user "
+                        "preset from ~/.fdp/config.toml).")
+    p.add_argument("--model", default=None,
+                   help="Override the preset's default model.")
+    p.add_argument("-n", "--max-iterations", type=int, default=None,
+                   help="Cap on tool-call rounds per turn.")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="toksearch")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    qp = sub.add_parser("query", help="One-shot natural-language query.")
+    qp.add_argument("query", help="The prompt (quote it on the shell).")
+    _add_common(qp)
+    qp.set_defaults(func=do_query)
+
+    cp = sub.add_parser("chat", help="Interactive conversation.")
+    _add_common(cp)
+    cp.set_defaults(func=do_chat)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/toksearch/llm/config.py
+++ b/toksearch/llm/config.py
@@ -1,0 +1,73 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Configuration object and loader for toksearch.llm.
+
+Precedence (highest first):
+  1. CLI flags (applied by callers after ``load_config()`` returns)
+  2. Environment variables: ``FDP_LLM_BACKEND``, ``ANTHROPIC_API_KEY``,
+     ``OPENAI_API_KEY``
+  3. ``~/.fdp/config.toml`` (``[llm]`` table)
+  4. Built-in defaults
+"""
+
+import os
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .errors import LLMConfigError
+
+
+@dataclass
+class Config:
+    backend: str | None = None          # preset name; None → caller's default
+    model: str | None = None            # overrides preset's default model
+    max_iterations: int = 20
+    anthropic_api_key: str | None = None
+    openai_api_key: str | None = None
+    user_presets: dict = field(default_factory=dict)
+
+
+_DEFAULT_CONFIG_PATH = Path.home() / ".fdp" / "config.toml"
+
+
+def load_config(config_path: Path | None = None) -> Config:
+    cfg = Config()
+    path = config_path if config_path is not None else _DEFAULT_CONFIG_PATH
+    if path.exists():
+        try:
+            with path.open("rb") as f:
+                data = tomllib.load(f)
+        except tomllib.TOMLDecodeError as e:
+            raise LLMConfigError(f"Malformed TOML in {path}: {e}") from e
+        llm = data.get("llm", {})
+        if "backend" in llm:
+            cfg.backend = llm["backend"]
+        if "model" in llm:
+            cfg.model = llm["model"]
+        if "max_iterations" in llm:
+            cfg.max_iterations = int(llm["max_iterations"])
+        if "anthropic_api_key" in llm:
+            cfg.anthropic_api_key = llm["anthropic_api_key"]
+        if "openai_api_key" in llm:
+            cfg.openai_api_key = llm["openai_api_key"]
+        cfg.user_presets = llm.get("presets", {})
+    # Env overlay
+    if "FDP_LLM_BACKEND" in os.environ:
+        cfg.backend = os.environ["FDP_LLM_BACKEND"]
+    if "ANTHROPIC_API_KEY" in os.environ:
+        cfg.anthropic_api_key = os.environ["ANTHROPIC_API_KEY"]
+    if "OPENAI_API_KEY" in os.environ:
+        cfg.openai_api_key = os.environ["OPENAI_API_KEY"]
+    return cfg

--- a/toksearch/llm/errors.py
+++ b/toksearch/llm/errors.py
@@ -1,0 +1,43 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Exception hierarchy for toksearch.llm.
+
+All exceptions raised by toksearch.llm inherit from ``LLMError``.  ``LLMUserAbort``
+also inherits from ``KeyboardInterrupt`` so REPL frames can use a single
+``except KeyboardInterrupt`` to handle ctrl-C.
+"""
+
+
+class LLMError(Exception):
+    """Base class for all toksearch.llm exceptions."""
+
+
+class LLMConfigError(LLMError):
+    """Bad configuration: unknown backend, unknown model, malformed preset."""
+
+
+class LLMAuthError(LLMError):
+    """Authentication failure: missing API key, invalid token, 401/403."""
+
+
+class LLMBackendError(LLMError):
+    """Backend returned an unrecoverable error: 5xx, network failure after retries."""
+
+
+class LLMRateLimitError(LLMError):
+    """Rate-limited by the provider; ``Retry-After`` exhausted."""
+
+
+class LLMUserAbort(LLMError, KeyboardInterrupt):
+    """User interrupted the conversation (e.g. ctrl-C between tool calls)."""

--- a/toksearch/llm/events.py
+++ b/toksearch/llm/events.py
@@ -1,0 +1,69 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Event dataclasses dispatched to Session.send() callbacks.
+
+Events are frozen and compare by value.  They are emitted by the active
+``Backend`` while the conversation advances; ``Session.send()`` routes them
+to the appropriate ``on_<kind>`` callback (and to ``on_event`` if provided).
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class TextDelta:
+    """An incremental (or whole, in non-streaming backends) chunk of assistant text."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """The assistant is requesting a tool invocation.
+
+    ``thought`` is populated for ``run_python`` (its schema requires a
+    ``thought`` field) and is ``None`` for tools without one.
+    """
+
+    id: str
+    name: str
+    args: dict
+    thought: str | None
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """The output of a tool invocation, about to be sent back to the model."""
+
+    id: str
+    output: str
+    is_error: bool
+
+
+@dataclass(frozen=True)
+class TurnComplete:
+    """The assistant has finished this turn.
+
+    ``stop_reason``:
+    - ``"end_turn"``: assistant stopped emitting tool calls.
+    - ``"max_iterations"``: hit ``Session.max_iterations`` before end_turn.
+    - ``"interrupted"``: user aborted (ctrl-C) or ``confirm()`` returned False.
+    """
+
+    stop_reason: Literal["end_turn", "max_iterations", "interrupted"]
+    final_text: str
+
+
+Event = TextDelta | ToolCall | ToolResult | TurnComplete

--- a/toksearch/llm/messages.py
+++ b/toksearch/llm/messages.py
@@ -1,0 +1,90 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Provider-neutral conversation history representation.
+
+``Message`` is one turn in the history.  Its ``content`` is a list of
+``ContentBlock``s — a tagged union (``kind`` field) of text, tool-use, and
+tool-result blocks.  Backends translate to and from their native shapes on
+their request/response boundary; the Session and tests see only this taxonomy.
+
+``*_to_dict`` and ``dict_to_*`` helpers provide JSON-safe round-trip so
+``/save`` (future) can serialize the history without provider-specific objects.
+"""
+
+from dataclasses import dataclass, field
+from typing import Literal, Union
+
+
+@dataclass
+class TextBlock:
+    text: str
+    kind: Literal["text"] = "text"
+
+
+@dataclass
+class ToolUseBlock:
+    id: str
+    name: str
+    args: dict
+    kind: Literal["tool_use"] = "tool_use"
+
+
+@dataclass
+class ToolResultBlock:
+    tool_use_id: str
+    output: str
+    is_error: bool
+    kind: Literal["tool_result"] = "tool_result"
+
+
+ContentBlock = Union[TextBlock, ToolUseBlock, ToolResultBlock]
+
+
+@dataclass
+class Message:
+    role: Literal["user", "assistant"]
+    content: list[ContentBlock] = field(default_factory=list)
+
+
+def block_to_dict(b: ContentBlock) -> dict:
+    if isinstance(b, TextBlock):
+        return {"kind": "text", "text": b.text}
+    if isinstance(b, ToolUseBlock):
+        return {"kind": "tool_use", "id": b.id, "name": b.name, "args": b.args}
+    if isinstance(b, ToolResultBlock):
+        return {"kind": "tool_result", "tool_use_id": b.tool_use_id,
+                "output": b.output, "is_error": b.is_error}
+    raise ValueError(f"Unknown block type: {type(b).__name__}")
+
+
+def dict_to_block(d: dict) -> ContentBlock:
+    kind = d.get("kind")
+    if kind == "text":
+        return TextBlock(text=d["text"])
+    if kind == "tool_use":
+        return ToolUseBlock(id=d["id"], name=d["name"], args=d["args"])
+    if kind == "tool_result":
+        return ToolResultBlock(tool_use_id=d["tool_use_id"],
+                               output=d["output"], is_error=d["is_error"])
+    raise ValueError(f"Unknown block kind: {kind!r}")
+
+
+def message_to_dict(m: Message) -> dict:
+    return {"role": m.role,
+            "content": [block_to_dict(b) for b in m.content]}
+
+
+def dict_to_message(d: dict) -> Message:
+    return Message(role=d["role"],
+                   content=[dict_to_block(b) for b in d["content"]])

--- a/toksearch/llm/presets.py
+++ b/toksearch/llm/presets.py
@@ -1,0 +1,82 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Backend presets.
+
+A ``Preset`` is a named configuration that maps a user-facing backend name
+(e.g. ``"anthropic"``, ``"amsc"``, ``"openai"``) to a concrete ``Backend``
+class plus the kwargs needed to construct it.  Presets exist so that
+site-specific endpoints (AmSC's Anthropic-compatible URL, etc.) can be added
+without subclassing ``AnthropicBackend`` just to change a ``base_url``.
+
+Built-in presets ship with core toksearch.  User presets come from
+``~/.fdp/config.toml``'s ``[llm.presets.<name>]`` tables and are merged in via
+``Config.user_presets``.  In PR 2, package-contributed presets will also be
+discovered via the ``toksearch.llm.presets`` entry point.
+"""
+
+from dataclasses import dataclass, field, replace
+
+from .config import Config
+from .errors import LLMConfigError
+
+
+@dataclass(frozen=True)
+class Preset:
+    backend: str                # "anthropic" | "openai" | "claude-max"
+    model: str | None = None
+    base_url: str | None = None
+    api_key_file: str | None = None
+    api_key_env: str | None = None
+    extra: dict = field(default_factory=dict)
+
+
+BUILTIN_PRESETS: dict[str, Preset] = {
+    "anthropic": Preset(
+        backend="anthropic",
+        model="claude-sonnet-4-6",
+        api_key_env="ANTHROPIC_API_KEY",
+    ),
+    "openai": Preset(
+        backend="openai",
+        model="gpt-4o",
+        api_key_env="OPENAI_API_KEY",
+    ),
+}
+
+
+def resolve_preset(name: str, config: Config) -> Preset:
+    """Resolve a preset name to a fully-populated ``Preset``.
+
+    Lookup order: user presets > built-in presets.  When a preset name exists
+    in both, the user preset's fields are merged on top of the built-in.
+    """
+    user = config.user_presets.get(name, {})
+    if name in BUILTIN_PRESETS:
+        base = BUILTIN_PRESETS[name]
+        if user:
+            return replace(base, **{k: v for k, v in user.items()
+                                    if k in {"backend", "model", "base_url",
+                                             "api_key_file", "api_key_env"}})
+        return base
+    if user:
+        try:
+            return Preset(**{k: v for k, v in user.items()
+                             if k in {"backend", "model", "base_url",
+                                      "api_key_file", "api_key_env", "extra"}})
+        except TypeError as e:
+            raise LLMConfigError(f"Invalid user preset {name!r}: {e}") from e
+    raise LLMConfigError(
+        f"Unknown backend / preset: {name!r}. Built-in presets: "
+        f"{sorted(BUILTIN_PRESETS)}. Define a user preset in "
+        f"~/.fdp/config.toml under [llm.presets.{name}].")

--- a/toksearch/llm/prompts.py
+++ b/toksearch/llm/prompts.py
@@ -1,0 +1,69 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""System-prompt assembly.
+
+The kernel prompt is small (~20 lines) and constant.  The dynamic parts —
+the list of contributed packages and the catalog of available skills — are
+built from the Session's installed contributors at construction time.
+"""
+
+from .tools import Skill
+
+
+_KERNEL = """\
+You are a TokSearch expert. Use the run_python tool to execute code that fetches
+and analyzes fusion data. The namespace persists across tool calls in this
+session - variables from earlier calls are available in later ones.
+
+{namespace_section}{catalog_section}Rules:
+- Do not include import statements; common modules are pre-imported.
+- If code raises an error, read the traceback, fix it, and try again.
+- When you have a result, store it in a variable named `result` or describe it
+  in plain text. Do not call any tool to "finish" - just stop emitting tool calls.
+"""
+
+
+def build_system_prompt(
+    skills: dict[str, Skill],
+    namespace_entries: list[tuple[str, str]],
+) -> str:
+    """Build the system prompt from the registered contributors.
+
+    Parameters
+    ----------
+    skills:
+        Mapping of skill name to ``Skill`` (from ``tools.discover_skills``).
+    namespace_entries:
+        List of ``(name, description)`` for each package contributed to the
+        run_python namespace (core toksearch + any extras).
+    """
+    if namespace_entries:
+        lines = ["You have access to fusion data via the following installed packages:"]
+        for name, desc in namespace_entries:
+            lines.append(f"- {name}: {desc}" if desc else f"- {name}")
+        namespace_section = "\n".join(lines) + "\n\n"
+    else:
+        namespace_section = ""
+
+    if skills:
+        lines = ["Available documentation skills (call lookup_docs(skill_name=...) to read):"]
+        for name in sorted(skills):
+            desc = skills[name].description
+            lines.append(f"- {name}: {desc}" if desc else f"- {name}")
+        catalog_section = "\n".join(lines) + "\n\n"
+    else:
+        catalog_section = ""
+
+    return _KERNEL.format(namespace_section=namespace_section,
+                          catalog_section=catalog_section)

--- a/toksearch/llm/session.py
+++ b/toksearch/llm/session.py
@@ -1,0 +1,143 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session — the user-facing object for toksearch.llm.
+
+Owns: history, run_python namespace, tool registry, skill registry, backend.
+"""
+
+from pathlib import Path
+from typing import Callable
+
+from .backends.base import Backend, Callbacks
+from .events import TurnComplete
+from .messages import Message, TextBlock, ToolResultBlock, ToolUseBlock
+from .prompts import build_system_prompt
+from .tools import LOOKUP_DOCS, RUN_PYTHON, ToolOutput, discover_skills
+
+
+def _default_namespace() -> dict:
+    """Build the standard run_python namespace.
+
+    Imports happen here (not at module load) so that simply importing
+    ``toksearch.llm`` doesn't drag in matplotlib / pandas / numpy until the
+    user actually constructs a Session.  toksearch and numpy are required;
+    pandas and matplotlib are optional (matplotlib is in the ``[llm]`` extra
+    but tests run without it).
+    """
+    import toksearch
+    import numpy as np
+    ns = {"toksearch": toksearch, "np": np}
+    try:
+        import pandas as pd
+        ns["pd"] = pd
+    except ImportError:
+        pass
+    try:
+        import matplotlib
+        matplotlib.use("Agg", force=False)  # idempotent; safe in non-GUI envs
+        import matplotlib.pyplot as plt
+        ns["plt"] = plt
+    except ImportError:
+        pass
+    return ns
+
+
+def _core_skill_dir() -> Path:
+    import toksearch
+    return Path(toksearch.__file__).parent / "skills"
+
+
+class Session:
+    """A conversational LLM session over the run_python persistent namespace."""
+
+    def __init__(
+        self,
+        backend: Backend,
+        model: str | None = None,
+        max_iterations: int = 20,
+        extra_namespace: dict | None = None,
+        packages: list[str] | None = None,    # PR 2 plumbing; unused in PR 1
+        extra_skill_dirs: list[Path] | None = None,
+    ):
+        self.backend = backend
+        self.model = model or backend.default_model
+        self.max_iterations = max_iterations
+        self.namespace = _default_namespace()
+        if extra_namespace:
+            self.namespace.update(extra_namespace)
+        # Skills: core toksearch + any extras the caller passed in
+        skill_dirs = [_core_skill_dir()] + list(extra_skill_dirs or [])
+        self.skills = discover_skills(skill_dirs)
+        # Tools: fixed in PR 1; PR 4 may register more.
+        self.tool_specs = [RUN_PYTHON, LOOKUP_DOCS]
+        self._tools_by_name = {t.name: t for t in self.tool_specs}
+        # System prompt: kernel + dynamic catalogs
+        namespace_entries = [
+            ("toksearch", "core pipeline, MdsSignal, ZarrSignal, fetch_dataset"),
+        ]
+        self.system_prompt = build_system_prompt(self.skills, namespace_entries)
+        # History
+        self.history: list[Message] = []
+
+    # ---- Public API ----
+
+    def send(
+        self,
+        prompt: str,
+        *,
+        on_text: Callable[[str], None] | None = None,
+        on_tool_call=None,
+        on_tool_result=None,
+        on_event=None,
+        confirm=None,
+    ) -> TurnComplete:
+        cbs = Callbacks(
+            on_text=on_text,
+            on_tool_call=on_tool_call,
+            on_tool_result=on_tool_result,
+            on_event=on_event,
+            confirm=confirm,
+        )
+        return self.backend.run_conversation(
+            self, prompt, cbs, max_iterations=self.max_iterations,
+        )
+
+    def reset(self) -> None:
+        """Clear history and reset the namespace to its initial pre-populated state."""
+        self.namespace = _default_namespace()
+        self.history = []
+
+    # ---- Hooks called by backends (semi-private) ----
+
+    def _append_user(self, text: str) -> None:
+        self.history.append(Message(role="user",
+                                     content=[TextBlock(text=text)]))
+
+    def _append_assistant(self, blocks) -> None:
+        self.history.append(Message(role="assistant",
+                                     content=list(blocks)))
+
+    def _append_tool_result(self, tool_use_id: str, output: str,
+                             is_error: bool) -> None:
+        self.history.append(Message(role="user", content=[
+            ToolResultBlock(tool_use_id=tool_use_id,
+                            output=output, is_error=is_error)
+        ]))
+
+    def _execute_tool(self, block: ToolUseBlock) -> ToolOutput:
+        spec = self._tools_by_name.get(block.name)
+        if spec is None:
+            return ToolOutput(text=f"Unknown tool: {block.name}",
+                              is_error=True)
+        return spec.handler(block.args, self)

--- a/toksearch/llm/tools.py
+++ b/toksearch/llm/tools.py
@@ -1,0 +1,108 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tools registered with a Session.
+
+Two tools ship in PR 1:
+
+- ``run_python`` — executes Python code in the Session's persistent namespace.
+- ``lookup_docs`` — returns the SKILL.md body for a named skill.
+
+Tool handlers take ``(args: dict, session)`` and return a ``ToolOutput``.
+"""
+
+import io
+import traceback
+from contextlib import redirect_stdout, redirect_stderr
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class ToolOutput:
+    """Result of a tool invocation."""
+
+    text: str
+    is_error: bool = False
+    interrupted: bool = False    # True only when handler caught KeyboardInterrupt
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Backend-agnostic tool descriptor.
+
+    Backends translate ``input_schema`` to their native shape on request build.
+    """
+
+    name: str
+    description: str
+    input_schema: dict
+    handler: Callable[[dict, Any], ToolOutput]
+
+
+# ----------------------------------------------------------------------
+# run_python
+# ----------------------------------------------------------------------
+
+_RUN_PYTHON_DESCRIPTION = (
+    "Execute a Python code string. The execution namespace persists across "
+    "calls within this session, so variables set in earlier calls are "
+    "available later. The namespace is pre-populated with: toksearch, plt "
+    "(matplotlib.pyplot), pd (pandas), np (numpy). Returns captured stdout "
+    "and stderr. Populate 'thought' with a one-sentence description of what "
+    "this code does and why."
+)
+
+
+def _run_python_handler(args: dict, session) -> ToolOutput:
+    code = args["code"]
+    stdout_buf = io.StringIO()
+    stderr_buf = io.StringIO()
+    is_error = False
+    interrupted = False
+    try:
+        with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
+            exec(code, session.namespace)  # noqa: S102 -- intentional
+    except KeyboardInterrupt:
+        return ToolOutput(text="(interrupted)", is_error=True, interrupted=True)
+    except Exception:
+        stderr_buf.write(traceback.format_exc())
+        is_error = True
+    out = stdout_buf.getvalue()
+    err = stderr_buf.getvalue()
+    parts = []
+    if out:
+        parts.append(f"stdout:\n{out}")
+    if err:
+        parts.append(f"stderr:\n{err}")
+    text = "\n".join(parts) if parts else "(no output)"
+    return ToolOutput(text=text, is_error=is_error, interrupted=interrupted)
+
+
+RUN_PYTHON = ToolSpec(
+    name="run_python",
+    description=_RUN_PYTHON_DESCRIPTION,
+    input_schema={
+        "type": "object",
+        "properties": {
+            "code":    {"type": "string",
+                        "description": "Python code to execute."},
+            "thought": {"type": "string",
+                        "description": "One-sentence description of what this "
+                                       "code does and why."},
+        },
+        "required": ["code", "thought"],
+    },
+    handler=_run_python_handler,
+)

--- a/toksearch/llm/tools.py
+++ b/toksearch/llm/tools.py
@@ -106,3 +106,95 @@ RUN_PYTHON = ToolSpec(
     },
     handler=_run_python_handler,
 )
+
+# ----------------------------------------------------------------------
+# lookup_docs + skill discovery
+# ----------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Skill:
+    name: str
+    description: str
+    body: str
+
+
+def parse_skill_md(path: Path) -> tuple[dict, str]:
+    """Return ``(frontmatter, body)`` for a SKILL.md file.
+
+    Frontmatter is the YAML-ish block between two ``---`` lines at the top of
+    the file (we only need ``name`` and ``description`` so we do a tiny
+    line-by-line parser instead of pulling in PyYAML).  If no frontmatter is
+    present, returns ``({}, full_text)``.
+    """
+    text = path.read_text()
+    if text.startswith("---"):
+        _, fm, body = text.split("---", 2)
+        fm_dict = {}
+        for line in fm.strip().splitlines():
+            if ":" in line:
+                k, _, v = line.partition(":")
+                fm_dict[k.strip()] = v.strip()
+        return fm_dict, body.lstrip("\n")
+    return {}, text
+
+
+def discover_skills(skill_dirs: list[Path]) -> dict[str, Skill]:
+    """Return ``{name: Skill}`` for every SKILL.md found under the given dirs.
+
+    Each entry in ``skill_dirs`` is searched one level deep: each subdirectory
+    containing a ``SKILL.md`` becomes a skill named after the subdirectory.
+    Dirs that don't exist are silently skipped.
+    """
+    skills: dict[str, Skill] = {}
+    for d in skill_dirs:
+        if not d.exists():
+            continue
+        for sub in sorted(d.iterdir()):
+            if not sub.is_dir():
+                continue
+            skill_md = sub / "SKILL.md"
+            if not skill_md.exists():
+                continue
+            fm, body = parse_skill_md(skill_md)
+            skills[sub.name] = Skill(
+                name=sub.name,
+                description=fm.get("description", ""),
+                body=body,
+            )
+    return skills
+
+
+_LOOKUP_DOCS_DESCRIPTION = (
+    "Read a documentation skill. Returns the SKILL.md body for one of the "
+    "registered skills. Call this when you need detail on a specific "
+    "toksearch feature beyond what's in the system prompt."
+)
+
+
+def _lookup_docs_handler(args: dict, session) -> ToolOutput:
+    name = args["skill_name"]
+    skill = session.skills.get(name)
+    if skill is None:
+        available = sorted(session.skills)
+        return ToolOutput(
+            text=f"Unknown skill: {name!r}. Available: {available}",
+            is_error=True,
+        )
+    return ToolOutput(text=skill.body, is_error=False)
+
+
+LOOKUP_DOCS = ToolSpec(
+    name="lookup_docs",
+    description=_LOOKUP_DOCS_DESCRIPTION,
+    input_schema={
+        "type": "object",
+        "properties": {
+            "skill_name": {
+                "type": "string",
+                "description": "Name of a skill registered with the Session.",
+            },
+        },
+        "required": ["skill_name"],
+    },
+    handler=_lookup_docs_handler,
+)


### PR DESCRIPTION
## Summary

First PR of the migration from `toksearch_d3d.agents` to a unified, multi-backend, conversational LLM library living in core `toksearch`. Adds the `toksearch/llm/` subpackage end-to-end: `Session`, events, provider-neutral history, tools (`run_python` with persistent namespace, `lookup_docs`), system-prompt assembly, `Backend` ABC + shared `_ToolLoopBackend`, `AnthropicBackend`, `OpenAIBackend`, `FakeBackend` testing seam, `toksearch chat` / `toksearch query` CLI, and console-script wiring.

- 21 commits, ~4400 lines (incl. tests)
- **103 tests passing** (2 integration tests skip without API keys)
- All LLM SDK calls mocked in unit tests; no network at test time
- Design doc: `docs/superpowers/specs/2026-05-18-toksearch-llm-design.md`
- Plan: `docs/superpowers/plans/2026-05-18-toksearch-llm-pr1.md`

**Explicitly deferred to follow-up PRs** (called out in plan & design):
- Streaming text deltas; blocking API in PR 1
- `prompt_toolkit`-based REPL; plain `input()` for now
- Slash commands `/save` `/history` `/namespace` `/backend` `/model`
- `--confirm` flag (the `confirm=` callable on `Session.send` ships)
- Entry-point discovery for namespace / skills / presets contributors (PR 2)
- `ClaudeSDKBackend` for Claude Max plan (PR 3)
- `amsc` preset registration (PR 4, in `toksearch_d3d`)
- `toksearch llm test` connectivity command
- Anthropic `cache_control`
- Retry-with-backoff

## Test plan

- [ ] CI passes `python -m unittest discover -p "test_llm*"` — 103 tests, 2 skipped
- [ ] `pixi run toksearch --help` shows `query` and `chat` subcommands
- [ ] `pixi run python -c "from toksearch.llm import Session"` imports cleanly
- [ ] Manual smoke (Anthropic): `TOKSEARCH_INTEGRATION=yes ANTHROPIC_API_KEY=sk-... pixi run bash -c 'cd tests && python -m unittest test_llm_integration.TestAnthropicIntegration'`
- [ ] Manual smoke (OpenAI): `TOKSEARCH_INTEGRATION=yes OPENAI_API_KEY=sk-... pixi run bash -c 'cd tests && python -m unittest test_llm_integration.TestOpenAIIntegration'`
- [ ] Manual REPL: `ANTHROPIC_API_KEY=sk-... pixi run toksearch chat` — set `x = 5`, then `what is x squared?` confirms namespace persists across turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)