### PR TITLE
toksearch.llm PR 3: Claude Agent SDK backend (Max plan)

### DIFF
--- a/docs/superpowers/plans/2026-05-19-toksearch-llm-pr3.md
+++ b/docs/superpowers/plans/2026-05-19-toksearch-llm-pr3.md
@@ -1,0 +1,930 @@
+# `toksearch.llm` PR 3 — Claude Agent SDK Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Add `ClaudeSDKBackend` so users with a Claude Max plan can drive `toksearch.llm` against their subscription instead of paying API costs. The SDK is intentionally restricted to our two MCP tools (`run_python`, `lookup_docs`) — built-in Claude Code tools (Bash, Read, Edit, Glob, Grep) are NOT enabled. The SDK is "just a way to bill Claude Max for tokens," not a richer agent.
+
+**Architecture:** `ClaudeSDKBackend` does NOT subclass `_ToolLoopBackend` — the SDK runs its own internal loop, and our loop logic doesn't fit. The backend implements `Backend.run_conversation` directly using `claude_agent_sdk.ClaudeSDKClient`. To preserve multi-turn conversational state across `Session.send()` calls (Session is sync; the SDK is async-first), a persistent asyncio event loop runs on a background thread, and each `send()` posts a coroutine via `run_coroutine_threadsafe`. The SDK's internal tool loop calls back into our process via an in-process MCP server (`create_sdk_mcp_server`) whose `run_python` and `lookup_docs` handlers proxy to `session._execute_tool` and dispatch `ToolCall`/`ToolResult` events through the active callbacks.
+
+**Tech Stack:** Python 3.11, `claude-agent-sdk` 0.2+, `mcp` 1.23+ (conda-forge), `asyncio`, `unittest`, `unittest.mock`.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-18-toksearch-llm-design.md` (the `ClaudeSDKBackend` section).
+
+**Branch:** `feat/llm-pr3` off `feat/llm-pr2` (will rebase onto main when PR 2 merges).
+
+## Scope notes
+
+- `allowed_tools` restricts the SDK to exactly two MCP tools we expose: `mcp__toksearch__run_python` and `mcp__toksearch__lookup_docs`. Built-in Claude Code tools are disabled. (Optional `--full-tools` flag deferred.)
+- `permission_mode="bypassPermissions"` — we already surface code via callbacks; the SDK's own permission prompts would be redundant noise.
+- The `claude` CLI must be installed and authenticated (e.g. `claude login`) or `CLAUDE_CODE_OAUTH_TOKEN` set. Auth failure surfaces as `LLMAuthError` with explicit remediation.
+- `claude-agent-sdk` + `mcp` are added to `[project.optional-dependencies].llm` so `pip install toksearch[llm]` gets the SDK. They are lazy-imported in `claude_sdk.py`; the registry catches `ImportError` and re-raises as `LLMConfigError` with install guidance.
+- Persistent event loop runs on a daemon thread; `Session` doesn't expose a `close()` and the loop dies with the process. A `close()` method would be a follow-up if needed.
+- The `confirm=` callback fires INSIDE our MCP tool handlers — same UX as raw API backends.
+
+---
+
+## File Structure
+
+| File | Action | Purpose |
+|---|---|---|
+| `toksearch/llm/backends/claude_sdk.py` | Create | `ClaudeSDKBackend` class, MCP server builder, async bridge. |
+| `toksearch/llm/backends/__init__.py` | Modify | Add `"claude-max"` to `get_backend_class` lazy lookup. |
+| `toksearch/llm/presets.py` | Modify | Add `"claude-max"` to `BUILTIN_PRESETS`. |
+| `toksearch/llm/cli.py` | Modify | `_resolve_api_key` returns None for `claude-max` (SDK uses OAuth, not an API key). |
+| `pyproject.toml` | Modify | Add `claude-agent-sdk` + `mcp` to `[project.optional-dependencies].llm`. |
+| `tests/test_llm_backends_claude_sdk.py` | Create | Mocked-SDK tests for MCP wiring, message translation, run_conversation. |
+| `tests/test_llm_backends_registry.py` | Modify | Add `claude-max` registry test. |
+| `tests/test_llm_presets.py` | Modify | Add `claude-max` builtin preset test. |
+| `tests/test_llm_integration.py` | Modify | Add gated integration test for Claude Max backend. |
+
+---
+
+## Task 1: `claude-max` preset, registry entry, and `ClaudeSDKBackend` skeleton
+
+**Files:**
+- Modify: `toksearch/llm/presets.py`
+- Modify: `toksearch/llm/backends/__init__.py`
+- Modify: `toksearch/llm/cli.py`
+- Create: `toksearch/llm/backends/claude_sdk.py` (skeleton with raising stub)
+- Modify: `tests/test_llm_presets.py`
+- Modify: `tests/test_llm_backends_registry.py`
+
+Use the FULL 13-line Apache 2.0 header (matching `setup.py` lines 1-13) in any new file.
+
+- [ ] **Step 1: Add builtin preset test**
+
+Append to `tests/test_llm_presets.py` (BEFORE `if __name__ == "__main__":`):
+
+```python
+class TestClaudeMaxPreset(unittest.TestCase):
+    def test_claude_max_in_builtins(self):
+        self.assertIn("claude-max", BUILTIN_PRESETS)
+        p = BUILTIN_PRESETS["claude-max"]
+        self.assertEqual(p.backend, "claude-max")
+        # Uses OAuth via `claude` CLI, not an API key env var:
+        self.assertIsNone(p.api_key_env)
+        self.assertIsNone(p.api_key_file)
+
+    def test_resolve_claude_max(self):
+        p = resolve_preset("claude-max", Config())
+        self.assertEqual(p.backend, "claude-max")
+```
+
+- [ ] **Step 2: Add registry test**
+
+Append to `tests/test_llm_backends_registry.py` (BEFORE `if __name__`):
+
+```python
+class TestClaudeMaxBackendClass(unittest.TestCase):
+    def test_get_backend_class_claude_max(self):
+        from toksearch.llm.backends import get_backend_class
+        from toksearch.llm.backends.claude_sdk import ClaudeSDKBackend
+        self.assertIs(get_backend_class("claude-max"), ClaudeSDKBackend)
+```
+
+- [ ] **Step 3: Verify both tests fail**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch && pixi run bash -c 'cd tests && python -m unittest test_llm_presets.TestClaudeMaxPreset test_llm_backends_registry.TestClaudeMaxBackendClass -v'
+```
+
+Expected: `KeyError` / `LLMConfigError` for presets; `ModuleNotFoundError: No module named 'toksearch.llm.backends.claude_sdk'` for registry.
+
+- [ ] **Step 4: Add `claude-max` to `BUILTIN_PRESETS`**
+
+In `/fusion/projects/dt/sammuli/fdp_dev/repos/toksearch/toksearch/llm/presets.py`, find the `BUILTIN_PRESETS` dict. Add `"claude-max"` entry after the existing `"openai"` entry. The final dict:
+
+```python
+BUILTIN_PRESETS: dict[str, Preset] = {
+    "anthropic": Preset(
+        backend="anthropic",
+        model="claude-sonnet-4-6",
+        api_key_env="ANTHROPIC_API_KEY",
+    ),
+    "openai": Preset(
+        backend="openai",
+        model="gpt-4o",
+        api_key_env="OPENAI_API_KEY",
+    ),
+    "claude-max": Preset(
+        backend="claude-max",
+        model=None,  # SDK picks the default; users may override via CLI.
+        api_key_env=None,
+        api_key_file=None,
+    ),
+}
+```
+
+- [ ] **Step 5: Add `claude-max` to backend registry lazy lookup**
+
+Open `/fusion/projects/dt/sammuli/fdp_dev/repos/toksearch/toksearch/llm/backends/__init__.py`. Replace `get_backend_class` with:
+
+```python
+def get_backend_class(name: str):
+    """Resolve a backend-class name to its class.
+
+    Imports the concrete class lazily so the registry import doesn't
+    require ``anthropic``, ``openai``, or ``claude-agent-sdk`` SDKs to be
+    installed.  An ImportError on lazy load is re-raised as ``LLMConfigError``
+    with installation guidance.
+    """
+    if name == "anthropic":
+        from .anthropic import AnthropicBackend
+        return AnthropicBackend
+    if name == "openai":
+        from .openai import OpenAIBackend
+        return OpenAIBackend
+    if name == "claude-max":
+        try:
+            from .claude_sdk import ClaudeSDKBackend
+        except ImportError as e:
+            raise LLMConfigError(
+                "The claude-max backend requires the claude-agent-sdk and "
+                "mcp packages. Install them via `pip install toksearch[llm]` "
+                "or, in pixi-managed envs, add them under [dependencies] in "
+                "pixi.toml.") from e
+        return ClaudeSDKBackend
+    raise LLMConfigError(
+        f"Unknown backend: {name!r}. Known: anthropic, openai, claude-max.")
+```
+
+- [ ] **Step 6: Adjust `_resolve_api_key` for `claude-max`**
+
+Open `/fusion/projects/dt/sammuli/fdp_dev/repos/toksearch/toksearch/llm/cli.py`. Find `_resolve_api_key`. After the existing `preset.api_key_env` / `preset.api_key_file` lookups, BEFORE the `if preset.backend == "anthropic"` block, add:
+
+```python
+    if preset.backend == "claude-max":
+        # ClaudeSDKBackend uses OAuth via the `claude` CLI; no API key.
+        return None
+```
+
+This is conceptually redundant (the function already returns None at the bottom for unknown backends) but it makes the intent explicit and prevents accidental fallthrough if someone later adds a config-level `claude_max_api_key` field.
+
+- [ ] **Step 7: Create `claude_sdk.py` skeleton**
+
+Create `/fusion/projects/dt/sammuli/fdp_dev/repos/toksearch/toksearch/llm/backends/claude_sdk.py` with FULL Apache header, then:
+
+```python
+"""ClaudeSDKBackend - drive toksearch.llm against the Claude Agent SDK.
+
+This backend exists so users with a Claude Max plan can use toksearch.llm
+without paying API costs.  It is deliberately RESTRICTED -- the SDK is
+configured with allowed_tools=["mcp__toksearch__run_python",
+"mcp__toksearch__lookup_docs"] only.  Claude Code's built-in Bash/Read/Edit
+tools are NOT enabled; users who want those should run `claude` directly.
+
+Implementation notes:
+- The SDK is async-first; toksearch.llm.Session.send() is sync.  Bridging
+  is done by running a persistent asyncio event loop on a daemon thread
+  and dispatching coroutines via run_coroutine_threadsafe.
+- The ClaudeSDKClient is reused across send() calls within a Session so
+  the SDK can maintain its own conversation state.
+- The MCP server is in-process (create_sdk_mcp_server returns an
+  McpSdkServerConfig); no subprocess beyond the `claude` CLI itself.
+- Auth is via the `claude` CLI (run `claude login` or set
+  CLAUDE_CODE_OAUTH_TOKEN).  Connection failures raise LLMAuthError.
+"""
+
+import asyncio
+import threading
+from typing import TYPE_CHECKING
+
+import claude_agent_sdk as sdk
+
+from ..errors import LLMAuthError, LLMBackendError
+from ..events import TurnComplete
+from .base import Backend, Callbacks
+
+if TYPE_CHECKING:
+    from ..session import Session
+
+
+class ClaudeSDKBackend(Backend):
+    name = "claude-max"
+    default_model = "claude-sonnet-4-6"  # SDK will pick a reasonable default if None
+
+    def __init__(self, api_key=None, base_url=None):
+        # api_key and base_url are accepted for interface uniformity with
+        # the other backends; both are ignored.  The SDK gets credentials
+        # from `claude login` or CLAUDE_CODE_OAUTH_TOKEN at process start.
+        self._loop = None
+        self._thread = None
+        self._client = None
+        self._current_callbacks = None
+        self._current_session = None
+
+    def run_conversation(self, session, new_user_message, callbacks,
+                          max_iterations):
+        raise NotImplementedError(
+            "ClaudeSDKBackend.run_conversation is implemented in Task 3.")
+```
+
+- [ ] **Step 8: Verify all tests pass**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch && pixi run bash -c 'cd tests && python -m unittest discover -p "test_llm*" 2>&1 | tail -5'
+```
+
+Expected: 125+ tests pass, 2 skipped. The new preset and registry tests should be green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git -C /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch add \
+  toksearch/llm/presets.py \
+  toksearch/llm/backends/__init__.py \
+  toksearch/llm/backends/claude_sdk.py \
+  toksearch/llm/cli.py \
+  tests/test_llm_presets.py \
+  tests/test_llm_backends_registry.py
+git -C /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch commit -m "$(cat <<'EOF'
+Add claude-max preset and ClaudeSDKBackend skeleton
+
+Registry lazily imports claude_sdk and re-raises ImportError as
+LLMConfigError with install guidance. The backend class itself is
+just a stub at this point; Task 2 wires the MCP server and Task 3
+implements run_conversation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: MCP server with `run_python` and `lookup_docs` tools
+
+**Files:**
+- Modify: `toksearch/llm/backends/claude_sdk.py`
+- Create: `tests/test_llm_backends_claude_sdk.py`
+
+This task builds the in-process MCP server that the SDK's internal tool loop will call back into. Each MCP tool fires the active `Callbacks`, executes via `session._execute_tool`, and returns an MCP-shaped result.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `/fusion/projects/dt/sammuli/fdp_dev/repos/toksearch/tests/test_llm_backends_claude_sdk.py` with FULL Apache header, then:
+
+```python
+"""Tests for ClaudeSDKBackend.
+
+The claude_agent_sdk module is real (conda-forge install), but we never
+construct an actual ClaudeSDKClient -- tests inject mocks to verify the
+backend wires options + MCP tools correctly and translates SDK messages
+into our event types.
+"""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from toksearch.llm.backends.base import Callbacks
+from toksearch.llm.backends.claude_sdk import ClaudeSDKBackend
+from toksearch.llm.messages import (
+    Message, TextBlock, ToolUseBlock, ToolResultBlock,
+)
+from toksearch.llm.tools import ToolOutput
+
+
+def _stub_session():
+    """Minimal Session-shaped stub."""
+    s = SimpleNamespace()
+    s.history = []
+    s.namespace = {}
+    s.system_prompt = "sys"
+    s.model = None
+    s.tool_specs = []
+    s.skills = {}
+    s._executed = []
+    def execute_tool(block):
+        s._executed.append(block)
+        if block.name == "run_python":
+            return ToolOutput(text=f"executed: {block.args.get('code')}",
+                              is_error=False)
+        if block.name == "lookup_docs":
+            return ToolOutput(text=f"docs for {block.args.get('skill_name')}",
+                              is_error=False)
+        return ToolOutput(text="unknown", is_error=True)
+    s._append_user = lambda msg: s.history.append(
+        Message(role="user", content=[TextBlock(text=msg)]))
+    s._append_assistant = lambda blocks: s.history.append(
+        Message(role="assistant", content=list(blocks)))
+    s._append_tool_result = lambda tid, out, err: s.history.append(
+        Message(role="user", content=[ToolResultBlock(
+            tool_use_id=tid, output=out, is_error=err)]))
+    s._execute_tool = execute_tool
+    return s
+
+
+class TestMcpToolsRunPython(unittest.TestCase):
+    def test_run_python_tool_proxies_to_session(self):
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        calls, results = [], []
+        backend._current_session = sess
+        backend._current_callbacks = Callbacks(
+            on_tool_call=calls.append,
+            on_tool_result=results.append,
+        )
+        # _run_python_handler is the inner coroutine the MCP tool wraps.
+        result = asyncio.run(backend._run_python_handler(
+            {"code": "x = 1", "thought": "set x"}))
+        # MCP tools return {"content": [{"type": "text", "text": ...}]}
+        self.assertEqual(result["content"][0]["type"], "text")
+        self.assertIn("executed: x = 1", result["content"][0]["text"])
+        # Callbacks fired in order:
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].name, "run_python")
+        self.assertEqual(calls[0].thought, "set x")
+        self.assertEqual(len(results), 1)
+        self.assertIn("executed: x = 1", results[0].output)
+        # Tool result appended to session history
+        self.assertEqual(len(sess.history), 1)
+        block = sess.history[0].content[0]
+        self.assertIsInstance(block, ToolResultBlock)
+
+    def test_run_python_isError_propagates(self):
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        sess._execute_tool = lambda b: ToolOutput(
+            text="ZeroDivisionError", is_error=True)
+        backend._current_session = sess
+        backend._current_callbacks = Callbacks()
+        result = asyncio.run(backend._run_python_handler(
+            {"code": "1/0", "thought": "boom"}))
+        # is_error reflected in the MCP response (text content marked)
+        self.assertTrue(result.get("isError", False))
+
+
+class TestMcpToolsLookupDocs(unittest.TestCase):
+    def test_lookup_docs_tool_proxies_to_session(self):
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        backend._current_session = sess
+        backend._current_callbacks = Callbacks()
+        result = asyncio.run(backend._lookup_docs_handler(
+            {"skill_name": "toksearch-pipeline"}))
+        self.assertEqual(result["content"][0]["type"], "text")
+        self.assertIn("docs for toksearch-pipeline",
+                      result["content"][0]["text"])
+
+
+class TestMcpToolsConfirm(unittest.TestCase):
+    def test_confirm_false_returns_isError(self):
+        """confirm() returning False aborts the tool call with an error result."""
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        backend._current_session = sess
+        backend._current_callbacks = Callbacks(confirm=lambda call: False)
+        result = asyncio.run(backend._run_python_handler(
+            {"code": "x = 1", "thought": "x"}))
+        self.assertTrue(result.get("isError", False))
+        # Session's tool was NOT executed
+        self.assertEqual(sess._executed, [])
+
+
+class TestBuildMcpServer(unittest.TestCase):
+    def test_build_mcp_server_returns_config(self):
+        backend = ClaudeSDKBackend()
+        server = backend._build_mcp_server()
+        # Should be an McpSdkServerConfig (returned by create_sdk_mcp_server).
+        from claude_agent_sdk.types import McpSdkServerConfig
+        self.assertIsInstance(server, McpSdkServerConfig)
+```
+
+- [ ] **Step 2: Verify failing**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch && pixi run bash -c 'cd tests && python -m unittest test_llm_backends_claude_sdk -v'
+```
+
+Expected: `AttributeError: 'ClaudeSDKBackend' object has no attribute '_run_python_handler'` and `_lookup_docs_handler` and `_build_mcp_server`.
+
+- [ ] **Step 3: Add MCP tool handlers and server builder to `ClaudeSDKBackend`**
+
+Open `/fusion/projects/dt/sammuli/fdp_dev/repos/toksearch/toksearch/llm/backends/claude_sdk.py`. Add the following methods to `ClaudeSDKBackend` (place them BEFORE `run_conversation`):
+
+```python
+    # ------------------------------------------------------------------
+    # MCP tool handlers (called by the SDK's internal loop via in-process MCP)
+    # ------------------------------------------------------------------
+
+    async def _run_python_handler(self, args: dict) -> dict:
+        """MCP tool: run_python.  Proxies to session._execute_tool."""
+        from ..events import ToolCall, ToolResult
+        from ..messages import ToolUseBlock
+        import uuid as _uuid
+        sess = self._current_session
+        cbs = self._current_callbacks
+        thought = args.get("thought")
+        call_id = f"sdk-{_uuid.uuid4().hex[:8]}"
+        cbs.fire_tool_call(ToolCall(
+            id=call_id, name="run_python", args=args, thought=thought,
+        ))
+        if cbs.confirm is not None and not cbs.confirm(ToolCall(
+                id=call_id, name="run_python", args=args, thought=thought)):
+            return {
+                "content": [{"type": "text", "text": "(interrupted)"}],
+                "isError": True,
+            }
+        block = ToolUseBlock(id=call_id, name="run_python", args=args)
+        output = sess._execute_tool(block)
+        cbs.fire_tool_result(ToolResult(
+            id=call_id, output=output.text, is_error=output.is_error,
+        ))
+        sess._append_tool_result(call_id, output.text, output.is_error)
+        return {
+            "content": [{"type": "text", "text": output.text}],
+            "isError": output.is_error,
+        }
+
+    async def _lookup_docs_handler(self, args: dict) -> dict:
+        """MCP tool: lookup_docs.  Proxies to session._execute_tool."""
+        from ..events import ToolCall, ToolResult
+        from ..messages import ToolUseBlock
+        import uuid as _uuid
+        sess = self._current_session
+        cbs = self._current_callbacks
+        call_id = f"sdk-{_uuid.uuid4().hex[:8]}"
+        cbs.fire_tool_call(ToolCall(
+            id=call_id, name="lookup_docs", args=args, thought=None,
+        ))
+        block = ToolUseBlock(id=call_id, name="lookup_docs", args=args)
+        output = sess._execute_tool(block)
+        cbs.fire_tool_result(ToolResult(
+            id=call_id, output=output.text, is_error=output.is_error,
+        ))
+        sess._append_tool_result(call_id, output.text, output.is_error)
+        return {
+            "content": [{"type": "text", "text": output.text}],
+            "isError": output.is_error,
+        }
+
+    # ------------------------------------------------------------------
+    # MCP server construction
+    # ------------------------------------------------------------------
+
+    def _build_mcp_server(self):
+        """Construct the in-process MCP server exposing our two tools."""
+        @sdk.tool(
+            "run_python",
+            "Execute a Python code string in the persistent toksearch "
+            "session namespace.",
+            {"code": str, "thought": str},
+        )
+        async def _rp(args):
+            return await self._run_python_handler(args)
+
+        @sdk.tool(
+            "lookup_docs",
+            "Read a documentation skill registered with the session.",
+            {"skill_name": str},
+        )
+        async def _ld(args):
+            return await self._lookup_docs_handler(args)
+
+        return sdk.create_sdk_mcp_server(
+            name="toksearch", version="1.0", tools=[_rp, _ld],
+        )
+```
+
+- [ ] **Step 4: Verify all tests pass**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch && pixi run bash -c 'cd tests && python -m unittest test_llm_backends_claude_sdk -v'
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch add toksearch/llm/backends/claude_sdk.py tests/test_llm_backends_claude_sdk.py
+git -C /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch commit -m "$(cat <<'EOF'
+Add MCP server with run_python and lookup_docs for ClaudeSDKBackend
+
+The two MCP tools proxy to session._execute_tool, fire callbacks before
+and after execution, and honor confirm() by returning an isError result.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Implement `run_conversation` (SDK lifecycle + async-to-sync bridge)
+
+**Files:**
+- Modify: `toksearch/llm/backends/claude_sdk.py`
+- Modify: `tests/test_llm_backends_claude_sdk.py`
+
+This task wires the SDK's `ClaudeSDKClient` into our Session and bridges async-to-sync via a persistent event loop on a daemon thread.
+
+- [ ] **Step 1: Add tests for `run_conversation`**
+
+Append to `tests/test_llm_backends_claude_sdk.py` (BEFORE `if __name__`):
+
+```python
+class TestRunConversation(unittest.TestCase):
+    """Verify run_conversation drives ClaudeSDKClient and translates messages."""
+
+    def _make_async_iter(self, items):
+        async def gen():
+            for item in items:
+                yield item
+        return gen()
+
+    def _mock_client(self, response_messages):
+        """Build a mock ClaudeSDKClient with the given response stream."""
+        client = mock.MagicMock()
+        client.connect = mock.AsyncMock()
+        client.query = mock.AsyncMock()
+        client.receive_response = mock.MagicMock(
+            return_value=self._make_async_iter(response_messages))
+        return client
+
+    def test_single_turn_text_response(self):
+        from claude_agent_sdk import (
+            AssistantMessage, TextBlock as SDKTextBlock, ResultMessage,
+        )
+        msgs = [
+            AssistantMessage(content=[SDKTextBlock(text="hi")], model="m",
+                              parent_tool_use_id=None, error=None,
+                              usage=None, message_id="m1",
+                              stop_reason="end_turn", session_id="s1",
+                              uuid="u1"),
+            ResultMessage(subtype="success", duration_ms=10,
+                           duration_api_ms=5, is_error=False, num_turns=1,
+                           session_id="s1", stop_reason="end_turn",
+                           total_cost_usd=0.001, usage=None,
+                           result="hi", structured_output=None,
+                           model_usage=None, permission_denials=None,
+                           deferred_tool_use=None, errors=None,
+                           api_error_status=None, uuid="u2"),
+        ]
+        client = self._mock_client(msgs)
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        with mock.patch(
+            "toksearch.llm.backends.claude_sdk.sdk.ClaudeSDKClient",
+            return_value=client,
+        ):
+            result = backend.run_conversation(
+                sess, "hello", Callbacks(), max_iterations=5)
+        self.assertEqual(result.stop_reason, "end_turn")
+        self.assertEqual(result.final_text, "hi")
+        # client.query was called with the user message
+        client.query.assert_called_once()
+        # User + assistant in history
+        roles = [m.role for m in sess.history]
+        self.assertEqual(roles, ["user", "assistant"])
+
+    def test_options_configure_mcp_and_allowed_tools(self):
+        """The SDK should be constructed with our MCP server + allowed_tools."""
+        from claude_agent_sdk import ResultMessage
+        msgs = [ResultMessage(
+            subtype="success", duration_ms=1, duration_api_ms=1,
+            is_error=False, num_turns=1, session_id="s",
+            stop_reason="end_turn", total_cost_usd=0.0, usage=None,
+            result="", structured_output=None, model_usage=None,
+            permission_denials=None, deferred_tool_use=None, errors=None,
+            api_error_status=None, uuid="u")]
+        client = self._mock_client(msgs)
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        with mock.patch(
+            "toksearch.llm.backends.claude_sdk.sdk.ClaudeSDKClient",
+            return_value=client,
+        ) as ctor:
+            backend.run_conversation(sess, "hi", Callbacks(),
+                                      max_iterations=5)
+        opts = ctor.call_args.kwargs["options"]
+        self.assertIn("toksearch", opts.mcp_servers)
+        self.assertEqual(
+            sorted(opts.allowed_tools),
+            ["mcp__toksearch__lookup_docs", "mcp__toksearch__run_python"])
+        self.assertEqual(opts.permission_mode, "bypassPermissions")
+
+    def test_connect_failure_raises_auth_error(self):
+        from claude_agent_sdk import CLINotFoundError
+        from toksearch.llm.errors import LLMAuthError
+        client = mock.MagicMock()
+        async def _boom():
+            raise CLINotFoundError("not found")
+        client.connect = _boom
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        with mock.patch(
+            "toksearch.llm.backends.claude_sdk.sdk.ClaudeSDKClient",
+            return_value=client,
+        ), self.assertRaises(LLMAuthError):
+            backend.run_conversation(sess, "hi", Callbacks(),
+                                      max_iterations=5)
+```
+
+- [ ] **Step 2: Verify failing**
+
+- [ ] **Step 3: Implement `run_conversation` and helpers**
+
+Append to `ClaudeSDKBackend` in `/fusion/projects/dt/sammuli/fdp_dev/repos/toksearch/toksearch/llm/backends/claude_sdk.py` (replacing the `raise NotImplementedError` stub from Task 1):
+
+```python
+    # ------------------------------------------------------------------
+    # Async bridge
+    # ------------------------------------------------------------------
+
+    def _ensure_loop(self):
+        """Start the persistent daemon-thread event loop on first use."""
+        if self._loop is not None:
+            return
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._loop.run_forever, daemon=True,
+            name="toksearch-llm-claude-sdk")
+        self._thread.start()
+
+    def _run_coro(self, coro):
+        self._ensure_loop()
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result()
+
+    # ------------------------------------------------------------------
+    # Conversation entry point
+    # ------------------------------------------------------------------
+
+    def run_conversation(self, session, new_user_message, callbacks,
+                          max_iterations) -> TurnComplete:
+        # Stash per-call state for the MCP handlers to read.
+        self._current_session = session
+        self._current_callbacks = callbacks
+        session._append_user(new_user_message)
+        return self._run_coro(self._async_turn(
+            session, new_user_message, callbacks, max_iterations))
+
+    async def _async_turn(self, session, prompt, callbacks, max_iterations):
+        client = await self._get_or_create_client(session, max_iterations)
+        await client.query(prompt)
+        # Collect assistant blocks across all messages from this turn.
+        assistant_blocks: list = []
+        final_text = ""
+        stop_reason = "end_turn"
+        async for msg in client.receive_response():
+            if isinstance(msg, sdk.AssistantMessage):
+                for b in msg.content:
+                    if isinstance(b, sdk.TextBlock):
+                        # Native text deltas can be streamed; fire on_text once
+                        # per AssistantMessage in PR 3 (no chunking).
+                        callbacks.fire_text(b.text)
+                        assistant_blocks.append(
+                            __import__("toksearch.llm.messages",
+                                        fromlist=["TextBlock"]).TextBlock(
+                                text=b.text))
+                        final_text = b.text
+                    elif isinstance(b, sdk.ToolUseBlock):
+                        # The SDK already invoked the tool via our MCP server
+                        # (which appended the tool_result to history).  Record
+                        # the tool_use block in our history too.
+                        TUB = __import__(
+                            "toksearch.llm.messages",
+                            fromlist=["ToolUseBlock"]).ToolUseBlock
+                        assistant_blocks.append(TUB(
+                            id=b.id, name=b.name, args=dict(b.input)))
+            elif isinstance(msg, sdk.ResultMessage):
+                if msg.stop_reason:
+                    if msg.stop_reason in ("end_turn", "max_iterations",
+                                            "interrupted"):
+                        stop_reason = msg.stop_reason
+                    else:
+                        stop_reason = "end_turn"
+                if msg.result:
+                    final_text = msg.result
+                break
+        # Record the full assistant turn at once (after the loop) so the
+        # provider-neutral history shape stays consistent across backends.
+        # Tool-use blocks emitted by the SDK come AFTER their tool_result was
+        # already appended (because the SDK called our MCP handler first);
+        # we keep the chronological order by inserting the assistant turn
+        # before those tool_results.  Simpler approach for PR 3: append the
+        # assistant blocks at the end -- history is informational; backends
+        # don't replay it for the SDK (the SDK owns its session state).
+        if assistant_blocks:
+            session._append_assistant(assistant_blocks)
+        result = TurnComplete(stop_reason=stop_reason, final_text=final_text)
+        callbacks.fire_turn_complete(result)
+        return result
+
+    async def _get_or_create_client(self, session, max_iterations):
+        if self._client is not None:
+            return self._client
+        options = sdk.ClaudeAgentOptions(
+            system_prompt=session.system_prompt,
+            mcp_servers={"toksearch": self._build_mcp_server()},
+            allowed_tools=[
+                "mcp__toksearch__run_python",
+                "mcp__toksearch__lookup_docs",
+            ],
+            permission_mode="bypassPermissions",
+            model=session.model,
+            max_turns=max_iterations,
+        )
+        try:
+            self._client = sdk.ClaudeSDKClient(options=options)
+            await self._client.connect()
+        except sdk.CLINotFoundError as e:
+            raise LLMAuthError(
+                "Could not find the `claude` CLI. Install Claude Code "
+                "(see https://docs.claude.com/en/docs/claude-code) and "
+                "run `claude login` to use the claude-max backend.") from e
+        except sdk.CLIConnectionError as e:
+            raise LLMAuthError(
+                "Failed to connect to the `claude` CLI. Run `claude login` "
+                "or set CLAUDE_CODE_OAUTH_TOKEN. Original error: " + str(e)
+            ) from e
+        except sdk.ClaudeSDKError as e:
+            raise LLMBackendError(f"Claude Agent SDK error: {e}") from e
+        return self._client
+```
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch && pixi run bash -c 'cd tests && python -m unittest test_llm_backends_claude_sdk -v'
+```
+
+Expected: 7 tests pass (4 from Task 2 + 3 new).
+
+Run the full LLM suite:
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch && pixi run bash -c 'cd tests && python -m unittest discover -p "test_llm*" 2>&1 | tail -3'
+```
+
+Expected: 128+ tests, 2 skipped, all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch add toksearch/llm/backends/claude_sdk.py tests/test_llm_backends_claude_sdk.py
+git -C /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch commit -m "$(cat <<'EOF'
+Implement ClaudeSDKBackend.run_conversation
+
+Bridges sync Session.send() to the async ClaudeSDKClient via a persistent
+event loop on a daemon thread. The client is reused across send() calls
+so the SDK maintains its own conversation state. CLI auth failures
+(claude CLI missing or not logged in) surface as LLMAuthError with
+clear remediation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add SDKs to `[llm]` extra and integration test
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `tests/test_llm_integration.py`
+
+- [ ] **Step 1: Add `claude-agent-sdk` and `mcp` to `[project.optional-dependencies].llm`**
+
+In `/fusion/projects/dt/sammuli/fdp_dev/repos/toksearch/pyproject.toml`, find:
+
+```toml
+[project.optional-dependencies]
+llm = ["anthropic>=0.34", "openai>=1.50", "matplotlib"]
+```
+
+Replace with:
+
+```toml
+[project.optional-dependencies]
+llm = [
+    "anthropic>=0.34",
+    "openai>=1.50",
+    "matplotlib",
+    "claude-agent-sdk>=0.2",
+    "mcp>=1.23",
+]
+```
+
+- [ ] **Step 2: Add gated integration test**
+
+Open `/fusion/projects/dt/sammuli/fdp_dev/repos/toksearch/tests/test_llm_integration.py`. After the existing `TestOpenAIIntegration` class, append:
+
+```python
+_HAS_CLAUDE_MAX = os.environ.get("TOKSEARCH_CLAUDE_MAX") == "yes"
+
+
+@unittest.skipUnless(_INTEGRATION_ON and _HAS_CLAUDE_MAX,
+                     "TOKSEARCH_INTEGRATION=yes and TOKSEARCH_CLAUDE_MAX=yes required; "
+                     "the `claude` CLI must be installed and logged in.")
+class TestClaudeMaxIntegration(unittest.TestCase):
+    def test_simple_arithmetic_end_to_end(self):
+        from toksearch.llm.backends.claude_sdk import ClaudeSDKBackend
+        backend = ClaudeSDKBackend()
+        sess = Session(backend=backend, max_iterations=5)
+        result = sess.send(PROMPT)
+        _assert_simple_arithmetic(result, sess)
+```
+
+Note: the Claude Max integration test uses a separate gate (`TOKSEARCH_CLAUDE_MAX=yes`) instead of an API key env var because the SDK uses OAuth via the `claude` CLI. Setting the env var is an explicit opt-in that the user has `claude login` already done.
+
+- [ ] **Step 3: Confirm the test still skips cleanly without the gate**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch && pixi run bash -c 'cd tests && python -m unittest test_llm_integration -v 2>&1 | tail -10'
+```
+
+Expected: all 3 integration tests skip (2 from PR 1 + 1 new).
+
+- [ ] **Step 4: Confirm full LLM suite still passes**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch && pixi run bash -c 'cd tests && python -m unittest discover -p "test_llm*" 2>&1 | tail -3'
+```
+
+Expected: 128+ tests, 3 skipped, all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch add pyproject.toml tests/test_llm_integration.py
+git -C /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch commit -m "$(cat <<'EOF'
+Add claude-agent-sdk to [llm] extra and Claude Max integration test
+
+The integration test is gated on TOKSEARCH_INTEGRATION=yes plus a
+separate TOKSEARCH_CLAUDE_MAX=yes opt-in, because the SDK uses OAuth
+via the `claude` CLI rather than an API key env var -- the opt-in
+makes it explicit that the user has `claude login` set up.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Manual smoke test (operator-run, not automated)
+
+**Files:** none modified.
+
+Requires `claude` CLI installed and `claude login` completed (or `CLAUDE_CODE_OAUTH_TOKEN` set).
+
+- [ ] **Step 1: One-shot query via the SDK**
+
+```bash
+pixi run toksearch query --backend claude-max "Use run_python to compute 2 ** 10 and report the result."
+```
+
+Expected: per-iteration `[run_python] ...` lines, then a final text mentioning `1024`.
+
+- [ ] **Step 2: Multi-turn chat preserves the namespace**
+
+```bash
+pixi run toksearch chat --backend claude-max
+```
+
+In the REPL:
+```
+you> use run_python to set x = 5 and confirm the value
+[...agent output...]
+you> what is x squared?
+[...agent should reference x and compute 25...]
+you> /quit
+```
+
+Expected: second turn references `x` from the first; the persistent namespace works through the MCP-tool path.
+
+- [ ] **Step 3: Negative test — missing `claude` CLI**
+
+```bash
+PATH=/usr/bin:/bin pixi run toksearch query --backend claude-max "hi"
+```
+
+Expected: prints `error: Could not find the \`claude\` CLI...` and exits non-zero.
+
+If any step fails, the failure is either in `run_conversation` (translation/wiring) or `_get_or_create_client` (auth). Both are covered by unit tests; a new smoke failure is worth a follow-up unit test case.
+
+---
+
+## Self-Review Notes
+
+Coverage against the PR 3 scope:
+- ✓ `ClaudeSDKBackend` with `claude-max` backend name → Task 1.
+- ✓ Lazy import in registry with helpful error on missing SDK → Task 1.
+- ✓ Built-in `claude-max` preset → Task 1.
+- ✓ In-process MCP server with `run_python` and `lookup_docs` → Task 2.
+- ✓ `allowed_tools` restricted to our two MCP tools (Bash/Read/Edit/Glob/Grep disabled) → Task 3.
+- ✓ `permission_mode="bypassPermissions"` → Task 3.
+- ✓ Persistent client across `send()` calls via background event loop → Task 3.
+- ✓ `confirm=` callback honored inside MCP handler → Task 2.
+- ✓ Auth error remediation when `claude` CLI missing or unauthenticated → Task 3.
+- ✓ Integration test gated on opt-in env vars → Task 4.
+
+Deferred (explicitly out of scope for PR 3):
+- `--full-tools` flag to also enable Claude Code's built-in tools.
+- Backend `close()` method for explicit cleanup of the event-loop thread.
+- Streaming text deltas (the SDK supports `include_partial_messages=True`; PR 3 fires `on_text` once per AssistantMessage).
+- Cost / usage reporting from `ResultMessage` (we ignore those fields; future PR could surface them via a new event type).

--- a/pixi.lock
+++ b/pixi.lock
@@ -67,6 +67,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/claude-agent-sdk-0.2.82-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
@@ -115,6 +116,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
@@ -242,6 +244,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.9-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py312he3d6523_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mcp-1.27.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/ga-fdp/linux-64/mdsplus-xrdcl-1.0.0-py312ha0f1011_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.0-pyhcf101f3_0.conda
@@ -264,6 +267,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-api-1.41.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.2.2-h19cb568_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
@@ -293,7 +297,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py312h868fb18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pymssql-2.3.12-py312h8285ef7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py312h50ac2ff_1.conda
@@ -301,12 +307,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyspark-4.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_2_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.12-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.29-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hfb55c3c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
@@ -332,7 +341,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-3.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-1.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
@@ -352,6 +363,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.14-h69e2008_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.47.0-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
@@ -1339,6 +1351,22 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 50965
   timestamp: 1760437331772
+- conda: https://conda.anaconda.org/conda-forge/noarch/claude-agent-sdk-0.2.82-pyhcf101f3_0.conda
+  sha256: 533917615004c3ccbaf7f3c64e226ebc5d56e490e829bb8a35416ac3219eada8
+  md5: 2732640df060247faf7909feee73d16a
+  depends:
+  - anyio >=4.0.0
+  - mcp >=1.23.0
+  - python >=3.10
+  - typing_extensions >=4.0.0
+  - sniffio >=1.0.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/claude-agent-sdk?source=hash-mapping
+  size: 201129
+  timestamp: 1778822002464
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
   sha256: 8aee789c82d8fdd997840c952a586db63c6890b00e88c4fb6e80a38edd5f51c0
   md5: 94b550b8d3a614dbd326af798c7dfb40
@@ -1974,6 +2002,18 @@ packages:
   - pkg:pypi/httpx?source=hash-mapping
   size: 63082
   timestamp: 1733663449209
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.3-pyhd8ed1ab_0.conda
+  sha256: afe03faa3d227869d2d645cce2b902b9f76c297207bf5db1670cab56a4b09834
+  md5: d884b0fc71e824093baf8f437d585461
+  depends:
+  - httpx
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/httpx-sse?source=hash-mapping
+  size: 14711
+  timestamp: 1760142772011
 - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.15.0-pyhd8ed1ab_0.conda
   sha256: 71d200fe916b614061dd987cc94c2c373541210564cd74233e0cebf4114b8ac1
   md5: b00e94a6d39ef6b787215a824aa3bedb
@@ -3937,6 +3977,37 @@ packages:
   - pkg:pypi/matplotlib-inline?source=hash-mapping
   size: 15175
   timestamp: 1761214578417
+- conda: https://conda.anaconda.org/conda-forge/noarch/mcp-1.27.1-pyhd8ed1ab_0.conda
+  sha256: 0f58562be3c1606ee35f037f986c9f414e364549b7ad3a93a57108756f3d2b9d
+  md5: f7ba25c38702e69718d886cda5512b57
+  depends:
+  - anyio >=4.5
+  - httpx >=0.27.1,<1.0.0
+  - httpx-sse >=0.4
+  - jsonschema >=4.20.0
+  - opentelemetry-api >=1.28.0
+  - pydantic >=2.12.0,<3.0.0
+  - pydantic-settings >=2.5.2
+  - pyjwt >=2.10.1
+  - python >=3.10
+  - python-dotenv >=1.0.0
+  - python-multipart >=0.0.9
+  - pywin32-on-windows
+  - rich >=13.9.4
+  - sse-starlette >=3.0.0
+  - starlette >=0.27
+  - typer >=0.16.0
+  - typing-extensions >=4.13.0
+  - typing-inspection >=0.4.1
+  - uvicorn >=0.31.1
+  constrains:
+  - pywin32 >=310
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mcp?source=hash-mapping
+  size: 151658
+  timestamp: 1778676274988
 - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.5.0-pyhd8ed1ab_0.conda
   sha256: 123cc004e2946879708cdb6a9eff24acbbb054990d6131bb94bca7a374ebebfc
   md5: 1997a083ef0b4c9331f9191564be275e
@@ -4460,6 +4531,19 @@ packages:
   purls: []
   size: 3164551
   timestamp: 1769555830639
+- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-api-1.41.1-pyhd8ed1ab_1.conda
+  sha256: 8b8efeb5a8f4444a6b5217c1c7159b85e375a045a77d4798d79ffd8ca3441850
+  md5: a6be4f36350136b71bd45412685bae46
+  depends:
+  - importlib-metadata >=6.0,<8.8.0
+  - python >=3.10
+  - typing-extensions >=4.5.0
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/opentelemetry-api?source=hash-mapping
+  size: 48573
+  timestamp: 1777348432839
 - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.2.2-h19cb568_0.conda
   sha256: 84cfe4e11d3186c0c369f111700e978c849fb9e4ab7ed031acbe3663daacd141
   md5: a98b8d7cfdd20004f1bdd1a51cb22c58
@@ -4936,6 +5020,21 @@ packages:
   - pkg:pypi/pydantic-core?source=hash-mapping
   size: 1895409
   timestamp: 1778084226169
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+  sha256: a4ad48b01e5e2640561011d8d48ac038fec66670f24e22c370097747bd9200d2
+  md5: 3b05fc4bb3e31efd3498136b3221c18f
+  depends:
+  - typing-inspection >=0.4.0
+  - python >=3.10
+  - pydantic >=2.7.0
+  - python-dotenv >=0.21.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-settings?source=hash-mapping
+  size: 52280
+  timestamp: 1778254612174
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -4947,6 +5046,21 @@ packages:
   - pkg:pypi/pygments?source=hash-mapping
   size: 889287
   timestamp: 1750615908735
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+  sha256: 4279ee4cf2533fd17910ae7373159d9bee2492d8c50932ddc74dd27a70b15de4
+  md5: b27a9f4eca2925036e43542488d3a804
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.0
+  - python
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyjwt?source=hash-mapping
+  size: 32247
+  timestamp: 1773482160904
 - conda: https://conda.anaconda.org/conda-forge/noarch/pymdown-extensions-10.7.1-pyhd8ed1ab_0.conda
   sha256: 85f7b24ff6b5008725a703f215d71694cb9204e0c5a824fd61742e79615eea3e
   md5: 6f168ac92434bb4ab86a6190eefff35c
@@ -5106,6 +5220,17 @@ packages:
   - pkg:pypi/python-dateutil?source=hash-mapping
   size: 233310
   timestamp: 1751104122689
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
+  sha256: 74e417a768f59f02a242c25e7db0aa796627b5bc8c818863b57786072aeb85e5
+  md5: 130584ad9f3a513cdd71b1fdc1244e9c
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/python-dotenv?source=hash-mapping
+  size: 27848
+  timestamp: 1772388605021
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   sha256: df9aa74e9e28e8d1309274648aac08ec447a92512c33f61a8de0afa9ce32ebe8
   md5: 23029aae904a2ba587daba708208012f
@@ -5139,6 +5264,18 @@ packages:
   - pkg:pypi/python-json-logger?source=hash-mapping
   size: 13383
   timestamp: 1677079727691
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.29-pyhcf101f3_0.conda
+  sha256: 6f5e3b3ffc9fe8feca6d9bbbdde71759d706c2caa3816a381fbd3ee6099ca590
+  md5: 82d9e2a5de24392e4983601e81f8a8a1
+  depends:
+  - python >=3.10
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/python-multipart?source=compressed-mapping
+  size: 37826
+  timestamp: 1779050956843
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2025.3-pyhd8ed1ab_0.conda
   sha256: 467134ef39f0af2dbb57d78cb3e4821f01003488d331a8dd7119334f4f47bfbd
   md5: 7ead57407430ba33f681738905278d03
@@ -5182,6 +5319,17 @@ packages:
   - pkg:pypi/pytz?source=hash-mapping
   size: 189015
   timestamp: 1742920947249
+- conda: https://conda.anaconda.org/conda-forge/noarch/pywin32-on-windows-0.1.0-pyh1179c8e_3.tar.bz2
+  sha256: 6502696aaef571913b22a808b15c185bd8ea4aabb952685deb29e6a6765761cb
+  md5: 2807a0becd1d986fe1ef9b7f8135f215
+  depends:
+  - __unix
+  - python >=2.7
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 4856
+  timestamp: 1646866525560
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
   sha256: f23de6cc72541c6081d3d27482dbc9fc5dd03be93126d9155f06d0cf15d6e90e
   md5: 2160894f57a40d2d629a34ee8497795f
@@ -5657,6 +5805,19 @@ packages:
   - pkg:pypi/soupsieve?source=hash-mapping
   size: 38187
   timestamp: 1769034509657
+- conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-3.4.4-pyhd8ed1ab_0.conda
+  sha256: 0252cf10fa6c4b6e02f90ae887c80f6c6f5c293f73377b5463a96623d6245f61
+  md5: 9dbd1ecbc7a53fbe2aa3a760de3a1df7
+  depends:
+  - anyio >=4.7.0
+  - python >=3.10
+  - starlette >=0.49.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/sse-starlette?source=hash-mapping
+  size: 21861
+  timestamp: 1778622864705
 - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc
@@ -5671,6 +5832,20 @@ packages:
   - pkg:pypi/stack-data?source=hash-mapping
   size: 26988
   timestamp: 1733569565672
+- conda: https://conda.anaconda.org/conda-forge/noarch/starlette-1.0.0-pyhcf101f3_0.conda
+  sha256: 1a1dc376e95491f4b2003f4428e6f7caf4a3de0ef9869248b29dcc9704c34b39
+  md5: 8fbd5b6879350f1b5303c1a652d4b781
+  depends:
+  - anyio >=3.6.2,<5
+  - python >=3.10
+  - typing_extensions >=4.10.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/starlette?source=hash-mapping
+  size: 63717
+  timestamp: 1774215956101
 - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
   sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
   md5: 13dc3adbc692664cd3beabd216434749
@@ -5745,8 +5920,8 @@ packages:
   timestamp: 1764695075374
 - pypi: ./
   name: toksearch
-  version: 2.6.0+19.gd483cca.dirty
-  sha256: 5ce1aefc2a3f59c376462e700864a2ac839c221d9d7199a3eb016109899ca32b
+  version: 2.6.0+29.gf4d2241
+  sha256: 2a60b1e5197c276c7d9c1acc63664b55279f686393c526f381dd75dfac86fe4e
   requires_dist:
   - anthropic>=0.34 ; extra == 'llm'
   - openai>=1.50 ; extra == 'llm'
@@ -5934,6 +6109,22 @@ packages:
   - pkg:pypi/urllib3?source=hash-mapping
   size: 103172
   timestamp: 1767817860341
+- conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.47.0-pyhc90fa1f_0.conda
+  sha256: 8d215db50485e99d1ef1dc796e275f1c26e532994ac7ffa574faa9349ce92650
+  md5: b36eb3071fdf2bedb0ff1bf8386aeb46
+  depends:
+  - __unix
+  - click >=7.0
+  - h11 >=0.8
+  - python >=3.10
+  - typing_extensions >=4.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/uvicorn?source=compressed-mapping
+  size: 56185
+  timestamp: 1778851091795
 - conda: https://conda.anaconda.org/conda-forge/noarch/verspec-0.1.0-pyh29332c3_2.conda
   sha256: 723351de1d7cee8bd22f8ea64b169f36f5c625c315c59c0267fab4bad837d503
   md5: 9c71dfe38494dd49c2547a3842b86fa7

--- a/pixi.lock
+++ b/pixi.lock
@@ -5920,12 +5920,14 @@ packages:
   timestamp: 1764695075374
 - pypi: ./
   name: toksearch
-  version: 2.6.0+29.gf4d2241
-  sha256: 2a60b1e5197c276c7d9c1acc63664b55279f686393c526f381dd75dfac86fe4e
+  version: 2.6.0+35.g97c263d
+  sha256: 191e44f87fbe93f8bc9c0b7425df83d3a8fdb40b1efe03f0f6eb3727392abda2
   requires_dist:
   - anthropic>=0.34 ; extra == 'llm'
   - openai>=1.50 ; extra == 'llm'
   - matplotlib ; extra == 'llm'
+  - claude-agent-sdk>=0.2 ; extra == 'llm'
+  - mcp>=1.23 ; extra == 'llm'
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
   sha256: 62940c563de45790ba0f076b9f2085a842a65662268b02dd136a8e9b1eaf47a8
   md5: 72e780e9aa2d0a3295f59b1874e3768b

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,6 +26,8 @@ pip = "*"
 anthropic = ">=0.34"
 openai = ">=1.50"
 matplotlib = "*"
+claude-agent-sdk = ">=0.2"
+mcp = ">=1.23"
 
 [tasks]
 build = "pip install -e . --no-deps"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,13 @@ dynamic = ["version"]
 toksearch = "toksearch.llm.cli:main"
 
 [project.optional-dependencies]
-llm = ["anthropic>=0.34", "openai>=1.50", "matplotlib"]
+llm = [
+    "anthropic>=0.34",
+    "openai>=1.50",
+    "matplotlib",
+    "claude-agent-sdk>=0.2",
+    "mcp>=1.23",
+]
 
 [project.entry-points."toksearch.llm.namespace"]
 toksearch = "toksearch"

--- a/tests/test_llm_backends_claude_sdk.py
+++ b/tests/test_llm_backends_claude_sdk.py
@@ -1,0 +1,140 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ClaudeSDKBackend.
+
+The claude_agent_sdk module is real (conda-forge install), but we never
+construct an actual ClaudeSDKClient -- tests inject mocks to verify the
+backend wires options + MCP tools correctly and translates SDK messages
+into our event types.
+"""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from toksearch.llm.backends.base import Callbacks
+from toksearch.llm.backends.claude_sdk import ClaudeSDKBackend
+from toksearch.llm.messages import (
+    Message, TextBlock, ToolUseBlock, ToolResultBlock,
+)
+from toksearch.llm.tools import ToolOutput
+
+
+def _stub_session():
+    """Minimal Session-shaped stub."""
+    s = SimpleNamespace()
+    s.history = []
+    s.namespace = {}
+    s.system_prompt = "sys"
+    s.model = None
+    s.tool_specs = []
+    s.skills = {}
+    s._executed = []
+    def execute_tool(block):
+        s._executed.append(block)
+        if block.name == "run_python":
+            return ToolOutput(text=f"executed: {block.args.get('code')}",
+                              is_error=False)
+        if block.name == "lookup_docs":
+            return ToolOutput(text=f"docs for {block.args.get('skill_name')}",
+                              is_error=False)
+        return ToolOutput(text="unknown", is_error=True)
+    s._append_user = lambda msg: s.history.append(
+        Message(role="user", content=[TextBlock(text=msg)]))
+    s._append_assistant = lambda blocks: s.history.append(
+        Message(role="assistant", content=list(blocks)))
+    s._append_tool_result = lambda tid, out, err: s.history.append(
+        Message(role="user", content=[ToolResultBlock(
+            tool_use_id=tid, output=out, is_error=err)]))
+    s._execute_tool = execute_tool
+    return s
+
+
+class TestMcpToolsRunPython(unittest.TestCase):
+    def test_run_python_tool_proxies_to_session(self):
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        calls, results = [], []
+        backend._current_session = sess
+        backend._current_callbacks = Callbacks(
+            on_tool_call=calls.append,
+            on_tool_result=results.append,
+        )
+        # _run_python_handler is the inner coroutine the MCP tool wraps.
+        result = asyncio.run(backend._run_python_handler(
+            {"code": "x = 1", "thought": "set x"}))
+        # MCP tools return {"content": [{"type": "text", "text": ...}]}
+        self.assertEqual(result["content"][0]["type"], "text")
+        self.assertIn("executed: x = 1", result["content"][0]["text"])
+        # Callbacks fired in order:
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].name, "run_python")
+        self.assertEqual(calls[0].thought, "set x")
+        self.assertEqual(len(results), 1)
+        self.assertIn("executed: x = 1", results[0].output)
+        # Tool result appended to session history
+        self.assertEqual(len(sess.history), 1)
+        block = sess.history[0].content[0]
+        self.assertIsInstance(block, ToolResultBlock)
+
+    def test_run_python_isError_propagates(self):
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        sess._execute_tool = lambda b: ToolOutput(
+            text="ZeroDivisionError", is_error=True)
+        backend._current_session = sess
+        backend._current_callbacks = Callbacks()
+        result = asyncio.run(backend._run_python_handler(
+            {"code": "1/0", "thought": "boom"}))
+        # is_error reflected in the MCP response (text content marked)
+        self.assertTrue(result.get("isError", False))
+
+
+class TestMcpToolsLookupDocs(unittest.TestCase):
+    def test_lookup_docs_tool_proxies_to_session(self):
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        backend._current_session = sess
+        backend._current_callbacks = Callbacks()
+        result = asyncio.run(backend._lookup_docs_handler(
+            {"skill_name": "toksearch-pipeline"}))
+        self.assertEqual(result["content"][0]["type"], "text")
+        self.assertIn("docs for toksearch-pipeline",
+                      result["content"][0]["text"])
+
+
+class TestMcpToolsConfirm(unittest.TestCase):
+    def test_confirm_false_returns_isError(self):
+        """confirm() returning False aborts the tool call with an error result."""
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        backend._current_session = sess
+        backend._current_callbacks = Callbacks(confirm=lambda call: False)
+        result = asyncio.run(backend._run_python_handler(
+            {"code": "x = 1", "thought": "x"}))
+        self.assertTrue(result.get("isError", False))
+        # Session's tool was NOT executed
+        self.assertEqual(sess._executed, [])
+
+
+class TestBuildMcpServer(unittest.TestCase):
+    def test_build_mcp_server_returns_config(self):
+        backend = ClaudeSDKBackend()
+        server = backend._build_mcp_server()
+        # McpSdkServerConfig is a TypedDict (subclass of dict); isinstance
+        # against a TypedDict raises TypeError, so we check the underlying type.
+        from claude_agent_sdk.types import McpSdkServerConfig
+        self.assertIsInstance(server, dict)
+        self.assertEqual(server.get("type"), "sdk")

--- a/tests/test_llm_backends_claude_sdk.py
+++ b/tests/test_llm_backends_claude_sdk.py
@@ -17,19 +17,29 @@ The claude_agent_sdk module is real (conda-forge install), but we never
 construct an actual ClaudeSDKClient -- tests inject mocks to verify the
 backend wires options + MCP tools correctly and translates SDK messages
 into our event types.
+
+The test module gracefully skips itself when claude-agent-sdk is not
+installed (e.g. the conda-recipe's minimal test env that omits the
+``[llm]`` optional-dependency extra).
 """
 
-import asyncio
 import unittest
-from types import SimpleNamespace
-from unittest import mock
 
-from toksearch.llm.backends.base import Callbacks
-from toksearch.llm.backends.claude_sdk import ClaudeSDKBackend
-from toksearch.llm.messages import (
-    Message, TextBlock, ToolUseBlock, ToolResultBlock,
-)
-from toksearch.llm.tools import ToolOutput
+try:
+    import asyncio
+    import claude_agent_sdk  # noqa: F401
+    from types import SimpleNamespace
+    from unittest import mock
+
+    from toksearch.llm.backends.base import Callbacks
+    from toksearch.llm.backends.claude_sdk import ClaudeSDKBackend
+    from toksearch.llm.messages import (
+        Message, TextBlock, ToolUseBlock, ToolResultBlock,
+    )
+    from toksearch.llm.tools import ToolOutput
+    _SDK_AVAILABLE = True
+except ImportError:
+    _SDK_AVAILABLE = False
 
 
 def _stub_session():
@@ -62,6 +72,7 @@ def _stub_session():
     return s
 
 
+@unittest.skipUnless(_SDK_AVAILABLE, "claude-agent-sdk not installed")
 class TestMcpToolsRunPython(unittest.TestCase):
     def test_run_python_tool_proxies_to_session(self):
         backend = ClaudeSDKBackend()
@@ -102,6 +113,7 @@ class TestMcpToolsRunPython(unittest.TestCase):
         self.assertTrue(result.get("isError", False))
 
 
+@unittest.skipUnless(_SDK_AVAILABLE, "claude-agent-sdk not installed")
 class TestMcpToolsLookupDocs(unittest.TestCase):
     def test_lookup_docs_tool_proxies_to_session(self):
         backend = ClaudeSDKBackend()
@@ -115,6 +127,7 @@ class TestMcpToolsLookupDocs(unittest.TestCase):
                       result["content"][0]["text"])
 
 
+@unittest.skipUnless(_SDK_AVAILABLE, "claude-agent-sdk not installed")
 class TestMcpToolsConfirm(unittest.TestCase):
     def test_confirm_false_returns_isError(self):
         """confirm() returning False aborts the tool call with an error result."""
@@ -129,6 +142,7 @@ class TestMcpToolsConfirm(unittest.TestCase):
         self.assertEqual(sess._executed, [])
 
 
+@unittest.skipUnless(_SDK_AVAILABLE, "claude-agent-sdk not installed")
 class TestBuildMcpServer(unittest.TestCase):
     def test_build_mcp_server_returns_config(self):
         backend = ClaudeSDKBackend()
@@ -140,6 +154,7 @@ class TestBuildMcpServer(unittest.TestCase):
         self.assertEqual(server.get("type"), "sdk")
 
 
+@unittest.skipUnless(_SDK_AVAILABLE, "claude-agent-sdk not installed")
 class TestRunConversation(unittest.TestCase):
     """Verify run_conversation drives ClaudeSDKClient and translates messages."""
 

--- a/tests/test_llm_backends_claude_sdk.py
+++ b/tests/test_llm_backends_claude_sdk.py
@@ -138,3 +138,104 @@ class TestBuildMcpServer(unittest.TestCase):
         from claude_agent_sdk.types import McpSdkServerConfig
         self.assertIsInstance(server, dict)
         self.assertEqual(server.get("type"), "sdk")
+
+
+class TestRunConversation(unittest.TestCase):
+    """Verify run_conversation drives ClaudeSDKClient and translates messages."""
+
+    def _make_async_iter(self, items):
+        async def gen():
+            for item in items:
+                yield item
+        return gen()
+
+    def _mock_client(self, response_messages):
+        """Build a mock ClaudeSDKClient with the given response stream."""
+        client = mock.MagicMock()
+        client.connect = mock.AsyncMock()
+        client.query = mock.AsyncMock()
+        client.receive_response = mock.MagicMock(
+            return_value=self._make_async_iter(response_messages))
+        return client
+
+    def test_single_turn_text_response(self):
+        from claude_agent_sdk import (
+            AssistantMessage, TextBlock as SDKTextBlock, ResultMessage,
+        )
+        msgs = [
+            AssistantMessage(content=[SDKTextBlock(text="hi")], model="m",
+                              parent_tool_use_id=None, error=None,
+                              usage=None, message_id="m1",
+                              stop_reason="end_turn", session_id="s1",
+                              uuid="u1"),
+            ResultMessage(subtype="success", duration_ms=10,
+                           duration_api_ms=5, is_error=False, num_turns=1,
+                           session_id="s1", stop_reason="end_turn",
+                           total_cost_usd=0.001, usage=None,
+                           result="hi", structured_output=None,
+                           model_usage=None, permission_denials=None,
+                           deferred_tool_use=None, errors=None,
+                           api_error_status=None, uuid="u2"),
+        ]
+        client = self._mock_client(msgs)
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        with mock.patch(
+            "toksearch.llm.backends.claude_sdk.sdk.ClaudeSDKClient",
+            return_value=client,
+        ):
+            result = backend.run_conversation(
+                sess, "hello", Callbacks(), max_iterations=5)
+        self.assertEqual(result.stop_reason, "end_turn")
+        self.assertEqual(result.final_text, "hi")
+        # client.query was called with the user message
+        client.query.assert_called_once()
+        # User + assistant in history
+        roles = [m.role for m in sess.history]
+        self.assertEqual(roles, ["user", "assistant"])
+
+    def test_options_configure_mcp_and_allowed_tools(self):
+        """The SDK should be constructed with our MCP server + allowed_tools."""
+        from claude_agent_sdk import ResultMessage
+        msgs = [ResultMessage(
+            subtype="success", duration_ms=1, duration_api_ms=1,
+            is_error=False, num_turns=1, session_id="s",
+            stop_reason="end_turn", total_cost_usd=0.0, usage=None,
+            result="", structured_output=None, model_usage=None,
+            permission_denials=None, deferred_tool_use=None, errors=None,
+            api_error_status=None, uuid="u")]
+        client = self._mock_client(msgs)
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        with mock.patch(
+            "toksearch.llm.backends.claude_sdk.sdk.ClaudeSDKClient",
+            return_value=client,
+        ) as ctor:
+            backend.run_conversation(sess, "hi", Callbacks(),
+                                      max_iterations=5)
+        opts = ctor.call_args.kwargs["options"]
+        self.assertIn("toksearch", opts.mcp_servers)
+        self.assertEqual(
+            sorted(opts.allowed_tools),
+            ["mcp__toksearch__lookup_docs", "mcp__toksearch__run_python"])
+        self.assertEqual(opts.permission_mode, "bypassPermissions")
+
+    def test_connect_failure_raises_auth_error(self):
+        from claude_agent_sdk import CLINotFoundError
+        from toksearch.llm.errors import LLMAuthError
+        client = mock.MagicMock()
+        async def _boom():
+            raise CLINotFoundError("not found")
+        client.connect = _boom
+        backend = ClaudeSDKBackend()
+        sess = _stub_session()
+        with mock.patch(
+            "toksearch.llm.backends.claude_sdk.sdk.ClaudeSDKClient",
+            return_value=client,
+        ), self.assertRaises(LLMAuthError):
+            backend.run_conversation(sess, "hi", Callbacks(),
+                                      max_iterations=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_backends_registry.py
+++ b/tests/test_llm_backends_registry.py
@@ -17,6 +17,12 @@ import unittest
 
 from toksearch.llm.errors import LLMConfigError
 
+try:
+    import claude_agent_sdk  # noqa: F401
+    _HAS_CLAUDE_SDK = True
+except ImportError:
+    _HAS_CLAUDE_SDK = False
+
 
 class TestBackendRegistry(unittest.TestCase):
     def test_get_backend_class_anthropic(self):
@@ -35,11 +41,33 @@ class TestBackendRegistry(unittest.TestCase):
             get_backend_class("nonexistent")
 
 
+@unittest.skipUnless(_HAS_CLAUDE_SDK, "claude-agent-sdk not installed")
 class TestClaudeMaxBackendClass(unittest.TestCase):
     def test_get_backend_class_claude_max(self):
         from toksearch.llm.backends import get_backend_class
         from toksearch.llm.backends.claude_sdk import ClaudeSDKBackend
         self.assertIs(get_backend_class("claude-max"), ClaudeSDKBackend)
+
+
+class TestClaudeMaxImportErrorMessage(unittest.TestCase):
+    """When claude-agent-sdk is missing, get_backend_class('claude-max') should
+    raise LLMConfigError with installation guidance (rather than ImportError)."""
+
+    def test_helpful_error_when_sdk_missing(self):
+        from toksearch.llm.backends import get_backend_class
+        import sys
+        # Simulate "SDK not installed" by patching the import.
+        from unittest import mock
+        # Remove any cached import so the lazy load actually runs.
+        sdk_modules = [m for m in list(sys.modules)
+                       if m.startswith("toksearch.llm.backends.claude_sdk")
+                       or m.startswith("claude_agent_sdk")]
+        with mock.patch.dict(sys.modules, {m: None for m in sdk_modules}):
+            with self.assertRaises(LLMConfigError) as cm:
+                get_backend_class("claude-max")
+            msg = str(cm.exception)
+            self.assertIn("claude-agent-sdk", msg)
+            self.assertIn("[llm]", msg)
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_backends_registry.py
+++ b/tests/test_llm_backends_registry.py
@@ -35,5 +35,12 @@ class TestBackendRegistry(unittest.TestCase):
             get_backend_class("nonexistent")
 
 
+class TestClaudeMaxBackendClass(unittest.TestCase):
+    def test_get_backend_class_claude_max(self):
+        from toksearch.llm.backends import get_backend_class
+        from toksearch.llm.backends.claude_sdk import ClaudeSDKBackend
+        self.assertIs(get_backend_class("claude-max"), ClaudeSDKBackend)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -86,5 +86,21 @@ class TestOpenAIIntegration(unittest.TestCase):
         _assert_simple_arithmetic(result, sess)
 
 
+_HAS_CLAUDE_MAX = os.environ.get("TOKSEARCH_CLAUDE_MAX") == "yes"
+
+
+@unittest.skipUnless(_INTEGRATION_ON and _HAS_CLAUDE_MAX,
+                     "TOKSEARCH_INTEGRATION=yes and TOKSEARCH_CLAUDE_MAX=yes "
+                     "required; the `claude` CLI must be installed and "
+                     "logged in.")
+class TestClaudeMaxIntegration(unittest.TestCase):
+    def test_simple_arithmetic_end_to_end(self):
+        from toksearch.llm.backends.claude_sdk import ClaudeSDKBackend
+        backend = ClaudeSDKBackend()
+        sess = Session(backend=backend, max_iterations=5)
+        result = sess.send(PROMPT)
+        _assert_simple_arithmetic(result, sess)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_presets.py
+++ b/tests/test_llm_presets.py
@@ -120,5 +120,19 @@ class TestDiscoveredPresets(unittest.TestCase):
         self.assertIsNone(p.base_url)
 
 
+class TestClaudeMaxPreset(unittest.TestCase):
+    def test_claude_max_in_builtins(self):
+        self.assertIn("claude-max", BUILTIN_PRESETS)
+        p = BUILTIN_PRESETS["claude-max"]
+        self.assertEqual(p.backend, "claude-max")
+        # Uses OAuth via `claude` CLI, not an API key env var:
+        self.assertIsNone(p.api_key_env)
+        self.assertIsNone(p.api_key_file)
+
+    def test_resolve_claude_max(self):
+        p = resolve_preset("claude-max", Config())
+        self.assertEqual(p.backend, "claude-max")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/toksearch/llm/backends/__init__.py
+++ b/toksearch/llm/backends/__init__.py
@@ -17,10 +17,12 @@ from ..errors import LLMConfigError
 
 
 def get_backend_class(name: str):
-    """Resolve a backend-class name (e.g. 'anthropic', 'openai') to its class.
+    """Resolve a backend-class name to its class.
 
-    Imports the concrete class lazily so the import of ``toksearch.llm.backends``
-    doesn't require ``anthropic`` / ``openai`` SDKs to be installed.
+    Imports the concrete class lazily so the registry import doesn't
+    require ``anthropic``, ``openai``, or ``claude-agent-sdk`` SDKs to be
+    installed.  An ImportError on lazy load is re-raised as ``LLMConfigError``
+    with installation guidance.
     """
     if name == "anthropic":
         from .anthropic import AnthropicBackend
@@ -28,6 +30,15 @@ def get_backend_class(name: str):
     if name == "openai":
         from .openai import OpenAIBackend
         return OpenAIBackend
+    if name == "claude-max":
+        try:
+            from .claude_sdk import ClaudeSDKBackend
+        except ImportError as e:
+            raise LLMConfigError(
+                "The claude-max backend requires the claude-agent-sdk and "
+                "mcp packages. Install them via `pip install toksearch[llm]` "
+                "or, in pixi-managed envs, add them under [dependencies] in "
+                "pixi.toml.") from e
+        return ClaudeSDKBackend
     raise LLMConfigError(
-        f"Unknown backend: {name!r}. Known: anthropic, openai. "
-        "(claude-max is added in PR 3.)")
+        f"Unknown backend: {name!r}. Known: anthropic, openai, claude-max.")

--- a/toksearch/llm/backends/claude_sdk.py
+++ b/toksearch/llm/backends/claude_sdk.py
@@ -59,6 +59,88 @@ class ClaudeSDKBackend(Backend):
         self._current_callbacks = None
         self._current_session = None
 
+    # ------------------------------------------------------------------
+    # MCP tool handlers (called by the SDK's internal loop via in-process MCP)
+    # ------------------------------------------------------------------
+
+    async def _run_python_handler(self, args: dict) -> dict:
+        """MCP tool: run_python.  Proxies to session._execute_tool."""
+        from ..events import ToolCall, ToolResult
+        from ..messages import ToolUseBlock
+        import uuid as _uuid
+        sess = self._current_session
+        cbs = self._current_callbacks
+        thought = args.get("thought")
+        call_id = f"sdk-{_uuid.uuid4().hex[:8]}"
+        cbs.fire_tool_call(ToolCall(
+            id=call_id, name="run_python", args=args, thought=thought,
+        ))
+        if cbs.confirm is not None and not cbs.confirm(ToolCall(
+                id=call_id, name="run_python", args=args, thought=thought)):
+            return {
+                "content": [{"type": "text", "text": "(interrupted)"}],
+                "isError": True,
+            }
+        block = ToolUseBlock(id=call_id, name="run_python", args=args)
+        output = sess._execute_tool(block)
+        cbs.fire_tool_result(ToolResult(
+            id=call_id, output=output.text, is_error=output.is_error,
+        ))
+        sess._append_tool_result(call_id, output.text, output.is_error)
+        return {
+            "content": [{"type": "text", "text": output.text}],
+            "isError": output.is_error,
+        }
+
+    async def _lookup_docs_handler(self, args: dict) -> dict:
+        """MCP tool: lookup_docs.  Proxies to session._execute_tool."""
+        from ..events import ToolCall, ToolResult
+        from ..messages import ToolUseBlock
+        import uuid as _uuid
+        sess = self._current_session
+        cbs = self._current_callbacks
+        call_id = f"sdk-{_uuid.uuid4().hex[:8]}"
+        cbs.fire_tool_call(ToolCall(
+            id=call_id, name="lookup_docs", args=args, thought=None,
+        ))
+        block = ToolUseBlock(id=call_id, name="lookup_docs", args=args)
+        output = sess._execute_tool(block)
+        cbs.fire_tool_result(ToolResult(
+            id=call_id, output=output.text, is_error=output.is_error,
+        ))
+        sess._append_tool_result(call_id, output.text, output.is_error)
+        return {
+            "content": [{"type": "text", "text": output.text}],
+            "isError": output.is_error,
+        }
+
+    # ------------------------------------------------------------------
+    # MCP server construction
+    # ------------------------------------------------------------------
+
+    def _build_mcp_server(self):
+        """Construct the in-process MCP server exposing our two tools."""
+        @sdk.tool(
+            "run_python",
+            "Execute a Python code string in the persistent toksearch "
+            "session namespace.",
+            {"code": str, "thought": str},
+        )
+        async def _rp(args):
+            return await self._run_python_handler(args)
+
+        @sdk.tool(
+            "lookup_docs",
+            "Read a documentation skill registered with the session.",
+            {"skill_name": str},
+        )
+        async def _ld(args):
+            return await self._lookup_docs_handler(args)
+
+        return sdk.create_sdk_mcp_server(
+            name="toksearch", version="1.0", tools=[_rp, _ld],
+        )
+
     def run_conversation(self, session, new_user_message, callbacks,
                           max_iterations):
         raise NotImplementedError(

--- a/toksearch/llm/backends/claude_sdk.py
+++ b/toksearch/llm/backends/claude_sdk.py
@@ -1,0 +1,65 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ClaudeSDKBackend - drive toksearch.llm against the Claude Agent SDK.
+
+This backend exists so users with a Claude Max plan can use toksearch.llm
+without paying API costs.  It is deliberately RESTRICTED -- the SDK is
+configured with allowed_tools=["mcp__toksearch__run_python",
+"mcp__toksearch__lookup_docs"] only.  Claude Code's built-in Bash/Read/Edit
+tools are NOT enabled; users who want those should run `claude` directly.
+
+Implementation notes:
+- The SDK is async-first; toksearch.llm.Session.send() is sync.  Bridging
+  is done by running a persistent asyncio event loop on a daemon thread
+  and dispatching coroutines via run_coroutine_threadsafe.
+- The ClaudeSDKClient is reused across send() calls within a Session so
+  the SDK can maintain its own conversation state.
+- The MCP server is in-process (create_sdk_mcp_server returns an
+  McpSdkServerConfig); no subprocess beyond the `claude` CLI itself.
+- Auth is via the `claude` CLI (run `claude login` or set
+  CLAUDE_CODE_OAUTH_TOKEN).  Connection failures raise LLMAuthError.
+"""
+
+import asyncio
+import threading
+from typing import TYPE_CHECKING
+
+import claude_agent_sdk as sdk
+
+from ..errors import LLMAuthError, LLMBackendError
+from ..events import TurnComplete
+from .base import Backend, Callbacks
+
+if TYPE_CHECKING:
+    from ..session import Session
+
+
+class ClaudeSDKBackend(Backend):
+    name = "claude-max"
+    default_model = "claude-sonnet-4-6"  # SDK will pick a reasonable default if None
+
+    def __init__(self, api_key=None, base_url=None):
+        # api_key and base_url are accepted for interface uniformity with
+        # the other backends; both are ignored.  The SDK gets credentials
+        # from `claude login` or CLAUDE_CODE_OAUTH_TOKEN at process start.
+        self._loop = None
+        self._thread = None
+        self._client = None
+        self._current_callbacks = None
+        self._current_session = None
+
+    def run_conversation(self, session, new_user_message, callbacks,
+                          max_iterations):
+        raise NotImplementedError(
+            "ClaudeSDKBackend.run_conversation is implemented in Task 3.")

--- a/toksearch/llm/backends/claude_sdk.py
+++ b/toksearch/llm/backends/claude_sdk.py
@@ -141,7 +141,104 @@ class ClaudeSDKBackend(Backend):
             name="toksearch", version="1.0", tools=[_rp, _ld],
         )
 
+    # ------------------------------------------------------------------
+    # Async bridge
+    # ------------------------------------------------------------------
+
+    def _ensure_loop(self):
+        """Start the persistent daemon-thread event loop on first use."""
+        if self._loop is not None:
+            return
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._loop.run_forever, daemon=True,
+            name="toksearch-llm-claude-sdk")
+        self._thread.start()
+
+    def _run_coro(self, coro):
+        self._ensure_loop()
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result()
+
+    # ------------------------------------------------------------------
+    # Conversation entry point
+    # ------------------------------------------------------------------
+
     def run_conversation(self, session, new_user_message, callbacks,
-                          max_iterations):
-        raise NotImplementedError(
-            "ClaudeSDKBackend.run_conversation is implemented in Task 3.")
+                          max_iterations) -> TurnComplete:
+        # Stash per-call state for the MCP handlers to read.
+        self._current_session = session
+        self._current_callbacks = callbacks
+        session._append_user(new_user_message)
+        return self._run_coro(self._async_turn(
+            session, new_user_message, callbacks, max_iterations))
+
+    async def _async_turn(self, session, prompt, callbacks, max_iterations):
+        from ..messages import TextBlock as _TextBlock, ToolUseBlock as _ToolUseBlock
+        client = await self._get_or_create_client(session, max_iterations)
+        await client.query(prompt)
+        # Collect assistant blocks across all messages from this turn.
+        assistant_blocks: list = []
+        final_text = ""
+        stop_reason = "end_turn"
+        async for msg in client.receive_response():
+            if isinstance(msg, sdk.AssistantMessage):
+                for b in msg.content:
+                    if isinstance(b, sdk.TextBlock):
+                        # Native text deltas can be streamed; fire on_text once
+                        # per AssistantMessage in PR 3 (no chunking).
+                        callbacks.fire_text(b.text)
+                        assistant_blocks.append(_TextBlock(text=b.text))
+                        final_text = b.text
+                    elif isinstance(b, sdk.ToolUseBlock):
+                        # The SDK already invoked the tool via our MCP server
+                        # (which appended the tool_result to history). Record
+                        # the tool_use block in our history too.
+                        assistant_blocks.append(_ToolUseBlock(
+                            id=b.id, name=b.name, args=dict(b.input)))
+            elif isinstance(msg, sdk.ResultMessage):
+                if msg.stop_reason:
+                    if msg.stop_reason in ("end_turn", "max_iterations",
+                                            "interrupted"):
+                        stop_reason = msg.stop_reason
+                    else:
+                        stop_reason = "end_turn"
+                if msg.result:
+                    final_text = msg.result
+                break
+        if assistant_blocks:
+            session._append_assistant(assistant_blocks)
+        result = TurnComplete(stop_reason=stop_reason, final_text=final_text)
+        callbacks.fire_turn_complete(result)
+        return result
+
+    async def _get_or_create_client(self, session, max_iterations):
+        if self._client is not None:
+            return self._client
+        options = sdk.ClaudeAgentOptions(
+            system_prompt=session.system_prompt,
+            mcp_servers={"toksearch": self._build_mcp_server()},
+            allowed_tools=[
+                "mcp__toksearch__run_python",
+                "mcp__toksearch__lookup_docs",
+            ],
+            permission_mode="bypassPermissions",
+            model=session.model,
+            max_turns=max_iterations,
+        )
+        try:
+            self._client = sdk.ClaudeSDKClient(options=options)
+            await self._client.connect()
+        except sdk.CLINotFoundError as e:
+            raise LLMAuthError(
+                "Could not find the `claude` CLI. Install Claude Code "
+                "(see https://docs.claude.com/en/docs/claude-code) and "
+                "run `claude login` to use the claude-max backend.") from e
+        except sdk.CLIConnectionError as e:
+            raise LLMAuthError(
+                "Failed to connect to the `claude` CLI. Run `claude login` "
+                "or set CLAUDE_CODE_OAUTH_TOKEN. Original error: " + str(e)
+            ) from e
+        except sdk.ClaudeSDKError as e:
+            raise LLMBackendError(f"Claude Agent SDK error: {e}") from e
+        return self._client

--- a/toksearch/llm/cli.py
+++ b/toksearch/llm/cli.py
@@ -74,6 +74,9 @@ def _resolve_api_key(preset, cfg) -> str | None:
                 return path.read_text().strip()
             except OSError:
                 pass
+    if preset.backend == "claude-max":
+        # ClaudeSDKBackend uses OAuth via the `claude` CLI; no API key.
+        return None
     if preset.backend == "anthropic":
         return cfg.anthropic_api_key
     if preset.backend == "openai":

--- a/toksearch/llm/presets.py
+++ b/toksearch/llm/presets.py
@@ -52,6 +52,12 @@ BUILTIN_PRESETS: dict[str, Preset] = {
         model="gpt-4o",
         api_key_env="OPENAI_API_KEY",
     ),
+    "claude-max": Preset(
+        backend="claude-max",
+        model=None,  # SDK picks the default; users may override via CLI.
+        api_key_env=None,
+        api_key_file=None,
+    ),
 }
 
 


### PR DESCRIPTION
## Summary

Stacked on #30 (PR 2). Adds `ClaudeSDKBackend` so users with a Claude Max plan can drive `toksearch.llm` against their subscription instead of paying API costs. The backend is deliberately RESTRICTED: it only exposes our two MCP tools (`run_python`, `lookup_docs`); built-in Claude Code tools (Bash, Read, Edit, Glob, Grep) are NOT enabled. Users who want full Claude Code should run `claude` directly.

- 6 commits (1 plan + pixi-env-update + 4 implementation), 135 LLM tests passing, 3 skipped (integration)
- New backend: `claude-max` preset + lazy-imported `ClaudeSDKBackend` in the registry
- In-process MCP server via `create_sdk_mcp_server` — no extra subprocess beyond the `claude` CLI itself
- Sync `Session.send()` ↔ async `ClaudeSDKClient` bridge via a persistent asyncio loop on a daemon thread; client reused across `send()` calls so the SDK maintains its own conversation state
- Auth via the `claude` CLI (`claude login` or `CLAUDE_CODE_OAUTH_TOKEN`); `CLINotFoundError` / `CLIConnectionError` translated to `LLMAuthError` with explicit remediation
- `[llm]` extra now bundles `claude-agent-sdk>=0.2` and `mcp>=1.23`; pixi dev env updated in the first commit
- Plan: `docs/superpowers/plans/2026-05-19-toksearch-llm-pr3.md`

## Test plan

- [ ] CI passes `python -m unittest discover -p "test_llm*"` — 135 tests, 3 skipped
- [ ] `pixi run python -c "from toksearch.llm.backends import get_backend_class; print(get_backend_class('claude-max'))"` resolves without ImportError
- [ ] `pixi run python -c "from toksearch.llm.presets import BUILTIN_PRESETS; print('claude-max' in BUILTIN_PRESETS)"` prints `True`
- [ ] Manual smoke (Claude Max): `TOKSEARCH_INTEGRATION=yes TOKSEARCH_CLAUDE_MAX=yes pixi run bash -c 'cd tests && python -m unittest test_llm_integration.TestClaudeMaxIntegration'` — requires `claude login`
- [ ] Manual REPL: `pixi run toksearch chat --backend claude-max` — multi-turn namespace persistence works through the MCP-tool path

## Deferred to follow-ups (called out in the plan)

- `--full-tools` flag to also enable Claude Code's built-in tools
- Backend `close()` method for explicit daemon-thread cleanup
- Streaming text deltas (the SDK supports `include_partial_messages=True`; PR 3 fires `on_text` once per AssistantMessage)
- Cost / usage reporting from `ResultMessage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)