### PR TITLE
Fix SignalRegistry leak and redundant per-signal cleanup in multiprocessing pipelines

### DIFF
--- a/tests/test_mds.py
+++ b/tests/test_mds.py
@@ -566,3 +566,49 @@ class TestMdsTreeRegistry(unittest.TestCase):
                 tree = registry.open_tree(treename, shot, treepath=None)
         except mds.TreeNOPATH:
             self.fail("open_tree failed to open tree using environment")
+
+
+class TestMdsCleanupShotKey(unittest.TestCase):
+    """cleanup_shot() on a remote signal is a network round trip.
+
+    SignalRegistry sweeps every registered signal once per record, so signals
+    that share the resource being cleaned have to advertise that or the sweep
+    pays for the same close several times over.
+    """
+
+    def test_remote_signals_on_one_server_share_a_key(self):
+        a = MdsSignal("a", "efit01", location="remote://atlas.gat.com")
+        b = MdsSignal("b", "efit01", location="remote://atlas.gat.com")
+        self.assertEqual(a.cleanup_shot_key(), b.cleanup_shot_key())
+
+    def test_treename_is_not_part_of_the_remote_key(self):
+        # closeAllTrees() closes every tree open on the connection, whichever
+        # signal opened it, so two trees on one server are still one close.
+        a = MdsSignal("a", "efit01", location="remote://atlas.gat.com")
+        b = MdsSignal("b", "d3d", location="remote://atlas.gat.com")
+        self.assertEqual(a.cleanup_shot_key(), b.cleanup_shot_key())
+
+    def test_different_servers_do_not_share_a_key(self):
+        a = MdsSignal("a", "efit01", location="remote://atlas.gat.com")
+        b = MdsSignal("b", "efit01", location="remote://other.gat.com")
+        self.assertNotEqual(a.cleanup_shot_key(), b.cleanup_shot_key())
+
+    def test_local_signals_share_a_key_by_treename(self):
+        a = MdsSignal("a", "efit01", location="/some/path")
+        b = MdsSignal("b", "efit01", location="/some/path")
+        self.assertEqual(a.cleanup_shot_key(), b.cleanup_shot_key())
+
+    def test_local_signals_on_different_trees_do_not_share_a_key(self):
+        # Local trees are closed per treename, so these are two closes.
+        a = MdsSignal("a", "efit01", location="/some/path")
+        b = MdsSignal("b", "d3d", location="/some/path")
+        self.assertNotEqual(a.cleanup_shot_key(), b.cleanup_shot_key())
+
+    def test_local_and_remote_keys_do_not_collide(self):
+        local = MdsSignal("a", "efit01", location="/some/path")
+        remote = MdsSignal("a", "efit01", location="remote://efit01")
+        self.assertNotEqual(local.cleanup_shot_key(), remote.cleanup_shot_key())
+
+    def test_mds_signal_delegates_to_the_underlying_signal(self):
+        sig = MdsSignal("a", "efit01", location="remote://atlas.gat.com")
+        self.assertEqual(sig.cleanup_shot_key(), sig.sig.cleanup_shot_key())

--- a/tests/test_multiprocessing_backend.py
+++ b/tests/test_multiprocessing_backend.py
@@ -1,0 +1,105 @@
+# Copyright 2024 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from toksearch.backend.multiprocessing import _Mapper
+from toksearch.pipeline.pipeline_funcs import _SafeFetch
+from toksearch.record import Record
+from toksearch.signal.mock_signal import MockSignal
+from toksearch.signal.signal import SignalRegistry
+
+
+class _CountingSignal(MockSignal):
+    """MockSignal that tallies cleanup_shot calls across every instance.
+
+    The tally is class-level on purpose: the behavior under test is what
+    happens as *distinct* Signal objects pile up, which is what a worker sees
+    when joblib unpickles the operations afresh for each batch.
+    """
+
+    calls = 0
+
+    def cleanup_shot(self, shot):
+        _CountingSignal.calls += 1
+
+
+class TestMapperRegistryScoping(unittest.TestCase):
+    """The registry must not accumulate signals from batch to batch.
+
+    Each iteration below builds a new signal and a new _Mapper over it, which
+    is what unpickling a dispatched batch produces in a worker process. Before
+    the registry was scoped to the record, these piled up for the life of the
+    worker and SignalRegistry.cleanup_shot() swept all of them once per
+    record -- quadratic work, and quadratic network round trips for signals
+    whose cleanup_shot() talks to a server.
+    """
+
+    def setUp(self):
+        SignalRegistry().reset()
+        _CountingSignal.calls = 0
+
+    def tearDown(self):
+        SignalRegistry().reset()
+
+    def test_registry_does_not_grow_across_batches(self):
+        reg = SignalRegistry()
+        sizes = []
+
+        for _ in range(5):
+            operations = [_SafeFetch("sig", MockSignal())]
+            mapper = _Mapper(operations)
+            for shot in range(3):
+                mapper(Record(shot))
+            sizes.append(len(reg.signals))
+
+        self.assertEqual(sizes, [1] * 5)
+
+    def test_cleanup_shot_work_is_linear_in_records(self):
+        num_batches, records_per_batch = 5, 4
+
+        for _ in range(num_batches):
+            operations = [_SafeFetch("sig", _CountingSignal())]
+            mapper = _Mapper(operations)
+            for shot in range(records_per_batch):
+                mapper(Record(shot))
+
+        # One sweep per record, not one per record per batch seen so far.
+        self.assertEqual(_CountingSignal.calls, num_batches * records_per_batch)
+
+    def test_every_signal_used_by_a_record_is_still_cleaned(self):
+        """Guards the reset from being too aggressive.
+
+        Scoping the registry to the record must not drop signals that the
+        record itself is using -- both fetches below have to be cleaned up.
+        """
+        reg = SignalRegistry()
+        operations = [
+            _SafeFetch("a", _CountingSignal()),
+            _SafeFetch("b", _CountingSignal()),
+        ]
+
+        _Mapper(operations)(Record(1))
+
+        self.assertEqual(_CountingSignal.calls, 2)
+        self.assertEqual(len(reg.signals), 2)
+
+    def test_records_are_still_populated(self):
+        operations = [_SafeFetch("sig", MockSignal())]
+        record = _Mapper(operations)(Record(1))
+        self.assertIsNotNone(record["sig"]["data"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -72,6 +72,41 @@ class TestSignalRegistry(unittest.TestCase):
         # Should not raise an error
         self.assertIn(sig, reg)
 
+    def test_cleanup_shot_dedupes_signals_sharing_a_resource(self):
+        # One connection behind three signals is still one thing to close.
+        reg = SignalRegistry()
+        reg.reset()
+        sigs = [_SharedResourceSignal("conn") for _ in range(3)]
+        for sig in sigs:
+            reg.register(sig)
+
+        reg.cleanup_shot(1234)
+
+        self.assertEqual(sum(s.cleanup_shot_calls for s in sigs), 1)
+
+    def test_cleanup_shot_visits_each_distinct_resource(self):
+        reg = SignalRegistry()
+        reg.reset()
+        sigs = [_SharedResourceSignal(name) for name in ("a", "b", "c")]
+        for sig in sigs:
+            reg.register(sig)
+
+        reg.cleanup_shot(1234)
+
+        self.assertEqual(sum(s.cleanup_shot_calls for s in sigs), 3)
+
+    def test_cleanup_shot_does_not_dedupe_by_default(self):
+        # A signal that has not said what it shares is cleaned on its own.
+        reg = SignalRegistry()
+        reg.reset()
+        sigs = [_SharedResourceSignal() for _ in range(3)]
+        for sig in sigs:
+            reg.register(sig)
+
+        reg.cleanup_shot(1234)
+
+        self.assertEqual(sum(s.cleanup_shot_calls for s in sigs), 3)
+
     def test_register_same_signal_twice(self):
         reg = SignalRegistry()
         reg.reset()
@@ -80,6 +115,27 @@ class TestSignalRegistry(unittest.TestCase):
         reg.register(sig)
         self.assertIn(sig, reg)
         self.assertEqual(len(reg.signals), 1)
+
+
+class _SharedResourceSignal(MockSignal):
+    """MockSignal that counts cleanup_shot calls and can share a resource.
+
+    Passing the same ``resource`` to two of these makes them look, to the
+    registry, like two signals backed by one connection.
+    """
+
+    def __init__(self, resource=None, **kwargs):
+        super().__init__(**kwargs)
+        self.resource = resource
+        self.cleanup_shot_calls = 0
+
+    def cleanup_shot(self, shot):
+        self.cleanup_shot_calls += 1
+
+    def cleanup_shot_key(self):
+        if self.resource is None:
+            return super().cleanup_shot_key()
+        return ("resource", self.resource)
 
 
 class TestDimensionedSignal(unittest.TestCase):

--- a/toksearch/backend/multiprocessing/__init__.py
+++ b/toksearch/backend/multiprocessing/__init__.py
@@ -21,6 +21,7 @@ from joblib import Parallel, delayed
 from ...record.record_set import RecordSet
 from ...record import Record
 from ...pipeline.pipeline_funcs import _map_single, _map_multiple
+from ...signal.signal import SignalRegistry
 
 
 DEFAULT_NUM_WORKERS = max(os.cpu_count() // 2, 1)
@@ -31,6 +32,21 @@ class _Mapper:
         self.operations = operations
 
     def __call__(self, record):
+        # joblib unpickles a fresh copy of the operations -- and so fresh Signal
+        # objects -- for every batch it dispatches. Signals register themselves
+        # with the process-global SignalRegistry when fetched, and
+        # cleanup_shot() sweeps everything the registry holds once per record.
+        # Without this reset the registry gains a set of signals per batch for
+        # the life of the worker, so the per-record sweep grows without bound.
+        # Where cleanup_shot() is a network round trip (MdsRemoteSignal issues
+        # closeAllTrees) that makes a run cost quadratic in the shot count.
+        #
+        # Resetting scopes the registry to the record being mapped, matching the
+        # scoping _map_multiple gets from its trailing cleanup(). reset() only
+        # drops references; it does not call Signal.cleanup(), so shared
+        # resources like the MdsConnectionRegistry connection survive and are
+        # still reused from record to record.
+        SignalRegistry().reset()
         return _map_single(record, self.operations)
 
 

--- a/toksearch/signal/mds.py
+++ b/toksearch/signal/mds.py
@@ -221,6 +221,10 @@ class MdsLocalSignal(Signal):
         """
         MdsTreeRegistry().close_tree(self.treename, shot)
 
+    def cleanup_shot_key(self):
+        """Trees are held per treename, so one close per treename is enough."""
+        return ("mds_local_tree", self.treename)
+
     def cleanup(self):
         """Close all trees"""
         MdsTreeRegistry().close_all_trees()
@@ -380,6 +384,10 @@ class MdsSignal(Signal):
             shot (int): The shot number to close the tree for
         """
         self.sig.cleanup_shot(shot)
+
+    def cleanup_shot_key(self):
+        """Defer to the local or remote signal actually doing the cleanup."""
+        return self.sig.cleanup_shot_key()
 
     def cleanup(self):
         """Close all trees or disconnect from the remote server"""
@@ -542,6 +550,15 @@ class MdsRemoteSignal(Signal):
             connection.closeAllTrees()
         except:
             pass
+
+    def cleanup_shot_key(self):
+        """Signals sharing a server share a connection -- and one round trip.
+
+        MdsConnectionRegistry hands out one connection per server, and
+        closeAllTrees() closes every tree open on it regardless of which
+        signal opened it, so the treename is deliberately not part of the key.
+        """
+        return ("mds_remote_connection", self.server)
 
     def cleanup(self):
         """Disconnect from the remote server"""

--- a/toksearch/signal/signal.py
+++ b/toksearch/signal/signal.py
@@ -279,6 +279,22 @@ class Signal(ABC):
         """
         pass
 
+    def cleanup_shot_key(self):
+        """Identify the resource that cleanup_shot() acts on.
+
+        SignalRegistry.cleanup_shot() sweeps every registered signal once per
+        record. Signals that share a backing resource need only one of those
+        calls between them -- several remote signals on one server share a
+        single connection, and closeAllTrees() on it closes the trees for all
+        of them. Returning equal keys lets the registry make the call once
+        instead of once per signal, which on a remote connection is the
+        difference between one network round trip per record and several.
+
+        The default keys on the signal itself, so signals that share nothing,
+        or that have not said what they share, keep being cleaned individually.
+        """
+        return id(self)
+
     @abstractmethod
     def cleanup(self):
         """Close down any resources that are shared amongst multiple shots.
@@ -347,7 +363,12 @@ class SignalRegistry:
         """
 
         with _gc_disabled():
+            cleaned = set()
             for signal in self.signals:
+                key = signal.cleanup_shot_key()
+                if key in cleaned:
+                    continue
+                cleaned.add(key)
                 try:
                     signal.cleanup_shot(shot)
                 except Exception as e:


### PR DESCRIPTION
Fixes #55.

Two commits, both about `SignalRegistry.cleanup_shot()` — which the
multiprocessing backend calls once per record, and which for remote MDSplus
signals is a network round trip.

## 1. Scope the registry to the record being mapped

joblib unpickles a fresh copy of the operations — and so fresh `Signal`
objects — for every batch it dispatches. Signals register themselves with the
process-global `SignalRegistry` when fetched, and nothing reset it on this
path: only `_map_multiple` does that, and the multiprocessing backend maps
record-at-a-time through `_map_single`.

Every batch therefore left another set of signals behind for the life of the
worker, and the per-record sweep grew without bound — quadratic in the shot
count, with a network round trip per registered signal.

`_Mapper` now resets the registry, scoping it to the record being mapped and
matching what `_map_multiple` already gets from its trailing `cleanup()`.

Two details worth review:

- The reset is in `_Mapper`, not in the shared `_map_single`, because the
  backend calls `_map_multiple(records, [])` in the **parent** purely to
  trigger the trailing `cleanup()`. Resetting inside `_map_single` would empty
  the registry first and silently make that a no-op.
- `reset()`, not `cleanup()` — `reset()` only drops references, so the shared
  `MdsConnectionRegistry` connection survives and is still reused. `cleanup()`
  would disconnect and force a reconnect per record.

I also considered making the registry a `WeakSet`, which would fix the class of
bug rather than this instance. I didn't: signals can sit in reference cycles, so
reclamation would depend on GC timing, and a nondeterministic bound is a poor
foundation for a performance fix.

## 2. Clean shared resources once per record, not once per signal

Even with the registry correctly scoped, a three-signal pipeline made three
`closeAllTrees()` round trips per record. All three signals share one server,
`MdsConnectionRegistry` hands out one connection per server, and
`closeAllTrees()` closes every tree on it — so two of the three were closing
trees that were already closed.

Signals now report what `cleanup_shot()` acts on via `cleanup_shot_key()`, and
the registry makes one call per distinct key:

- `MdsRemoteSignal` keys on the **server**, deliberately not the treename.
- `MdsLocalSignal` keys on the **treename**, which is how
  `MdsTreeRegistry.close_tree()` is addressed.
- `MdsSignal` delegates, as it already does for `cleanup_shot()`.

The base implementation keys on the signal object, so anything that has not
declared a shared resource — `ZarrSignal`, `PtDataSignal`, `ImasSignal`,
user-defined signals — is cleaned individually exactly as before.

## Measurements

800 shots, 8 workers, three `efit01` signals, `batch_size="auto"`:

| | shots/s | signals in registry | closeAllTrees | cleanup share of task |
|---|---|---|---|---|
| atlas, before | 118.3 | 81 | 3.00/shot | 71.0% |
| atlas, after | 204.2 | 3 | 1.00/shot | ~12% |
| mdsip relay, before | 7.5 | 300 | 3.00/shot | 89.5% |
| mdsip relay, after | 62.9 | 3 | 1.00/shot | ~6% |

Attribution of the second commit alone, with the first already in place:

| | closeAllTrees | cleanup | shots/s |
|---|---|---|---|
| atlas, before | 3.00/shot | 4.4 ms/shot | 142.3 |
| atlas, after | 1.00/shot | 1.6 ms/shot | 204.2 |
| relay, before | 3.00/shot | 20.5 ms/shot | 52.0 |
| relay, after | 1.00/shot | 6.2 ms/shot | 62.9 |

Throughput moves around with server load — the call count and cleanup time are
the reliable figures. The Pelican path is unaffected throughout:
`MdsLocalSignal.cleanup_shot` is a local dict operation, so the leak was
present but free (0.1 ms/shot).

## Tests

10 new tests. Verified to fail without the corresponding source change:

- `tests/test_multiprocessing_backend.py` (4) — reproduces the leak
  deterministically in-process by giving each simulated batch fresh `Signal`
  objects, as unpickling does. Pre-fix the registry grows `[1, 2, 3, 4, 5]`;
  post-fix `[1, 1, 1, 1, 1]`. A second test pins `cleanup_shot` work to linear
  in records. A third guards the reset from being *too* aggressive — every
  signal a single record uses must still be cleaned.
- `tests/test_signal.py` (3) — registry dedupes signals sharing a resource,
  still visits each distinct resource, and does not dedupe by default.
- `tests/test_mds.py` (7) — key grouping by server/treename, treename excluded
  from the remote key, local and remote keys not colliding, `MdsSignal`
  delegation.

Full suite: 327 passed, 3 skipped.

## Note on #52

This supersedes the mechanism described in #52, which reported the symptom
correctly but attributed it to joblib starving the workers. Measured occupancy
is 96–99% with a median gap between tasks of 0.3–0.5 ms — the workers were busy
the whole time, closing trees that were already closed. #52 and #54 have been
corrected accordingly. Larger `batch_size` helped only by reducing the batch
*count*, which is the linear term in the leak's cost; it is a mitigation, not a
fix, and matters much less now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
