### PR TITLE
perf: lazy-load Ray and Spark backends to speed up `import toksearch`

### DIFF
--- a/docs/superpowers/plans/2026-07-08-lazy-backend-imports.md
+++ b/docs/superpowers/plans/2026-07-08-lazy-backend-imports.md
@@ -1,0 +1,293 @@
+# Lazy-load Ray and Spark Backends Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `import toksearch` ~2.9s faster by deferring the Ray and Spark backend imports until `compute_ray()`/`compute_spark()` are actually called.
+
+**Architecture:** The Ray (~2.6s) and Spark/pyspark (~0.34s) backends are imported eagerly at the top of `toksearch/pipeline/record_pipeline.py`, so their cost is paid on every `import toksearch` even though most workflows use `compute_multiprocessing()`/`compute_serial()`. Enable PEP 563 deferred annotations (`from __future__ import annotations`) so the `-> RayRecordSet` / `sc: Optional[SparkContext]` signatures don't force those names to resolve at definition time, move the heavy imports into the two `compute_*` method bodies, and keep a `TYPE_CHECKING` block for static tooling. A subprocess-based regression test locks in the win.
+
+**Tech Stack:** Python 3.12, `unittest` (test suite discovered by `tests/testit.py`), `pixi` for the dev environment.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-lazy-backend-imports-design.md`
+
+---
+
+## File Structure
+
+- **Modify:** `toksearch/pipeline/record_pipeline.py` — the only file with eager Ray/Spark imports on the `import toksearch` path. Add `from __future__ import annotations`, remove the three eager backend imports, add a `TYPE_CHECKING` block, and move the imports into `compute_ray()`/`compute_spark()`.
+- **Create:** `tests/test_lazy_backend_imports.py` — a `unittest` regression test that runs `import toksearch` in a clean subprocess and asserts `ray`/`pyspark` are absent from `sys.modules`.
+
+No public API changes: `toksearch/__init__.py` re-exports none of the backend classes.
+
+---
+
+## Task 1: Add the failing regression test
+
+**Files:**
+- Create: `tests/test_lazy_backend_imports.py`
+
+- [ ] **Step 1: Write the regression test**
+
+Create `tests/test_lazy_backend_imports.py` with exactly this content. The test spawns a **fresh** subprocess (required — the pytest/unittest parent process may already have Ray/Spark in `sys.modules`, e.g. `tests/test_pipeline.py` imports `ray` at module top level).
+
+```python
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression guard: importing toksearch must not eagerly import the heavy
+Ray and Spark backends. See
+docs/superpowers/specs/2026-07-07-lazy-backend-imports-design.md.
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+
+
+HEAVY_PREFIXES = ("ray", "pyspark")
+
+
+def _heavy_modules_after(snippet):
+    """Run `snippet` in a clean interpreter, return the sorted list of loaded
+    ray/pyspark modules."""
+    code = (
+        f"{snippet}\n"
+        "import sys, json\n"
+        "loaded = sorted(\n"
+        "    m for m in sys.modules\n"
+        "    if m == 'ray' or m == 'pyspark'\n"
+        "    or m.startswith('ray.') or m.startswith('pyspark.')\n"
+        ")\n"
+        "print(json.dumps(loaded))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed (rc={result.returncode}):\n{result.stderr}"
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+class TestLazyBackendImports(unittest.TestCase):
+    def test_import_toksearch_does_not_import_ray_or_spark(self):
+        heavy = _heavy_modules_after("import toksearch")
+        self.assertEqual(
+            heavy, [], f"`import toksearch` eagerly loaded: {heavy}"
+        )
+
+    def test_building_pipeline_does_not_import_ray_or_spark(self):
+        heavy = _heavy_modules_after(
+            "from toksearch import Pipeline\np = Pipeline([1, 2, 3])"
+        )
+        self.assertEqual(
+            heavy, [], f"Building a Pipeline eagerly loaded: {heavy}"
+        )
+```
+
+- [ ] **Step 2: Run the test to verify it FAILS**
+
+Run:
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch
+pixi run python -m pytest tests/test_lazy_backend_imports.py -v
+```
+Expected: **FAIL**. Both tests fail because `import toksearch` currently pulls in Ray (and pyspark) via `record_pipeline.py`. The assertion message will list `ray`, `ray.*`, `pyspark`, `pyspark.*` modules.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch
+git add tests/test_lazy_backend_imports.py
+git commit -m "test: guard against eager Ray/Spark import in toksearch"
+```
+
+---
+
+## Task 2: Make the Ray and Spark imports lazy
+
+**Files:**
+- Modify: `toksearch/pipeline/record_pipeline.py`
+
+Current relevant state (line numbers approximate):
+- module docstring ends at the `"""` on line ~21, then `import os` on line ~23
+- `from typing import List, Optional, Callable, Union, Type, Iterable` on line ~37
+- eager backend imports on lines ~64–70
+- `compute_ray()` body builds `RayConfig(...)` and calls `self.compute(RayRecordSet, ...)`
+- `compute_spark()` body builds `ToksearchSparkConfig(...)` and calls `self.compute(SparkRecordSet, ...)`
+
+- [ ] **Step 1: Add `from __future__ import annotations` as the first statement after the module docstring**
+
+It MUST be the first statement after the docstring (PEP 563 requirement). Insert it immediately before `import os`:
+
+```python
+"""
+... existing module docstring ...
+"""
+
+from __future__ import annotations
+
+import os
+import copy
+import importlib
+```
+
+- [ ] **Step 2: Add `TYPE_CHECKING` to the typing import**
+
+Change:
+```python
+from typing import List, Optional, Callable, Union, Type, Iterable
+```
+to:
+```python
+from typing import List, Optional, Callable, Union, Type, Iterable, TYPE_CHECKING
+```
+
+- [ ] **Step 3: Replace the eager backend import block**
+
+Replace this block (lines ~64–70):
+```python
+from ..backend.multiprocessing import MultiprocessingRecordSet, MultiprocessingConfig
+from ..backend.ray import RayRecordSet, RayConfig
+
+from ..backend.spark import SparkRecordSet, ToksearchSparkConfig
+from pyspark.context import SparkContext
+
+from ..backend.serial import SerialRecordSet
+```
+with:
+```python
+from ..backend.multiprocessing import MultiprocessingRecordSet, MultiprocessingConfig
+from ..backend.serial import SerialRecordSet
+
+# Ray and Spark are heavy optional backends: Ray alone adds ~2.6s to
+# `import toksearch` (via its jsonschema -> rfc3987 dependency chain), and
+# pyspark ~0.3s. They are imported lazily inside compute_ray()/compute_spark()
+# so the common serial/multiprocessing workflows don't pay that cost. These
+# TYPE_CHECKING-only imports keep the method annotations resolvable for type
+# checkers and IDEs without importing anything at runtime.
+if TYPE_CHECKING:
+    from ..backend.ray import RayRecordSet, RayConfig
+    from ..backend.spark import SparkRecordSet, ToksearchSparkConfig
+    from pyspark.context import SparkContext
+```
+
+- [ ] **Step 4: Add the lazy import inside `compute_ray()`**
+
+In the body of `compute_ray()`, add the import as the first statement, immediately before `config = RayConfig(`:
+```python
+        from ..backend.ray import RayRecordSet, RayConfig
+
+        config = RayConfig(
+            numparts=numparts,
+            placement_group_func=placement_group_func,
+            memory_per_task=memory_per_shot,
+            **ray_init_kwargs,
+        )
+
+        return self.compute(RayRecordSet, config=config)
+```
+
+- [ ] **Step 5: Add the lazy import inside `compute_spark()`**
+
+In the body of `compute_spark()`, add the import as the first statement, immediately before `config = ToksearchSparkConfig(`:
+```python
+        from ..backend.spark import SparkRecordSet, ToksearchSparkConfig
+
+        config = ToksearchSparkConfig(sc=sc, numparts=numparts, cache=cache)
+        return self.compute(SparkRecordSet, config=config)
+```
+
+Note: `SparkContext` is referenced only in the `sc: Optional[SparkContext] = None` annotation (the default value is `None`), so under PEP 563 it needs no runtime import — the `TYPE_CHECKING` block covers it.
+
+- [ ] **Step 6: Run the regression test to verify it PASSES**
+
+Run:
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch
+pixi run python -m pytest tests/test_lazy_backend_imports.py -v
+```
+Expected: **PASS** (both tests). `import toksearch` and building a `Pipeline` no longer load `ray`/`pyspark`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch
+git add toksearch/pipeline/record_pipeline.py
+git commit -m "perf: lazy-load Ray and Spark backends to speed up import
+
+Defers the eager Ray (~2.6s) and Spark (~0.3s) backend imports in
+record_pipeline.py into compute_ray()/compute_spark(). Uses PEP 563
+deferred annotations so the method signatures still reference the backend
+types. No public API change."
+```
+
+---
+
+## Task 3: Verify existing backend behavior and measure the win
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm `compute_ray` / `compute_spark` still work**
+
+The existing `tests/test_pipeline.py` exercises the compute backends (it imports `ray` and uses `RayDD`). Run it to confirm the lazy imports didn't break the compute paths. This spins up a local Ray instance and may take a minute.
+
+Run:
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch
+pixi run python -m pytest tests/test_pipeline.py -v
+```
+Expected: **PASS** (same result as before the change — no new failures).
+
+- [ ] **Step 2: Measure `import toksearch` before/after**
+
+Warm the caches first, then time it:
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch
+pixi run python -c "import toksearch"  # warm
+for i in 1 2 3; do \
+  /usr/bin/time -v pixi run python -c "import toksearch" 2>&1 | grep -i "wall clock"; \
+done
+```
+Expected: warm wall-clock drops from ~4.3s (pre-change baseline) to ~1.6s. (Absolute numbers vary with NFS cache state and the constant `pixi run` overhead; the ~2.9s reduction is the signal.)
+
+- [ ] **Step 3: Confirm no eager ray/spark imports remain on the import path**
+
+Run:
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch
+pixi run python -c "import toksearch, sys; print(sorted(m for m in sys.modules if m.startswith(('ray','pyspark'))))"
+```
+Expected: `[]`
+
+- [ ] **Step 4: Run the full mock test suite as a final sanity check**
+
+Run:
+```bash
+cd /fusion/projects/dt/sammuli/fdp_dev/repos/toksearch/tests
+pixi run --manifest-path ../pixi.toml python -B testit.py --mock
+```
+Expected: all tests pass (mock mode avoids the ptdata/d3drdb integration requirements). If unrelated pre-existing failures appear, confirm they also fail on the pre-change commit before attributing them to this work.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** All spec design points are covered — `from __future__ import annotations` (Task 2 Step 1), remove eager imports + `TYPE_CHECKING` block (Task 2 Step 3), in-body imports (Steps 4–5), multiprocessing/serial left eager (Step 3), subprocess regression test (Task 1), verification + timing (Task 3).
+- **Type consistency:** Symbol names used consistently throughout — `RayRecordSet`, `RayConfig`, `SparkRecordSet`, `ToksearchSparkConfig`, `SparkContext` match the current `record_pipeline.py` definitions and their `backend/ray/__init__.py` / `backend/spark/__init__.py` sources.
+- **No placeholders:** every code and command step is concrete.
+- **Out of scope (per spec):** deferring `xarray`/`MDSplus`; cutting the `ga-fdp` release (done separately via a `release-*` tag).

--- a/docs/superpowers/specs/2026-07-07-lazy-backend-imports-design.md
+++ b/docs/superpowers/specs/2026-07-07-lazy-backend-imports-design.md
@@ -1,0 +1,145 @@
+# Lazy-load Ray and Spark backends in TokSearch
+
+**Date:** 2026-07-07
+**Status:** Approved design
+**Scope:** `toksearch` source repo only (published to `ga-fdp` via a `release-*` tag separately)
+
+## Problem
+
+`import toksearch` costs ~4.3s warm (and far worse cold on the `/fusion` NFS
+mount — a first-run `import fdp.cli` alone was measured at 4.8s). Profiling with
+`python -X importtime` attributes the cost as:
+
+| Component | Cumulative (warm) | On import path via |
+|-----------|-------------------|--------------------|
+| `ray` backend | ~2.6s | `record_pipeline.py:65` (eager) |
+| `pyspark` / Spark backend | ~0.34s | `record_pipeline.py:67,68` (eager) |
+| `xarray` | ~0.6–0.9s | `record_pipeline.py:35`, signal path |
+| `MDSplus` | ~0.3s | `signal/mds.py` via public `MdsSignal` |
+
+Within Ray, the cost is dominated by a single pathological transitive
+dependency, `rfc3987_syntax.syntax_helpers` (pulled in by
+`ray.runtime_env → jsonschema`), which compiles a large grammar at import time
+(~1.0–2.2s of CPU, largely cache-independent).
+
+The Ray and Spark backends are imported **eagerly** at module top level, so
+their combined ~2.9s is paid on *every* `import toksearch` — even though the
+common FDP workflows use `compute_multiprocessing()` or `compute_serial()` and
+never touch Ray or Spark.
+
+## Goal
+
+Defer the Ray and Spark backend imports so they are only paid when a user
+actually calls `compute_ray()` or `compute_spark()`. Target: `import toksearch`
+drops from ~4.3s → ~1.6s warm.
+
+Out of scope (deliberately): deferring `xarray`, `MDSplus`, or `numpy`. These
+sit on the core signal/dataset path (`xarray` is used pervasively in
+`record_pipeline.py`; `MDSplus` is reached through the public `MdsSignal`
+re-export in `toksearch/__init__.py`) and are far riskier to defer for a smaller
+marginal win.
+
+## Current state (verified)
+
+- `toksearch/pipeline/record_pipeline.py` eagerly imports all four backends:
+  - line 64: `from ..backend.multiprocessing import MultiprocessingRecordSet, MultiprocessingConfig`
+  - line 65: `from ..backend.ray import RayRecordSet, RayConfig`
+  - line 67: `from ..backend.spark import SparkRecordSet, ToksearchSparkConfig`
+  - line 68: `from pyspark.context import SparkContext`
+  - line 70: `from ..backend.serial import SerialRecordSet`
+- The backend symbols are used only inside the `compute_*` methods and in their
+  signatures:
+  - `compute_ray(...) -> RayRecordSet` uses `RayConfig`, `RayRecordSet`
+  - `compute_spark(sc: Optional[SparkContext] = None, ...) -> SparkRecordSet`
+    uses `ToksearchSparkConfig`, `SparkRecordSet`, `SparkContext`
+  - `compute_multiprocessing`, `compute_serial` use the cheap backends
+- `toksearch/__init__.py` re-exports **none** of the backend RecordSet/Config
+  classes (only `Signal`, `ZarrSignal`, `MdsSignal`, `MdsTreePath`,
+  `XarrayAligner`, `Pipeline`). Making backends lazy therefore changes no public
+  import surface.
+- The only other eager `import ray` / `import pyspark` sites are in
+  `toksearch/slurm/` (`ray_cluster.py`, `spark_cluster.py`), which are **not** on
+  the `import toksearch` path (`__init__.py` imports only `signal` and
+  `pipeline`). No change needed there.
+- `backend/multiprocessing` and `backend/serial` do not transitively import
+  Ray or Spark.
+
+## Design
+
+All changes are contained in `toksearch/pipeline/record_pipeline.py`.
+
+1. **Enable deferred annotations.** Add `from __future__ import annotations`
+   (PEP 563) at the top of the file so all annotations become un-evaluated
+   strings. This lets `compute_ray()`/`compute_spark()` keep their
+   `-> RayRecordSet` and `sc: Optional[SparkContext]` annotations without those
+   names being resolvable at function-definition time.
+
+   Safe here: `Pipeline` is a plain class — not a dataclass or pydantic model —
+   and nothing calls `typing.get_type_hints()` on it, so no runtime code depends
+   on the annotations being live objects.
+
+2. **Remove the eager backend imports.** Delete the three top-level lines:
+   - `from ..backend.ray import RayRecordSet, RayConfig`
+   - `from ..backend.spark import SparkRecordSet, ToksearchSparkConfig`
+   - `from pyspark.context import SparkContext`
+
+3. **Add a `TYPE_CHECKING` block** re-declaring those names so static type
+   checkers and IDEs still resolve the annotations:
+
+   ```python
+   from typing import TYPE_CHECKING
+   if TYPE_CHECKING:
+       from ..backend.ray import RayRecordSet, RayConfig
+       from ..backend.spark import SparkRecordSet, ToksearchSparkConfig
+       from pyspark.context import SparkContext
+   ```
+
+4. **Move the imports into the method bodies:**
+   - `compute_ray()`: add `from ..backend.ray import RayRecordSet, RayConfig` at
+     the top of the method body.
+   - `compute_spark()`: add
+     `from ..backend.spark import SparkRecordSet, ToksearchSparkConfig` at the
+     top of the method body. `SparkContext` is referenced **only** in the
+     `sc: Optional[SparkContext] = None` annotation (verified — the default value
+     is `None`, not a `SparkContext()` call), so under PEP 563 it needs no
+     runtime import inside the method.
+
+5. **Leave `multiprocessing` and `serial` backend imports eager** — they are
+   cheap and pull in nothing heavy.
+
+Because Python caches imported modules in `sys.modules`, the first call to
+`compute_ray()`/`compute_spark()` pays the import once; subsequent calls are
+free. Behavior is otherwise identical.
+
+## Regression guard
+
+Add a pytest that guards the laziness so an eager import cannot silently creep
+back in:
+
+- Spawn a **subprocess** with a clean interpreter (`subprocess.run([sys.executable,
+  "-c", "import toksearch; import sys; ...])`) — a subprocess is required
+  because pytest itself may already have imported Ray/Spark into the parent's
+  `sys.modules`.
+- Assert that after `import toksearch`, neither `ray` nor `pyspark` is present in
+  `sys.modules`.
+- Optionally, a second assertion that after constructing a `Pipeline` (without
+  calling a compute method) Ray/Spark are still absent.
+
+This test lives alongside the existing backend tests in the toksearch test
+suite.
+
+## Verification
+
+- Run the toksearch test suite (`pixi run pytest`) — existing backend tests must
+  still pass, confirming `compute_ray`/`compute_spark` work with the deferred
+  imports.
+- Measure `import toksearch` warm wall time before/after in the toksearch repo's
+  own pixi env; expect ~4.3s → ~1.6s.
+- Confirm the new regression test passes.
+
+## Non-goals / follow-ups
+
+- Deferring `xarray` and `MDSplus` (separate, more invasive effort).
+- The upstream `rfc3987_syntax` slowness (a jsonschema/ray dependency) — sidesteps
+  itself once Ray is lazy; not chased directly.
+- Cutting the `ga-fdp` release: done separately by tagging `release-*`.

--- a/tests/test_lazy_backend_imports.py
+++ b/tests/test_lazy_backend_imports.py
@@ -32,10 +32,10 @@ def _heavy_modules_after(snippet):
     code = (
         f"{snippet}\n"
         "import sys, json\n"
+        f"HEAVY = {HEAVY_PREFIXES!r}\n"
         "loaded = sorted(\n"
         "    m for m in sys.modules\n"
-        "    if m == 'ray' or m == 'pyspark'\n"
-        "    or m.startswith('ray.') or m.startswith('pyspark.')\n"
+        "    if any(m == p or m.startswith(p + '.') for p in HEAVY)\n"
         ")\n"
         "print(json.dumps(loaded))\n"
     )

--- a/tests/test_lazy_backend_imports.py
+++ b/tests/test_lazy_backend_imports.py
@@ -1,0 +1,66 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression guard: importing toksearch must not eagerly import the heavy
+Ray and Spark backends. See
+docs/superpowers/specs/2026-07-07-lazy-backend-imports-design.md.
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+
+
+HEAVY_PREFIXES = ("ray", "pyspark")
+
+
+def _heavy_modules_after(snippet):
+    """Run `snippet` in a clean interpreter, return the sorted list of loaded
+    ray/pyspark modules."""
+    code = (
+        f"{snippet}\n"
+        "import sys, json\n"
+        "loaded = sorted(\n"
+        "    m for m in sys.modules\n"
+        "    if m == 'ray' or m == 'pyspark'\n"
+        "    or m.startswith('ray.') or m.startswith('pyspark.')\n"
+        ")\n"
+        "print(json.dumps(loaded))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed (rc={result.returncode}):\n{result.stderr}"
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+class TestLazyBackendImports(unittest.TestCase):
+    def test_import_toksearch_does_not_import_ray_or_spark(self):
+        heavy = _heavy_modules_after("import toksearch")
+        self.assertEqual(
+            heavy, [], f"`import toksearch` eagerly loaded: {heavy}"
+        )
+
+    def test_building_pipeline_does_not_import_ray_or_spark(self):
+        heavy = _heavy_modules_after(
+            "from toksearch import Pipeline\np = Pipeline([1, 2, 3])"
+        )
+        self.assertEqual(
+            heavy, [], f"Building a Pipeline eagerly loaded: {heavy}"
+        )

--- a/toksearch/pipeline/record_pipeline.py
+++ b/toksearch/pipeline/record_pipeline.py
@@ -20,6 +20,8 @@ data in a series of steps, including both predefined methods and arbitrary
 user-defined functions.
 """
 
+from __future__ import annotations
+
 import os
 import copy
 import importlib
@@ -34,7 +36,7 @@ import numpy as np
 import itertools
 import xarray as xr
 import multiprocessing
-from typing import List, Optional, Callable, Union, Type, Iterable
+from typing import List, Optional, Callable, Union, Type, Iterable, TYPE_CHECKING
 
 
 from ..utilities.utilities import (
@@ -62,12 +64,20 @@ from ..record.record_set import RecordSet
 
 
 from ..backend.multiprocessing import MultiprocessingRecordSet, MultiprocessingConfig
-from ..backend.ray import RayRecordSet, RayConfig
-
-from ..backend.spark import SparkRecordSet, ToksearchSparkConfig
-from pyspark.context import SparkContext
-
 from ..backend.serial import SerialRecordSet
+
+# Ray and Spark are heavy optional backends: Ray alone adds ~2.6s to
+# `import toksearch` (via its jsonschema -> rfc3987 dependency chain), and
+# pyspark ~0.3s. They are imported lazily inside compute_ray()/compute_spark()
+# so the common serial/multiprocessing workflows don't pay that cost. These
+# TYPE_CHECKING-only imports keep the method annotations resolvable for type
+# checkers and IDEs without importing anything at runtime. Any method that
+# uses one of these symbols at runtime must repeat the import locally in its
+# body (see compute_ray/compute_spark).
+if TYPE_CHECKING:
+    from ..backend.ray import RayRecordSet, RayConfig
+    from ..backend.spark import SparkRecordSet, ToksearchSparkConfig
+    from pyspark.context import SparkContext
 
 from .pipeline_source import PipelineSource
 
@@ -393,6 +403,8 @@ class Pipeline:
         Returns:
             RayRecordSet: The record set
         """
+        from ..backend.ray import RayRecordSet, RayConfig
+
         config = RayConfig(
             numparts=numparts,
             placement_group_func=placement_group_func,
@@ -420,6 +432,8 @@ class Pipeline:
         Returns:
             SparkRecordSet: The record set
         """
+        from ..backend.spark import SparkRecordSet, ToksearchSparkConfig
+
         config = ToksearchSparkConfig(sc=sc, numparts=numparts, cache=cache)
         return self.compute(SparkRecordSet, config=config)
 


### PR DESCRIPTION
## Summary

`import toksearch` was ~4.4s warm (far worse cold on NFS) because `toksearch/pipeline/record_pipeline.py` eagerly imported the **Ray** (~2.6s) and **Spark/pyspark** (~0.34s) backends at module top level — paid on *every* import even though the common workflows use `compute_multiprocessing()`/`compute_serial()` and never touch Ray or Spark. Within Ray the cost is dominated by a single transitive dep, `rfc3987_syntax` (via `ray.runtime_env → jsonschema`), which compiles a large grammar at import.

This defers the Ray/Spark imports into `compute_ray()`/`compute_spark()`:
- Add `from __future__ import annotations` (PEP 563) so the `-> RayRecordSet` / `sc: Optional[SparkContext]` signatures don't force those names to resolve at definition time.
- Move the eager `ray`/`spark`/`pyspark` imports into a `TYPE_CHECKING` block (for static tooling) plus in-body imports inside the two `compute_*` methods.
- `multiprocessing`/`serial` backends stay eager (they're cheap).

No public API change — `toksearch/__init__.py` re-exports none of the backend classes. PEP 563 is safe here: the file has no dataclass/pydantic/`get_type_hints` usage.

**Measured (same env, warm):** `import toksearch` **~4.38s → ~1.40s** (~3× faster); `ray`/`pyspark` no longer appear in `sys.modules` after import.

A subprocess-based regression test (`tests/test_lazy_backend_imports.py`) locks in the win so an eager import can't silently creep back.

## Test Plan

- [x] `tests/test_lazy_backend_imports.py` — passes (asserts `ray`/`pyspark` absent from a fresh interpreter's `sys.modules` after `import toksearch` and after building a `Pipeline`)
- [x] `tests/test_pipeline.py` — 28 passed (exercises the Ray backend end-to-end via the now-lazy import)
- [x] Full non-cluster suite — 305 passed / 3 skipped
- [x] Import-time measured before/after in the same pixi env (~4.38s → ~1.40s)

Spec + plan: `docs/superpowers/specs/2026-07-07-lazy-backend-imports-design.md`, `docs/superpowers/plans/2026-07-08-lazy-backend-imports.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)