### PR TITLE
fix(anthropic): friendly LLMAuthError when no API key is configured

### DIFF
--- a/tests/test_llm_backends_anthropic.py
+++ b/tests/test_llm_backends_anthropic.py
@@ -134,5 +134,40 @@ class TestAnthropicBaseUrl(unittest.TestCase):
                 "https://custom.example")
 
 
+class TestAnthropicMissingKey(unittest.TestCase):
+    # With no key available the SDK raises TypeError ("Could not resolve
+    # authentication method") — at request time in current versions, at
+    # construction in older ones. Both sites must translate it into
+    # LLMAuthError so the CLI prints remedies, not a traceback.
+
+    def _assert_remedies(self, exc):
+        msg = str(exc)
+        self.assertIn("ANTHROPIC_API_KEY", msg)
+        self.assertIn("config.toml", msg)
+        self.assertIn("claude-max", msg)
+
+    def test_request_time_typeerror_translated(self):
+        backend = AnthropicBackend(api_key=None)
+        backend._client = mock.MagicMock()
+        backend._client.messages.create.side_effect = TypeError(
+            "Could not resolve authentication method.")
+        with self.assertRaises(LLMAuthError) as ctx:
+            backend._send_request(system_prompt="s", history=[],
+                                  tools=[], model="m")
+        self._assert_remedies(ctx.exception)
+
+    def test_construction_time_typeerror_translated(self):
+        backend = AnthropicBackend(api_key=None)
+        # Patch through the backend module's own reference so this works
+        # whether `anthropic` is the stub above or the real SDK.
+        with mock.patch(
+            "toksearch.llm.backends.anthropic.anthropic.Anthropic",
+            side_effect=TypeError("Could not resolve authentication method."),
+        ):
+            with self.assertRaises(LLMAuthError) as ctx:
+                backend._ensure_client()
+        self._assert_remedies(ctx.exception)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/toksearch/llm/backends/anthropic.py
+++ b/toksearch/llm/backends/anthropic.py
@@ -44,13 +44,28 @@ class AnthropicBackend(_ToolLoopBackend):
         self._max_tokens = max_tokens
         self._client = None  # lazy; tests inject a mock
 
+    # The SDK raises TypeError ("Could not resolve authentication method")
+    # when no key is available — at construction in older versions, at
+    # request time in newer ones. Both sites translate it via this helper so
+    # the CLI prints remedies instead of a traceback.
+    @staticmethod
+    def _missing_key_error(e: TypeError) -> LLMAuthError:
+        return LLMAuthError(
+            "No Anthropic API key found. Either export ANTHROPIC_API_KEY, "
+            "set anthropic_api_key in the [llm] table of ~/.fdp/config.toml, "
+            "or use --backend claude-max to authenticate via the claude CLI."
+        )
+
     def _build_client(self):
         kwargs = {}
         if self._api_key is not None:
             kwargs["api_key"] = self._api_key
         if self._base_url is not None:
             kwargs["base_url"] = self._base_url
-        self._client = anthropic.Anthropic(**kwargs)
+        try:
+            self._client = anthropic.Anthropic(**kwargs)
+        except TypeError as e:
+            raise self._missing_key_error(e) from e
         return self._client
 
     def _ensure_client(self):
@@ -119,6 +134,8 @@ class AnthropicBackend(_ToolLoopBackend):
                 messages=self._history_to_native(history),
                 tools=[self._spec_to_native(t) for t in tools],
             )
+        except TypeError as e:
+            raise self._missing_key_error(e) from e
         except anthropic.AuthenticationError as e:
             raise LLMAuthError(
                 "Anthropic auth failed. Set ANTHROPIC_API_KEY or pass "


### PR DESCRIPTION
## Summary
- `fdp chat --query` with no Anthropic credentials crashed with a raw `TypeError: Could not resolve authentication method` traceback (reported 2026-07-30)
- The SDK raises that `TypeError` outside the `anthropic.*` exception types the backend translates — at request time in current SDKs, at construction in older ones; both sites now raise `LLMAuthError` naming the remedies: `ANTHROPIC_API_KEY`, `anthropic_api_key` in `~/.fdp/config.toml [llm]`, or `--backend claude-max`

## Test Plan
- [x] 2 new unit tests (request-time and construction-time translation), file-local SDK-stub convention
- [x] `tests.test_llm_backends_anthropic`: 7/7 OK
- [x] llm subset: 154 passed, 3 skipped
- [x] Live repro: `env -u ANTHROPIC_API_KEY … _send_request(...)` now prints the friendly message

🤖 Generated with [Claude Code](https://claude.com/claude-code)