### PR TITLE
ci: fix Deploy Docs step never firing on release tags

### DIFF
--- a/.github/workflows/conda_build.yaml
+++ b/.github/workflows/conda_build.yaml
@@ -57,9 +57,17 @@ jobs:
             ${HOME}/outdir/linux-64/*.conda
 
       - name: Deploy Docs
-        if: startsWith(github.ref, 'refs/tags/release-') && !contains(github.ref, 'rc') && !contains(github.ref, 'a') && !contains(github.ref, 'b')
+        # Pre-release detection happens in bash below: contains(github.ref, 'a')
+        # can never work as a guard because every ref contains the letter 'a'
+        # ("refs/tags/release-..."), which silently skipped this step on every
+        # stable release from 2.5 to 2.8.3.
+        if: startsWith(github.ref, 'refs/tags/release-')
         run: |
           TAG=${GITHUB_REF#refs/tags/release-}
+          if [[ "$TAG" =~ (rc|a|b)[0-9] ]]; then
+            echo "Pre-release $TAG — skipping docs deploy"
+            exit 0
+          fi
           MAJOR=$(echo $TAG | cut -d. -f1)
           MINOR=$(echo $TAG | cut -d. -f2)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ you> What's the peak |Ip| in MA?
 [output] 1.1325
 ```
 
-Backends: Anthropic API, OpenAI API, your Claude Max plan via the Claude Agent SDK, or the American Science Cloud (AmSC) endpoint via `toksearch_d3d`. See the [LLM tutorial](https://ga-fdp.github.io/toksearch/LLM_Tutorial/) for an end-to-end walkthrough and the [LLM Interface reference](https://ga-fdp.github.io/toksearch/llm/) for the full API surface.
+Backends: Anthropic API, OpenAI API, your Claude Max plan via the Claude Agent SDK, or the American Science Cloud (AmSC) endpoint via `toksearch_d3d`. See the [LLM tutorial](https://ga-fdp.github.io/toksearch/latest/LLM_Tutorial/) for an end-to-end walkthrough and the [LLM Interface reference](https://ga-fdp.github.io/toksearch/latest/llm/) for the full API surface.
 
 
 ## Installation


### PR DESCRIPTION
## Summary
- The Deploy Docs guard `!contains(github.ref, 'a')` can never pass — every ref (`refs/t**a**gs/rele**a**se-…`) contains an `a` — so docs deployment silently skipped on every stable release since the step was added; the published site froze at 2.4.X (breaking the README's LLM-doc links)
- Detect pre-releases in bash against the parsed version (`(rc|a|b)[0-9]`), mirroring the Upload step's existing logic
- 2.8.X docs were backfilled to gh-pages manually (`mike deploy --push --update-aliases 2.8.X latest`), so `latest` now serves 2.8.X including `llm.md` and the LLM tutorial

## Test Plan
- [x] Confirmed `Deploy Docs: skipped` on the release-2.8.3 run (vs `Upload to Anaconda: success`)
- [x] Repo default workflow permissions are `write`, so the CI gh-pages push is authorized
- [x] Manual backfill exercised the exact deploy command end-to-end (build + push verified on origin/gh-pages)
- [ ] Fires for real on the next `release-*` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)