### PR TITLE
LLM CLI ergonomics: compact tool output, session header, chat streaming, backends subcommand

### DIFF
--- a/toksearch/llm/cli.py
+++ b/toksearch/llm/cli.py
@@ -27,7 +27,7 @@ import sys
 
 from .config import load_config
 from .errors import LLMConfigError, LLMError
-from .presets import resolve_preset
+from .presets import BUILTIN_PRESETS, resolve_preset
 from .backends import get_backend_class
 from .session import Session
 
@@ -136,9 +136,16 @@ class _ToolPrinter:
         # reflect what it learned from the tool.
 
 
+def _print_session_header(command_name, session, *, file=sys.stderr):
+    """One-line header announcing the resolved backend and model."""
+    print(f"toksearch {command_name} (backend: {session.backend.name}, "
+          f"model: {session.model})", file=file)
+
+
 def do_query(args):
     session = build_session(args)
     printer = _ToolPrinter(verbose=args.verbose)
+    _print_session_header("query", session)
     try:
         result = session.send(
             args.query,
@@ -168,8 +175,7 @@ Slash commands:
 def do_chat(args):
     session = build_session(args)
     printer = _ToolPrinter(verbose=args.verbose)
-    print(f"toksearch chat (backend: {session.backend.name}, "
-          f"model: {session.model})")
+    _print_session_header("chat", session, file=sys.stdout)
     print("Type /help for commands. Ctrl-D to exit.\n")
     while True:
         try:
@@ -191,6 +197,7 @@ def do_chat(args):
         try:
             session.send(
                 line,
+                on_text=lambda t: print(t, end="", flush=True),
                 on_tool_call=printer.tool_call,
                 on_tool_result=printer.tool_result,
             )
@@ -198,6 +205,54 @@ def do_chat(args):
             print(f"error: {e}", file=sys.stderr)
             continue
         print()  # spacer between turns
+
+
+# ----------------------------------------------------------------------
+# `toksearch backends`
+# ----------------------------------------------------------------------
+
+def do_backends(args):
+    """Print the names that ``--backend`` will accept.
+
+    Lists built-in presets, entry-point-discovered presets (e.g. amsc
+    from toksearch_d3d), and user presets defined under
+    ``[llm.presets.<name>]`` in ``~/.fdp/config.toml``. Marks the
+    current default.
+    """
+    from .discovery import discover_presets
+
+    cfg = load_config()
+    discovered = discover_presets()
+    user_presets = cfg.user_presets or {}
+
+    default_name = cfg.backend or "anthropic"
+
+    rows: list[tuple[str, str, str, str]] = []
+    for name, preset in BUILTIN_PRESETS.items():
+        rows.append((name, "built-in", preset.backend, preset.model or "-"))
+    for name, preset in discovered.items():
+        if name in BUILTIN_PRESETS:
+            continue  # built-ins shadow discovered of the same name
+        rows.append((name, "discovered", preset.backend, preset.model or "-"))
+    for name, kv in user_presets.items():
+        if name in BUILTIN_PRESETS or name in discovered:
+            continue  # user overrides are merged onto the base; don't double-list
+        rows.append((name, "user", str(kv.get("backend", "?")),
+                     str(kv.get("model", "-"))))
+    rows.sort()
+
+    if not rows:
+        print("No backend presets available.")
+        return
+
+    headers = ("name", "source", "backend", "model")
+    widths = [max(len(h), max(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
+    fmt = "  ".join(f"{{:<{w}}}" for w in widths) + "  {}"
+    print(fmt.format(*headers, ""))
+    print("  ".join("-" * w for w in widths))
+    for name, source, backend, model in rows:
+        marker = "(default)" if name == default_name else ""
+        print(fmt.format(name, source, backend, model, marker).rstrip())
 
 
 # ----------------------------------------------------------------------
@@ -233,6 +288,12 @@ def main(argv=None):
     cp = sub.add_parser("chat", help="Interactive conversation.")
     _add_common(cp)
     cp.set_defaults(func=do_chat)
+
+    bp = sub.add_parser(
+        "backends",
+        help="List the names that --backend accepts (built-in, discovered, "
+             "and user presets).")
+    bp.set_defaults(func=do_backends)
 
     args = parser.parse_args(argv)
     args.func(args)

--- a/toksearch/llm/cli.py
+++ b/toksearch/llm/cli.py
@@ -88,31 +88,63 @@ def _resolve_api_key(preset, cfg) -> str | None:
 # `toksearch query`
 # ----------------------------------------------------------------------
 
-def _print_tool_call(call):
-    print(f"\n[{call.name}] {call.thought or ''}".rstrip())
-    code = call.args.get("code")
-    if code:
-        for line in code.splitlines():
-            print(f"  {line}")
+class _ToolPrinter:
+    """Pretty-printer for tool calls and results.
 
+    Compact mode (default): one-line summary per call -- the LLM's
+    `thought` if present, otherwise a key arg fallback. Successful
+    results print nothing; errors show the first line. Verbose mode
+    (`-v`) prints the full code and full body, matching the previous
+    behavior.
+    """
 
-def _print_tool_result(result):
-    label = "[output]" if not result.is_error else "[error]"
-    body = result.output or ""
-    for line in body.splitlines():
-        print(f"  {line}")
-    if not body:
-        print(f"{label} (empty)")
+    _ARG_FALLBACKS = ("skill_name", "name", "query")
+
+    def __init__(self, verbose: bool):
+        self.verbose = verbose
+
+    def tool_call(self, call):
+        detail = (call.thought or "").strip()
+        if not detail:
+            for key in self._ARG_FALLBACKS:
+                value = call.args.get(key)
+                if value:
+                    detail = str(value)
+                    break
+        print(f"\n[{call.name}] {detail}".rstrip())
+        if self.verbose:
+            code = call.args.get("code")
+            if code:
+                for line in code.splitlines():
+                    print(f"  {line}")
+
+    def tool_result(self, result):
+        body = result.output or ""
+        if result.is_error:
+            first = body.splitlines()[0] if body else "(empty)"
+            print(f"  [error] {first}")
+            if self.verbose and body:
+                for line in body.splitlines()[1:]:
+                    print(f"  {line}")
+        elif self.verbose:
+            if not body:
+                print("  [output] (empty)")
+            else:
+                for line in body.splitlines():
+                    print(f"  {line}")
+        # Compact + success: print nothing -- the LLM's reply will
+        # reflect what it learned from the tool.
 
 
 def do_query(args):
     session = build_session(args)
+    printer = _ToolPrinter(verbose=args.verbose)
     try:
         result = session.send(
             args.query,
             on_text=lambda t: print(t, end="", flush=True),
-            on_tool_call=_print_tool_call,
-            on_tool_result=_print_tool_result,
+            on_tool_call=printer.tool_call,
+            on_tool_result=printer.tool_result,
         )
     except LLMError as e:
         print(f"\nerror: {e}", file=sys.stderr)
@@ -135,6 +167,7 @@ Slash commands:
 
 def do_chat(args):
     session = build_session(args)
+    printer = _ToolPrinter(verbose=args.verbose)
     print(f"toksearch chat (backend: {session.backend.name}, "
           f"model: {session.model})")
     print("Type /help for commands. Ctrl-D to exit.\n")
@@ -158,8 +191,8 @@ def do_chat(args):
         try:
             session.send(
                 line,
-                on_tool_call=_print_tool_call,
-                on_tool_result=_print_tool_result,
+                on_tool_call=printer.tool_call,
+                on_tool_result=printer.tool_result,
             )
         except LLMError as e:
             print(f"error: {e}", file=sys.stderr)
@@ -183,6 +216,9 @@ def _add_common(p):
                    default=None,
                    help="Restrict discovered contributors to the named "
                         "package(s). Repeat the flag to allow multiple.")
+    p.add_argument("-v", "--verbose", action="store_true",
+                   help="Show full tool-call code and tool-result bodies. "
+                        "Default prints a one-line summary per call.")
 
 
 def main(argv=None):


### PR DESCRIPTION
## Summary

Three independent CLI polish items, two commits.

**Commit 1: compact tool-call output + \`-v / --verbose\`**

The old printers dumped every line of submitted code and every line of returned output. In practice this meant \`toksearch chat\` (and \`fdp chat\` via the same delegate) showed huge \`help()\` dumps and full skill bodies from \`lookup_docs\` between every turn, drowning out the actual model reply.

New \`_ToolPrinter\` class prints a one-line summary per call (the model's \`thought\` if populated, or a representative arg fallback for tools without one), and prints nothing on successful results. Errors always surface the first line. \`-v / --verbose\` restores the previous full-fidelity output.

**Commit 2: session header + chat streaming fix + \`backends\` subcommand**

- One-line session header (\`toksearch chat (backend: ..., model: ...)\`) is now printed by both \`query\` (stderr) and \`chat\` (stdout). Pre-existing \`chat\` line is preserved verbatim; \`query\` was silent.
- \`do_chat\` never passed \`on_text\`, so the LLM's reply was silently dropped in the REPL. The old verbose tool-result dump used to mask this; the compact mode exposed it. Pass the same streaming callback \`do_query\` already uses.
- New \`toksearch backends\` subcommand lists everything \`--backend\` accepts -- built-in, entry-point-discovered (e.g. \`amsc\` from \`toksearch_d3d\`), and user presets from \`~/.fdp/config.toml\` -- with the resolved default marked.

## Test plan

- [x] \`pixi run python -m unittest discover -s tests -p 'test_llm_cli*.py'\` passes (13/13).
- [x] \`pixi run python -m unittest discover -s tests -p 'test_llm*.py'\` passes (136/136).
- [x] \`python -m toksearch.llm.cli backends\` lists \`anthropic / claude-max / openai\` (toksearch repo) and additionally \`amsc\` (toksearch_d3d env).
- [ ] CI: conda build/test on PR.