### PR TITLE
Show a header logo when FDP_GUI_LOGO_PATH is set

### DIFF
--- a/tests/test_llm_gui_app.py
+++ b/tests/test_llm_gui_app.py
@@ -197,5 +197,77 @@ class TestBuildApp(unittest.TestCase):
         self.assertIsInstance(blocks, gr.Blocks)
 
 
+class TestHeaderLogo(unittest.TestCase):
+    """build_app honors FDP_GUI_LOGO_PATH for branding the header."""
+
+    def _noop_fn(self):
+        def fn(message, history):
+            yield []
+        return fn
+
+    def _walk(self, node):
+        yield node
+        for child in getattr(node, "children", None) or []:
+            yield from self._walk(child)
+
+    def test_no_env_var_no_image_component(self):
+        from toksearch.llm.gui.app import build_app
+        import gradio as gr
+        import os as _os
+
+        env = {k: v for k, v in _os.environ.items()
+               if k != "FDP_GUI_LOGO_PATH"}
+        with mock.patch.dict(_os.environ, env, clear=True):
+            blocks = build_app(session=mock.Mock(), fn=self._noop_fn())
+        images = [c for c in self._walk(blocks)
+                  if isinstance(c, gr.Image)]
+        self.assertEqual(images, [])
+
+    def test_env_var_pointing_at_real_file_adds_image(self):
+        import tempfile
+        from pathlib import Path
+        from toksearch.llm.gui.app import build_app
+        import gradio as gr
+        import os as _os
+
+        # Use any small extant file as a stand-in PNG; build_app only
+        # checks os.path.isfile, not the file's actual contents.
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(b"\x89PNG\r\n\x1a\n")
+            logo = f.name
+        try:
+            with mock.patch.dict(_os.environ,
+                                  {"FDP_GUI_LOGO_PATH": logo}):
+                blocks = build_app(session=mock.Mock(),
+                                    fn=self._noop_fn())
+            images = [c for c in self._walk(blocks)
+                      if isinstance(c, gr.Image)]
+            self.assertEqual(len(images), 1)
+            # Gradio stages the file into its own gradio_cache dir at
+            # postprocess time, so the recorded path is a copy of the
+            # original. Verify by tail-matching the basename instead
+            # of comparing absolute paths.
+            value = images[0].value
+            path = value.get("path") if isinstance(value, dict) else value
+            self.assertTrue(path.endswith(_os.path.basename(logo)),
+                            f"image value {path!r} doesn't end with "
+                            f"basename of {logo!r}")
+        finally:
+            Path(logo).unlink()
+
+    def test_env_var_pointing_at_nonexistent_file_is_ignored(self):
+        from toksearch.llm.gui.app import build_app
+        import gradio as gr
+        import os as _os
+
+        with mock.patch.dict(_os.environ,
+                              {"FDP_GUI_LOGO_PATH":
+                               "/does/not/exist/logo.png"}):
+            blocks = build_app(session=mock.Mock(), fn=self._noop_fn())
+        images = [c for c in self._walk(blocks)
+                  if isinstance(c, gr.Image)]
+        self.assertEqual(images, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_gui_app.py
+++ b/tests/test_llm_gui_app.py
@@ -153,6 +153,11 @@ class TestChatFn(unittest.TestCase):
         self.assertIn("srcdoc=", html)
         # The escaped srcdoc payload should reference plotly.
         self.assertIn("plotly", html.lower())
+        # The iframe must carry the fullscreen permission AND
+        # contain the injected fullscreen button + script.
+        self.assertIn('allow="fullscreen"', html)
+        self.assertIn("ts-fullscreen-btn", html)
+        self.assertIn("requestFullscreen", html)
 
     def test_matplotlib_figure_renders_as_static_gr_plot(self):
         """Matplotlib figures stay on the gr.Plot path -- they aren't

--- a/toksearch/llm/gui/app.py
+++ b/toksearch/llm/gui/app.py
@@ -110,17 +110,46 @@ def _plotly_iframe(fig, height: int = 500) -> str:
         default_height="100%",
         default_width="100%",
     )
-    # Zero the body margin inside the iframe so the chart fills it.
-    inner = inner.replace(
-        "<head>",
-        "<head><style>html,body{margin:0;padding:0;height:100%;}</style>",
-        1,
-    )
+    # Inject style + a floating "⛶ Full screen" button. The button
+    # calls requestFullscreen() on the iframe's documentElement, which
+    # the parent iframe element grants via `allow="fullscreen"`.
+    _injected = """
+<style>
+  html,body { margin:0; padding:0; height:100%; }
+  #ts-fullscreen-btn {
+    position: fixed; top: 6px; right: 6px; z-index: 9999;
+    padding: 4px 10px; font: 12px/1 system-ui, sans-serif;
+    background: rgba(255,255,255,0.9); color: #333;
+    border: 1px solid #ccc; border-radius: 4px; cursor: pointer;
+    opacity: 0.7;
+  }
+  #ts-fullscreen-btn:hover { opacity: 1; }
+</style>
+<script>
+window.addEventListener('DOMContentLoaded', function () {
+  var btn = document.createElement('button');
+  btn.id = 'ts-fullscreen-btn';
+  btn.innerText = '⛶ Full screen';
+  btn.title = 'Expand this plot to full screen';
+  btn.onclick = function () {
+    var el = document.documentElement;
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    } else if (el.requestFullscreen) {
+      el.requestFullscreen();
+    }
+  };
+  document.body.appendChild(btn);
+});
+</script>
+"""
+    inner = inner.replace("<head>", "<head>" + _injected, 1)
     escaped = _html.escape(inner, quote=True)
     return (
         f'<iframe srcdoc="{escaped}" '
         f'style="width:100%; height:{height}px; border:none; '
         f'display:block;" '
+        f'allow="fullscreen" '
         f'sandbox="allow-scripts"></iframe>'
     )
 

--- a/toksearch/llm/gui/app.py
+++ b/toksearch/llm/gui/app.py
@@ -21,6 +21,7 @@ via ``ChatMessage.metadata``), and inline plots
 (``ChatMessage(content=gr.Plot(fig))``).
 """
 
+import os
 import queue
 import sys
 import threading
@@ -32,6 +33,22 @@ from .figure_capture import _set_active_figure_emitter
 
 
 _ARG_FALLBACKS = ("skill_name", "name", "query")
+
+
+def _header_logo_path() -> str | None:
+    """Return a filesystem path to a header logo, or ``None``.
+
+    Honors ``$FDP_GUI_LOGO_PATH`` if set and pointing to an existing
+    file; otherwise no logo. Set by ``fdp chat --gui`` before
+    ``execvpe``ing into the toksearch CLI so the chat surface picks
+    up FDP branding automatically when running inside the platform.
+    Direct ``python -m toksearch.llm.gui`` invocations stay
+    unbranded unless the user exports the variable themselves.
+    """
+    path = os.environ.get("FDP_GUI_LOGO_PATH")
+    if path and os.path.isfile(path):
+        return path
+    return None
 
 
 def _tool_title(call) -> str:
@@ -226,7 +243,17 @@ def build_app(session, fn=None):
     UI wiring from the LLM call.
     """
     chat_fn = fn if fn is not None else _build_chat_fn(session)
+    logo_path = _header_logo_path()
     with gr.Blocks(title="toksearch chat") as blocks:
+        if logo_path:
+            gr.Image(
+                value=logo_path,
+                show_label=False,
+                container=False,
+                interactive=False,
+                buttons=[],
+                height=70,
+            )
         gr.ChatInterface(
             fn=chat_fn,
             chatbot=gr.Chatbot(
@@ -235,6 +262,6 @@ def build_app(session, fn=None):
                 # Permit gr.Plot content inside ChatMessages.
                 sanitize_html=False,
             ),
-            title="toksearch chat",
+            title=None if logo_path else "toksearch chat",
         )
     return blocks


### PR DESCRIPTION
## Summary

Reads \`\$FDP_GUI_LOGO_PATH\` at \`build_app\` time. If set and pointing at a real file, a small \`gr.Image\` (height=70, no toolbar/label/container) is prepended above the \`gr.ChatInterface\`, and the textual title is dropped to avoid a duplicate header. Empty / missing variable falls through to the unbranded layout.

Pairs with [fdp PR for 0.1.4](https://github.com/GA-FDP/fdp/pulls) which wires the var to point at fdp's bundled \`FDP Main Logo.png\` when \`fdp chat --gui\` execvpe's into the toksearch CLI.

## Test plan

- [x] Three new tests for build_app:
  - no env var → no \`gr.Image\` in the tree
  - env var pointing at a real file → \`gr.Image\` is added
  - env var pointing at a non-existent path → no \`gr.Image\` (silent fallback)
- [ ] CI: conda build + test