### PR TITLE
fix: embed plotly.js inline so chat-GUI figures render offline

### DIFF
--- a/tests/test_llm_gui_app.py
+++ b/tests/test_llm_gui_app.py
@@ -153,6 +153,16 @@ class TestChatFn(unittest.TestCase):
         self.assertIn("srcdoc=", html)
         # The escaped srcdoc payload should reference plotly.
         self.assertIn("plotly", html.lower())
+        # Offline-correct: the plotly.js *library* must be embedded inline,
+        # NOT loaded from the CDN. FDP runs on air-gapped/network-restricted
+        # compute where cdn.plot.ly is unreachable and a CDN-referenced
+        # figure would render blank. The embedded library's version banner
+        # ("plotly.js vX.Y.Z") is present only when inlined, and the payload
+        # is correspondingly large. (Note: the library *source* itself
+        # mentions cdn.plot.ly for topojson/image-export defaults, so we
+        # can't simply assert the substring is absent.)
+        self.assertIn("plotly.js v", html)
+        self.assertGreater(len(html), 1_000_000)
         # The iframe must carry the fullscreen permission AND
         # contain the injected fullscreen button + script.
         self.assertIn('allow="fullscreen"', html)

--- a/toksearch/llm/gui/app.py
+++ b/toksearch/llm/gui/app.py
@@ -95,16 +95,22 @@ def _plotly_iframe(fig, height: int = 500) -> str:
     stanza zeroes the iframe body margin so plotly fills the whole
     iframe rather than leaving a default browser gutter.
 
-    plotly.js itself loads from the CDN so the iframe payload stays
-    small (just chart data + a ``<script src="https://cdn.plot.ly/...">``
-    reference); the CDN script caches across charts.
+    plotly.js is embedded **inline** in the iframe (``include_plotlyjs=True``)
+    rather than referenced from the CDN. FDP commonly runs on air-gapped /
+    network-restricted lab compute where ``cdn.plot.ly`` is unreachable; a CDN
+    reference there silently fails to load plotly.js and the figure renders
+    blank (while matplotlib, a static PNG, still works). Inlining makes each
+    figure self-contained and offline-correct. Trade-off: ~several MB of
+    plotly.js per figure — fine over localhost, but a chat with many plots
+    grows the page; a future optimization could serve plotly.js once from the
+    Gradio static route.
     """
     import html as _html
     # Force autosize so the chart honors the iframe width rather than
     # plotly's default fixed pixel width.
     fig.update_layout(autosize=True)
     inner = fig.to_html(
-        include_plotlyjs="cdn",
+        include_plotlyjs=True,
         full_html=True,
         config={"responsive": True},
         default_height="100%",


### PR DESCRIPTION
## Summary

The inline-Plotly iframe in the chat GUI referenced plotly.js from the CDN (`include_plotlyjs='cdn'`). On air-gapped / network-restricted lab compute (FDP's common deployment) `cdn.plot.ly` is unreachable, so plotly.js never loads and the figure renders **blank** — while matplotlib (a static PNG) still works. This reads as the GUI "refusing" to show Plotly inline.

This embeds the library inline (`include_plotlyjs=True`) so each figure is self-contained and offline-correct.

**Trade-off:** ~several MB of plotly.js per figure — fine over localhost, but a chat with many plots grows the page. A future optimization could serve plotly.js once from the Gradio static route.

## Test Plan

- [x] `tests/test_llm_gui_app.py` — 11 passed; the updated test pins the embedded-library version banner (`plotly.js v…`, present only when inlined) and the correspondingly large payload size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)