### PR TITLE
feat(mcp): skills server compatible with mcp 1.x and 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ llm = [
     "openai>=1.50",
     "matplotlib",
     "claude-agent-sdk>=0.2",
+    # <2 held only by claude-agent-sdk; toksearch's mcp code runs on 1.x and 2.x
     "mcp>=1.23,<2",
 ]
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -48,6 +48,9 @@ requirements:
     - openai >=1.50
     - claude-agent-sdk >=0.2
     - gradio >=4
+    # toksearch's own mcp code runs under 1.x and 2.x; the <2 ceiling is
+    # held only by claude-agent-sdk (create_sdk_mcp_server uses the 1.x
+    # lowlevel API). Relax once claude-agent-sdk supports mcp 2.
     - mcp >=1.23,<2
     - matplotlib
     - plotly

--- a/tests/test_llm_mcp_server.py
+++ b/tests/test_llm_mcp_server.py
@@ -17,13 +17,62 @@ import asyncio
 import os
 import sys
 import unittest
+from contextlib import asynccontextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import mock
 
-from mcp.shared.memory import create_connected_server_and_client_session as connect
+try:
+    # mcp 1.x: one-call in-memory client/server bridge.
+    from mcp.shared.memory import (
+        create_connected_server_and_client_session as _connect_v1)
+except ImportError:
+    # mcp >= 2.0: the helper is gone; wire the memory streams by hand.
+    _connect_v1 = None
+    import anyio
+    from mcp import ClientSession
+    from mcp.shared.memory import create_client_server_memory_streams
 
 from toksearch.llm.mcp.server import build_server, discover_filtered_skills
+
+
+def _lowlevel(server):
+    """The wrapped lowlevel server: _mcp_server (1.x) / _lowlevel_server (2.x)."""
+    return getattr(server, "_mcp_server", None) or server._lowlevel_server
+
+
+def _is_error(result):
+    """CallToolResult error flag: isError (mcp 1.x) / is_error (2.x)."""
+    return getattr(result, "isError", None) if hasattr(result, "isError") \
+        else result.is_error
+
+
+def _mime_type(contents):
+    """Resource contents mime type: mimeType (mcp 1.x) / mime_type (2.x)."""
+    return getattr(contents, "mimeType", None) if hasattr(contents, "mimeType") \
+        else contents.mime_type
+
+
+@asynccontextmanager
+async def connect(server):
+    """Yield an un-initialized in-memory ClientSession for either mcp major."""
+    low = _lowlevel(server)
+    if _connect_v1 is not None:
+        async with _connect_v1(low) as client:
+            yield client
+        return
+    async with create_client_server_memory_streams() as (client_s, server_s):
+        client_read, client_write = client_s
+        server_read, server_write = server_s
+        async with anyio.create_task_group() as tg:
+            async def _serve():
+                await low.run(server_read, server_write,
+                              low.create_initialization_options(),
+                              raise_exceptions=True)
+            tg.start_soon(_serve)
+            async with ClientSession(client_read, client_write) as client:
+                yield client
+            tg.cancel_scope.cancel()
 
 
 def _make_skill(root: Path, name: str, description: str, body: str) -> None:
@@ -86,7 +135,7 @@ class TestServerInMemory(unittest.TestCase):
             server = build_server(extra_dirs=[root], packages=[])
 
             async def go():
-                async with connect(server._mcp_server) as client:
+                async with connect(server) as client:
                     await client.initialize()
                     listed = await client.list_resources()
                     uris = {str(r.uri): r for r in listed.resources}
@@ -95,7 +144,8 @@ class TestServerInMemory(unittest.TestCase):
                         uris["skill://alpha"].description, "Alpha skill")
                     read = await client.read_resource("skill://alpha")
                     self.assertIn("ALPHA BODY", read.contents[0].text)
-                    self.assertEqual(read.contents[0].mimeType, "text/markdown")
+                    self.assertEqual(_mime_type(read.contents[0]),
+                                     "text/markdown")
             asyncio.run(go())
 
     def test_read_skill_tool_ok_and_unknown(self):
@@ -105,15 +155,15 @@ class TestServerInMemory(unittest.TestCase):
             server = build_server(extra_dirs=[root], packages=[])
 
             async def go():
-                async with connect(server._mcp_server) as client:
+                async with connect(server) as client:
                     await client.initialize()
                     ok = await client.call_tool(
                         "read_skill", {"skill_name": "alpha"})
-                    self.assertIs(ok.isError, False)
+                    self.assertIs(_is_error(ok), False)
                     self.assertIn("ALPHA BODY", ok.content[0].text)
                     bad = await client.call_tool(
                         "read_skill", {"skill_name": "nope"})
-                    self.assertIs(bad.isError, True)
+                    self.assertIs(_is_error(bad), True)
                     self.assertIn("Unknown skill", bad.content[0].text)
             asyncio.run(go())
 

--- a/toksearch/llm/mcp/server.py
+++ b/toksearch/llm/mcp/server.py
@@ -20,7 +20,13 @@ resource, with a ``read_skill`` tool for clients that don't read resources.
 
 from pathlib import Path
 
-from mcp.server.fastmcp import FastMCP
+try:
+    # mcp 1.x ships the high-level server as vendored FastMCP.
+    from mcp.server.fastmcp import FastMCP as _McpServer
+except ImportError:
+    # mcp >= 2.0 removes mcp.server.fastmcp; the renamed MCPServer keeps
+    # the same resource()/tool()/run() surface.
+    from mcp.server import MCPServer as _McpServer
 
 from ..discovery import discover_skill_dirs
 from ..tools import Skill, discover_skills
@@ -58,9 +64,9 @@ def discover_filtered_skills(
 def build_server(
     extra_dirs: list[Path] | None = None,
     packages: list[str] | None = None,
-) -> FastMCP:
-    """Build a FastMCP server exposing discovered skills as resources + tool."""
-    mcp = FastMCP("toksearch-skills")
+) -> _McpServer:
+    """Build an MCP server exposing discovered skills as resources + tool."""
+    mcp = _McpServer("toksearch-skills")
     skills = discover_filtered_skills(extra_dirs=extra_dirs, packages=packages)
 
     for name, skill in skills.items():


### PR DESCRIPTION
## Summary
- Adaptive import in `server.py`: `mcp.server.fastmcp.FastMCP` (1.x) → `mcp.server.MCPServer` (2.x) — the renamed class keeps the identical `resource()/tool()/run()` decorator surface
- Tests bridged for both majors: the removed `create_connected_server_and_client_session` helper is reimplemented over `create_client_server_memory_streams` under 2.x; renamed response-model fields (`isError`→`is_error`, `mimeType`→`mime_type`) accessed adaptively
- Production `client.py` needed **zero changes** (only reads fields that survive)
- The `mcp >=1.23,<2` ceiling **stays** — held solely by claude-agent-sdk (`create_sdk_mcp_server` uses the removed 1.x lowlevel API). When claude-agent-sdk ships mcp-2 support, relaxing the pin is the entire remaining work.

## Test Plan
- [x] mcp 1.27 (pinned env): `test_llm_mcp_server` + `test_llm_mcp_client` — 9/9 OK
- [x] mcp 2.0.0 (scratch venv, real code files): in-memory resources list/read + `read_skill` tool (incl. error case), `python -m toksearch.llm.mcp` stdio launch, `SkillsMcpClient` round trip, bogus-command error path — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)