### PR TITLE
docs(llm): fix stale amsc-default claim; refresh cli.py comment

### DIFF
--- a/docs/llm.md
+++ b/docs/llm.md
@@ -65,9 +65,14 @@ DIII-D environment, the `fdp` script wraps the same commands with the
 FDP environment pre-configured (XRootD plugin, MDSplus tree paths, etc.):
 
 ```bash
-fdp query "Fetch ip for shot 200000 and report peak in MA."  # default: --backend amsc
+fdp query "Fetch ip for shot 200000 and report peak in MA."
 fdp chat                                                       # interactive
 ```
+
+The backend default is deployment-level, not device-driven: `--backend` →
+`$FDP_LLM_BACKEND` → `~/.fdp/config.toml [llm].backend` → built-in
+`anthropic`. GA on-prem users who want AmSC by default should set
+`backend = "amsc"` in `config.toml` (or `export FDP_LLM_BACKEND=amsc`).
 
 ### Python
 

--- a/toksearch/llm/cli.py
+++ b/toksearch/llm/cli.py
@@ -35,9 +35,10 @@ from .session import Session
 def build_session(args) -> Session:
     """Construct a Session from parsed CLI args."""
     cfg = load_config()
-    # Default backend is "anthropic" in PR 1; PR 4 will register the "amsc"
-    # preset (via toksearch_d3d entry point) and the default will move to
-    # "amsc" to preserve the existing fdp query behavior for GA-on-prem users.
+    # The default backend is deliberately deployment-level, not
+    # device-driven (fdp decoupled backend choice from the device catalog):
+    # flag > $FDP_LLM_BACKEND/config.toml > built-in "anthropic". Sites
+    # wanting a different default (e.g. amsc) set it in config.toml.
     backend_name = args.backend or cfg.backend or "anthropic"
     preset = resolve_preset(backend_name, cfg)
     backend_cls = get_backend_class(preset.backend)


### PR DESCRIPTION
## Summary
- `docs/llm.md` claimed `fdp query` defaults to `--backend amsc`; since fdp 0.5.x the backend is deployment-level (flag → `$FDP_LLM_BACKEND` → `config.toml [llm].backend` → built-in `anthropic`). Documents the real chain and how GA on-prem users pin `amsc`
- Replaces the outdated "PR 1/PR 4 will move the default to amsc" planning comment in `cli.py` (comment-only; no behavior change)

## Test Plan
- [x] `tests.test_llm_cli` green (comment-only code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)