### PR TITLE
MdsSignal: route fdp:// locations to a remote signal, and depend on the transport

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -202,7 +202,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.5-default_h746c552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
@@ -216,9 +216,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_117.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
@@ -227,7 +227,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.39.0-hdb79228_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.39.0-hdbdcf42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.73.1-h3288cfb_1.conda
@@ -266,6 +266,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.4-hd5a49e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hf670292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h7b12aa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_17.conda
@@ -273,9 +274,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_117.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h454ac66_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
@@ -308,6 +309,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py312he3d6523_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mcp-1.27.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/ga-fdp/linux-64/mdsip-fdp-0.1.0-h80ff2d7_0.conda
       - conda: https://conda.anaconda.org/ga-fdp/linux-64/mdsplus-xrdcl-1.0.0-py312ha0f1011_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.0-pyhcf101f3_0.conda
@@ -3514,23 +3516,24 @@ packages:
   purls: []
   size: 4518030
   timestamp: 1770902209173
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
-  sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
-  md5: c3cc2864f82a944bc90a7beb4d3b0e88
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
+  sha256: aff8ef75636d0825ce34911e0bef2f26816e7afd090a9dcb4b9bacab75cbf584
+  md5: 3f2fd5617cfacac49c85f6dc63842ea1
   depends:
   - __glibc >=2.17,<3.0.a0
   - krb5 >=1.22.2,<1.23.0a0
   - libgcc >=14
   - libnghttp2 >=1.68.1,<2.0a0
+  - libpsl >=0.23.0,<0.24.0a0
   - libssh2 >=1.11.1,<2.0a0
   - libzlib >=1.3.2,<2.0a0
-  - openssl >=3.5.6,<4.0a0
+  - openssl >=3.5.7,<4.0a0
   - zstd >=1.5.7,<1.6.0a0
   license: curl
   license_family: MIT
   purls: []
-  size: 468706
-  timestamp: 1777461492876
+  size: 480565
+  timestamp: 1785500108494
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
   sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
   md5: 6c77a605a7a689d17d4819c0f8ac9a00
@@ -3712,6 +3715,20 @@ packages:
   purls: []
   size: 1040478
   timestamp: 1770252533873
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+  sha256: d5cb8475131c31680f8fd30512c418f373064e272e452063276a8fb14c9fa42f
+  md5: 5a7d954665c707c93311657cd779c705
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 16.1.0 he0feb66_1
+  - libgcc-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 1057877
+  timestamp: 1785375436766
 - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_117.conda
   sha256: 57ef92396b4dc06c5a34792c0f601bc49793a963712e8419d5f03cb4ff87729f
   md5: 50d5470d29a25808d108d3917426d24b
@@ -3732,6 +3749,16 @@ packages:
   purls: []
   size: 27541
   timestamp: 1770252546553
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+  sha256: 225275c562337a1cd61705da0ee4235dde7bba7504de1c34b74c894adb2b0eee
+  md5: 7ed870c014a6f23c7dfafda53d2763a9
+  depends:
+  - libgcc 16.1.0 ha9f2e26_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 28210
+  timestamp: 1785375440733
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_17.conda
   sha256: 1604c083dd65bc91e68b6cfe32c8610395088cb96af1acaf71f0dcaf83ac58f7
   md5: a6c682ac611cb1fa4d73478f9e6efb06
@@ -3837,6 +3864,16 @@ packages:
   purls: []
   size: 603334
   timestamp: 1770252441199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+  sha256: 62cb599ad0539d99386515326d9d5e8f51f75a60c69c2131b21df76edf35bd89
+  md5: 88f2d91cb1533194c323534253094d23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 640415
+  timestamp: 1785375373755
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.39.0-hdb79228_0.conda
   sha256: d3341cf69cb02c07bbd1837968f993da01b7bd467e816b1559a3ca26c1ff14c5
   md5: a2e30ccd49f753fd30de0d30b1569789
@@ -4363,6 +4400,19 @@ packages:
   purls: []
   size: 4372578
   timestamp: 1766316228461
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hf670292_0.conda
+  sha256: 2e6405feb59e3f40a5a4641dfa73afda158046893aa73d478e23415e18997ece
+  md5: c8217f5bdd5b018087bdea081912cda5
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 72505
+  timestamp: 1786443494718
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h7b12aa8_0.conda
   sha256: eb5d5ef4d12cdf744e0f728b35bca910843c8cf1249f758cf15488ca04a21dbb
   md5: a30848ebf39327ea078cf26d114cff53
@@ -4496,6 +4546,19 @@ packages:
   purls: []
   size: 5852406
   timestamp: 1770252584235
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  sha256: 79721dd08aeb0ab9e773f1f9ef41cf4e6c17477e3d72319147619045bce05a09
+  md5: aed6cf89adc1e9b846e4367ac538e434
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 16.1.0 ha9f2e26_1
+  constrains:
+  - libstdcxx-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 6631744
+  timestamp: 1785375462643
 - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_117.conda
   sha256: ffb164d31e09b18cf95c6330bfce9268c1ce799103e56b7c004250332e7f9ede
   md5: 97f8b7e451f960200c057ca83d92f9be
@@ -4516,6 +4579,16 @@ packages:
   purls: []
   size: 27573
   timestamp: 1770252638797
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+  sha256: 2876ca4463d1b394eb969ce4a84d1620aa63fb8202a6397837d1e45ec76c1208
+  md5: c94f06123272d8e129d4acf3a25ffb35
+  depends:
+  - libstdcxx 16.1.0 h934c35e_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 28253
+  timestamp: 1785375500257
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
   sha256: c5008b602cb5c819f7b52d418b3ed17e1818cbbf6705b189e7ab36bb70cce3d8
   md5: 8ee3cb7f64be0e8c4787f3a4dbe024e6
@@ -5042,6 +5115,18 @@ packages:
   license_family: MIT
   size: 43805
   timestamp: 1754946862113
+- conda: https://conda.anaconda.org/ga-fdp/linux-64/mdsip-fdp-0.1.0-h80ff2d7_0.conda
+  sha256: abc993d73abd83fb8662a29f655a56af7684f0a842121369b8840ced817415b9
+  md5: c0795a4c789aaf05ad4092aac0467e05
+  depends:
+  - mdsplus-xrdcl
+  - libstdcxx >=16
+  - libgcc >=16
+  - __glibc >=2.28,<3.0.a0
+  - libcurl >=8.21.0,<9.0a0
+  license: Apache-2.0
+  size: 37287
+  timestamp: 1786645856335
 - conda: https://conda.anaconda.org/ga-fdp/linux-64/mdsplus-xrdcl-1.0.0-py312ha0f1011_2.conda
   sha256: 7a753a39b175bfe402fbdea8a9a78cb1374710888cb12f19552e5ed1004eef31
   md5: 5c147ee8c8242aed6fa9ca66016880cd
@@ -7347,7 +7432,7 @@ packages:
   timestamp: 1764695075374
 - pypi: ./
   name: toksearch
-  version: 2.8.1+20.g67d385b
+  version: 2.8.3+4.geed1425.dirty
   sha256: cb594b0acae3aee03eaed1ba38aeef128969e335e0b77dbbc20031f8389f808b
   requires_dist:
   - anthropic>=0.34 ; extra == 'llm'

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,6 +6,11 @@ platforms = ["linux-64"]
 [dependencies]
 python = ">=3.11,<3.13"
 mdsplus-xrdcl = ">=1,<2"
+# Supplies libMdsIpFDP.so, the transport MDSplus loads for an 'fdp://' location.
+# A dev/test dependency only, deliberately NOT in the conda recipe's run
+# requirements: MdsSignal's fdp:// support is an optional capability, and
+# toksearch is used at sites that have no FDP origin to reach.
+mdsip-fdp = ">=0.1.0"
 numpy = ">=1.20, <2"
 pymssql = "*"
 ray-core = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,9 +7,7 @@ platforms = ["linux-64"]
 python = ">=3.11,<3.13"
 mdsplus-xrdcl = ">=1,<2"
 # Supplies libMdsIpFDP.so, the transport MDSplus loads for an 'fdp://' location.
-# A dev/test dependency only, deliberately NOT in the conda recipe's run
-# requirements: MdsSignal's fdp:// support is an optional capability, and
-# toksearch is used at sites that have no FDP origin to reach.
+# Also a run requirement of the conda package -- see recipe/recipe.yaml.
 mdsip-fdp = ">=0.1.0"
 numpy = ">=1.20, <2"
 pymssql = "*"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -25,6 +25,16 @@ requirements:
   run:
     - python
     - mdsplus-xrdcl >=1,<2
+    # libMdsIpFDP.so, the transport MDSplus loads for an 'fdp://' location.
+    # A protocol, not a device: DIII-D is served this way today and C-Mod is
+    # next, so this is not DIII-D-specific plumbing riding along in core
+    # toksearch. Without it, an fdp:// location fails at connect with
+    # "Protocol FDP is not supported" on stderr and a bare "Error connecting"
+    # exception -- which, inside a Pipeline worker, loses the useful half.
+    #
+    # It is built once per MDSplus provider; the mdsplus-xrdcl pin above selects
+    # the matching variant.
+    - mdsip-fdp >=0.1.0
     - fdp-schema >=0.1.1
     - numpy >=1.20, <2
     - pymssql

--- a/tests/test_mds.py
+++ b/tests/test_mds.py
@@ -176,14 +176,25 @@ class TestMdsTreePath(unittest.TestCase):
 class TestMdsSignal(unittest.TestCase):
 
     def test_remote_location_grabbed_from_environment(self):
+        # A URL in TOKSEARCH_MDS_DEFAULT is a server, not a tree path. It used
+        # to become a treepath of the literal string "remote://fake.gat.com",
+        # which no tree can be opened from -- so setting the environment
+        # variable to a server silently produced a local signal that could only
+        # fail later.
         server = "fake.gat.com"
         default_location = f"remote://{server}"
 
         with set_env("TOKSEARCH_MDS_DEFAULT", default_location):
             sig = MdsSignal("blah", "efit01")
-        self.assertIsInstance(sig.sig, MdsLocalSignal)
-        self.assertIsInstance(sig.sig.treepath, MdsTreePath)
-        self.assertEqual(sig.sig.treepath.paths["efit01"], default_location)
+        self.assertIsInstance(sig.sig, MdsRemoteSignal)
+        self.assertEqual(sig.sig.server, server)
+
+    def test_fdp_location_grabbed_from_environment(self):
+        url = "fdp://origin.example.org:8443/mdsip"
+        with set_env("TOKSEARCH_MDS_DEFAULT", url):
+            sig = MdsSignal("blah", "efit01")
+        self.assertIsInstance(sig.sig, MdsRemoteSignal)
+        self.assertEqual(sig.sig.server, url)
 
     def test_local_location_grabbed_from_environment(self):
         default_location = "/some/fake/path"
@@ -219,6 +230,46 @@ class TestMdsSignal(unittest.TestCase):
             sig = MdsSignal("blah", "efit01", location=None)
         self.assertIsInstance(sig.sig.treepath, MdsTreePath)
         self.assertIsInstance(sig.sig, MdsLocalSignal)
+
+    def test_fdp_location_is_remote_and_keeps_the_whole_url(self):
+        # The scheme selects the MDSplus transport and the path is the relay's
+        # prefix on the origin, so unlike 'remote://' neither may be dropped.
+        # Before this was handled, urlparse's path was taken as a treepath and
+        # the host was discarded: the signal became a LOCAL read of "/mdsip".
+        url = "fdp://origin.example.org:8443/mdsip"
+        sig = MdsSignal("blah", "efit01", location=url)
+        self.assertIsInstance(sig.sig, MdsRemoteSignal)
+        self.assertEqual(sig.sig.server, url)
+
+    def test_fdp_location_without_a_path(self):
+        url = "fdp://origin.example.org:8443"
+        sig = MdsSignal("blah", "efit01", location=url)
+        self.assertIsInstance(sig.sig, MdsRemoteSignal)
+        self.assertEqual(sig.sig.server, url)
+
+    def test_other_mdsplus_transport_schemes_are_remote(self):
+        for url in ("tcp://a.gat.com:8000", "tcpv6://a.gat.com", "udt://a.gat.com"):
+            with self.subTest(url=url):
+                sig = MdsSignal("blah", "efit01", location=url)
+                self.assertIsInstance(sig.sig, MdsRemoteSignal)
+                self.assertEqual(sig.sig.server, url)
+
+    def test_unknown_scheme_raises_rather_than_becoming_a_treepath(self):
+        # Silently dropping the host turns a mistyped server into a local read
+        # that fails much later, somewhere less informative.
+        for url in ("pelican://osg-htc.org:443/fdp-d3d/x", "http://example.org/x"):
+            with self.subTest(url=url):
+                with self.assertRaises(ValueError):
+                    MdsSignal("blah", "efit01", location=url)
+
+    def test_host_double_colon_path_is_a_treepath(self):
+        # urlparse reads 'atlas.gat.com::/trees' as scheme 'atlas.gat.com'
+        # (dots are legal in a scheme), so this must be settled before any
+        # scheme dispatch or it looks like a server.
+        location = "atlas.gat.com::/trees"
+        sig = MdsSignal("blah", "efit01", location=location)
+        self.assertIsInstance(sig.sig, MdsLocalSignal)
+        self.assertEqual(sig.sig.treepath, location)
 
 
 class GenericTestMdsSignal(ABC):

--- a/toksearch/signal/mds.py
+++ b/toksearch/signal/mds.py
@@ -26,6 +26,12 @@ the MdsRemoteSignal class is used to fetch data from a remote server. The
 MdsSignal class determines which class to use based on the location argument
 provided to the constructor.
 
+A location is read as a server when it carries a URL scheme, and as a tree path
+otherwise. 'remote://host' names a server reached over MDSplus's default
+transport, while a scheme in MDSIP_TRANSPORT_SCHEMES -- notably 'fdp://', which
+reaches an FDP Pelican origin over HTTPS -- names the transport itself and is
+passed to MDSplus.Connection whole.
+
 Behind the scenes, the MdsLocalSignal uses the MdsTreeRegistry class to manage
 MDSplus trees on a local disk. The MdsRemoteSignal uses the MdsConnectionRegistry
 class to manage connections to remote servers.
@@ -51,6 +57,24 @@ from .signal import Signal
 from ..utilities.utilities import set_env
 
 _log = logging.getLogger(__name__)
+
+
+# URL schemes that name an MDSplus *transport*, so a location using one is a
+# connection string rather than a tree path.
+#
+# MDSplus picks the transport from the scheme itself: parse_host() splits
+# <scheme>://<host>, and LoadIo() dlopens "libMdsIp" + SCHEME.upper() + ".so"
+# and resolves the symbol Io. 'fdp' comes from the mdsip-fdp package
+# (GA-FDP/xrdoss-mdsplus) and tunnels mdsip over a Pelican origin's HTTPS port;
+# the rest ship with MDSplus.
+#
+# This is an allowlist rather than "any scheme" because LoadIo does not report
+# an unknown scheme as an error -- it silently returns the ssh-tunnel routines.
+# A typo would therefore try to ssh somewhere instead of failing, and a tree
+# path that happens to look like a URL would be quietly misread as a server.
+MDSIP_TRANSPORT_SCHEMES = frozenset(
+    {"fdp", "tcp", "tcpv6", "udt", "udtv6", "gsi", "ssh"}
+)
 
 
 def _dim_of_expression(expression, dim=0):
@@ -229,9 +253,22 @@ class MdsSignal(Signal):
                 also specify a remote server by specifying the location as
                 'remote://some.server'
 
+                - If a URL with an MDSplus transport scheme is given, it is used
+                as a connection string in full. In particular 'fdp://' reaches an
+                FDP Pelican origin over HTTPS, e.g.
+                'fdp://fdp-d3d-origin.nationalresearchplatform.org:8443/mdsip',
+                where the path is the relay's prefix on that origin. This
+                requires the mdsip-fdp package, which supplies the transport
+                MDSplus loads for the scheme. See MDSIP_TRANSPORT_SCHEMES.
+
                 - If an MdsTreePath object is provided, then the signal data is
                 fetched from a local disk according to the path specifications in
                 the MdsTreePath object.
+
+                A location carrying a scheme that is none of the above raises
+                ValueError rather than being read as a tree path, since dropping
+                the host silently would otherwise turn a mistyped server into a
+                local read.
             dims: See documentation for the Signal class. Defaults to ('times',)
             data_order: See documentation for the Signal class. Defaults to the same
                 as dims.
@@ -266,6 +303,14 @@ class MdsSignal(Signal):
 
                 default_location = os.getenv("TOKSEARCH_MDS_DEFAULT", None)
                 if default_location:
+                    if "://" in default_location:
+                        # A connection string, not a tree path. Dispatch it the
+                        # same way an explicit location= would be, so that
+                        # pointing a whole workflow at a server through the
+                        # environment behaves like pointing one signal at it.
+                        return cls.create_local_or_remote_signal(
+                            expression, treename, default_location, **kwargs
+                        )
                     path_kwargs = {treename: default_location}
 
             location = MdsTreePath(**path_kwargs)
@@ -274,21 +319,42 @@ class MdsSignal(Signal):
         if isinstance(location, MdsTreePath):
             return MdsLocalSignal(expression, treename, treepath=location, **kwargs)
 
+        # Anything without '://' is a tree path, not a URL, and is passed
+        # through untouched. That covers plain directories and MDSplus's own
+        # 'host::' / 'host::/path' syntax -- which must be settled before
+        # urlparse gets involved, because it reads 'abc::' as scheme 'abc' and
+        # 'atlas.gat.com::/trees' as scheme 'atlas.gat.com' (dots are legal in
+        # a scheme), either of which would otherwise be mistaken for a server.
+        if "://" not in location:
+            return MdsLocalSignal(
+                expression, treename, treepath=(location or None), **kwargs
+            )
+
         parsed_location = urlparse(location)
-        is_remote = parsed_location.scheme == "remote"
+        scheme = parsed_location.scheme.lower()
 
-        if is_remote:
-            server = parsed_location.netloc
-            sig = MdsRemoteSignal(expression, treename, server, **kwargs)
-        else:
-            if location.endswith("::"):
-                treepath = location
-            else:
-                temp_treepath = parsed_location.path
-                treepath = None if temp_treepath == "" else temp_treepath
-            sig = MdsLocalSignal(expression, treename, treepath=treepath, **kwargs)
+        if scheme == "remote":
+            # toksearch's own marker, not an MDSplus scheme: connect to this
+            # server over whatever transport MDSplus defaults to. The scheme is
+            # dropped and only the host is passed on.
+            return MdsRemoteSignal(
+                expression, treename, parsed_location.netloc, **kwargs
+            )
 
-        return sig
+        if scheme in MDSIP_TRANSPORT_SCHEMES:
+            # An MDSplus connection string. The WHOLE url goes to
+            # MDSplus.Connection: the scheme selects the transport, and the path
+            # is meaningful to it -- for fdp:// it is the relay's prefix on the
+            # origin, e.g. fdp://origin.example.org:8443/mdsip -- so neither the
+            # scheme nor the path may be dropped the way 'remote://' drops them.
+            return MdsRemoteSignal(expression, treename, location, **kwargs)
+
+        raise ValueError(
+            f"Unrecognized scheme {scheme!r} in MdsSignal location {location!r}. "
+            f"Use 'remote://<server>' for a plain mdsip server, one of "
+            f"{sorted(MDSIP_TRANSPORT_SCHEMES)} for a specific MDSplus "
+            f"transport, or a path with no scheme for a tree path."
+        )
 
 
     def gather(self, shot):
@@ -370,7 +436,10 @@ class MdsRemoteSignal(Signal):
         Arguments:
             expression: The tdi expression to fetch data from
             treename: The name of the tree to fetch from
-            server: The name of the remote server (e.g. atlas.gat.com)
+            server: What to hand MDSplus.Connection. Either a bare host
+                (e.g. atlas.gat.com), which uses MDSplus's default transport, or
+                a full connection URL whose scheme selects one
+                (e.g. fdp://origin.example.org:8443/mdsip).
             dims: See documentation for the Signal class. Defaults to ('times',)
             data_order: See documentation for the Signal class. Defaults to the same
                 as dims.


### PR DESCRIPTION
## The bug

`MdsSignal(..., location='fdp://origin:8443/mdsip')` silently produced a **local**
signal. The scheme was only ever compared against `'remote'`, so anything else
fell through to `urlparse().path` as a treepath:

| location | became | |
|---|---|---|
| `fdp://host:8443/mdsip` | `MdsLocalSignal(treepath='/mdsip')` | host discarded entirely |
| `fdp://host:8443` | `MdsLocalSignal(treepath=None)` | falls back to the environment's tree paths — can look like it works while reading somewhere else |

## The rule now

```
remote://host          MdsRemoteSignal(host)      unchanged; scheme dropped
<transport>://...      MdsRemoteSignal(WHOLE url)
anything without ://   treepath, passed through untouched
any other scheme       ValueError
```

The **whole** URL goes to `MDSplus.Connection` for a transport scheme, because
the scheme selects the transport (`LoadIo` dlopens `"libMdsIp" + SCHEME + ".so"`)
and the path is meaningful to it — for `fdp://` it is the relay's prefix on the
origin. Neither may be dropped the way `remote://` drops them.

`MDSIP_TRANSPORT_SCHEMES` is an allowlist rather than "any scheme" because
`LoadIo` does **not** report an unknown scheme as an error — it silently returns
the ssh-tunnel routines. A typo would try to ssh somewhere instead of failing.

Discriminating on `'://'` rather than urlparse's scheme is deliberate: urlparse
reads `'abc::'` as scheme `abc`, and `'atlas.gat.com::/trees'` as scheme
`atlas.gat.com` (dots are legal in a scheme), so MDSplus's own `host::/path`
syntax has to be settled before any scheme dispatch. That also fixes
`atlas.gat.com::/trees`, which previously became the treepath `':/trees'`.

## Behaviour change

`TOKSEARCH_MDS_DEFAULT` now goes through the same dispatch, so pointing a whole
workflow at a server through the environment behaves like pointing one signal at
it. It previously built a treepath of the literal string
`"remote://fake.gat.com"`, which no tree can be opened from — and the existing
test asserted `MdsLocalSignal` while being named
`test_remote_location_grabbed_from_environment`, which is the tell that it
recorded the bug rather than an intent.

## mdsip-fdp is a run dependency

The second commit reverses the first commit's reasoning, deliberately. `fdp://`
is a protocol, not a device integration — DIII-D is served this way today and
C-Mod is next — so the argument that keeps device specifics in `toksearch_d3d`
and `toksearch_mast` puts a shared access protocol in core toksearch.

Without it, an `fdp://` location fails at connect with `Protocol FDP is not
supported` on **stderr** and a bare `Error connecting to fdp://...` exception.
Inside a Pipeline worker the exception is what reaches `rec.errors` and the
useful half is lost.

The package is built once per MDSplus provider and the existing
`mdsplus-xrdcl >=1,<2` pin selects the matching variant. Verified against the
real channel: `mdsplus-xrdcl 1.0.1` + `mdsip-fdp 0.1.0 h80ff2d7` resolved
automatically.

## Verified

Against the production origin:

```
routing            MdsRemoteSignal, server=fdp://…/mdsip
direct fetch       (304,) with units {'data': 'A', 'times': 'ms'}
2-D \psirz         (304, 65, 65)
pipeline serial    4 shots
pipeline mp        matches serial exactly
```

45 unit tests pass, including new coverage for the fdp:// forms, other transport
schemes, unknown-scheme rejection, and `host::/path`.

Note the parallel case only became correct once GA-FDP/xrdoss-mdsplus#2 was
deployed: the origin's mdsip ran with `-m`, which shares one tree context across
connections, so concurrent clients silently read each other's shots. That is
fixed and verified in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)