### PR TITLE
Don't wipe the live MDSplus registry caches when pickling

### DIFF
--- a/tests/test_mds.py
+++ b/tests/test_mds.py
@@ -14,6 +14,7 @@
 
 import unittest
 import sys
+import pickle
 import os
 import tempfile
 import numpy as np
@@ -461,6 +462,64 @@ class TestMdsConnectionRegistry(unittest.TestCase):
         registry.disconnect("never.connected:1234")
 
 
+    def test_pickling_does_not_drop_the_live_connection_cache(self):
+        # __getstate__ used to hand back self.__dict__ itself and blank the
+        # map on it, so merely serializing the registry dropped the pickling
+        # process's own connections.
+        from unittest import mock
+
+        registry = MdsConnectionRegistry()
+        registry._connection_map["fake.host:9999"] = mock.MagicMock()
+        before = dict(registry._connection_map)
+        try:
+            pickle.dumps(registry)
+            self.assertEqual(registry._connection_map, before)
+        finally:
+            registry._connection_map.pop("fake.host:9999", None)
+
+    def test_connections_are_not_serialized(self):
+        from unittest import mock
+
+        registry = MdsConnectionRegistry()
+        registry._connection_map["fake.host:9999"] = mock.MagicMock()
+        try:
+            self.assertEqual(registry.__getstate__()["_connection_map"], {})
+            # A MagicMock cannot be pickled, so getting through dumps at all
+            # is itself proof the connections were left out.
+            pickle.dumps(registry)
+        finally:
+            registry._connection_map.pop("fake.host:9999", None)
+
+    def test_unpickling_keeps_the_receiving_process_cache(self):
+        from unittest import mock
+
+        registry = MdsConnectionRegistry()
+        blob = pickle.dumps(registry)
+        conn = mock.MagicMock()
+        registry._connection_map["fake.host:9999"] = conn
+        try:
+            restored = pickle.loads(blob)
+            # Unpickling returns this process's singleton, so a restore that
+            # replaced _connection_map would be clearing a live cache.
+            self.assertIs(restored, registry)
+            self.assertIs(restored._connection_map["fake.host:9999"], conn)
+        finally:
+            registry._connection_map.pop("fake.host:9999", None)
+
+    def test_non_connection_state_survives_a_round_trip(self):
+        # Only the connections are process-local; anything else the registry
+        # may carry should still travel.
+        registry = MdsConnectionRegistry()
+        registry.__dict__["_probe"] = 42
+        try:
+            blob = pickle.dumps(registry)
+            del registry.__dict__["_probe"]
+            pickle.loads(blob)
+            self.assertEqual(registry.__dict__.get("_probe"), 42)
+        finally:
+            registry.__dict__.pop("_probe", None)
+
+
 class TestMdsRemoteSignalRetry(unittest.TestCase):
     """Verify that MdsRemoteSignal.gather retries on MDSplusERROR.
 
@@ -520,6 +579,52 @@ class TestMdsRemoteSignalRetry(unittest.TestCase):
         ), self._mock.patch.object(MdsConnectionRegistry, "disconnect"):
             with self.assertRaises(MDSplusERROR):
                 self.signal.gather(123)
+
+
+class TestMdsTreeRegistryPickling(unittest.TestCase):
+    """Same defect as MdsConnectionRegistry: __getstate__ blanked the live map.
+
+    Here the casualty is the open-tree cache, dropped without being closed.
+    """
+
+    def tearDown(self):
+        MdsTreeRegistry().reset()
+
+    def test_pickling_does_not_drop_the_live_tree_cache(self):
+        from unittest import mock
+
+        registry = MdsTreeRegistry()
+        registry.reset()
+        sentinel = mock.MagicMock()
+        registry._tree_map["faketree"] = {1234: sentinel}
+
+        pickle.dumps(registry)
+
+        self.assertIs(registry._tree_map["faketree"][1234], sentinel)
+
+    def test_trees_are_not_serialized(self):
+        from unittest import mock
+
+        registry = MdsTreeRegistry()
+        registry.reset()
+        registry._tree_map["faketree"] = {1234: mock.MagicMock()}
+
+        self.assertEqual(registry.__getstate__()["_tree_map"], {})
+        pickle.dumps(registry)
+
+    def test_unpickling_keeps_the_receiving_process_trees(self):
+        from unittest import mock
+
+        registry = MdsTreeRegistry()
+        registry.reset()
+        blob = pickle.dumps(registry)
+        sentinel = mock.MagicMock()
+        registry._tree_map["faketree"] = {1234: sentinel}
+
+        restored = pickle.loads(blob)
+
+        self.assertIs(restored, registry)
+        self.assertIs(restored._tree_map["faketree"][1234], sentinel)
 
 
 class TestMdsTreeRegistry(unittest.TestCase):

--- a/toksearch/signal/mds.py
+++ b/toksearch/signal/mds.py
@@ -396,9 +396,23 @@ class MdsConnectionRegistry(object):
         return MdsConnectionRegistry.__instance
 
     def __getstate__(self):
-        _dict = self.__dict__
-        _dict["_connection_map"] = {}
-        return _dict
+        # MDSplus connections can't be pickled, and whoever unpickles this has
+        # to dial its own anyway. Copy before clearing: self.__dict__ IS the
+        # live singleton's dict, so blanking the map in place would drop the
+        # connections belonging to the process doing the pickling.
+        state = dict(self.__dict__)
+        state["_connection_map"] = {}
+        return state
+
+    def __setstate__(self, state):
+        # __new__ returns the receiving process's singleton, so restoring state
+        # wholesale would clobber connections that process has already opened.
+        # Everything else is restored; the connection map stays local.
+        state = dict(state)
+        state.pop("_connection_map", None)
+        existing = self.__dict__.get("_connection_map")
+        self.__dict__.update(state)
+        self.__dict__["_connection_map"] = {} if existing is None else existing
 
     def connect(self, server):
         conn = self._connection_map.get(server, None)
@@ -561,9 +575,20 @@ class MdsTreeRegistry(object):
         return MdsTreeRegistry.__instance
 
     def __getstate__(self):
-        _dict = self.__dict__
-        _dict["_tree_map"] = {}
-        return _dict
+        # Open trees can't be pickled. As with MdsConnectionRegistry, copy
+        # before clearing so serializing the registry doesn't close over the
+        # trees the pickling process still has open.
+        state = dict(self.__dict__)
+        state["_tree_map"] = {}
+        return state
+
+    def __setstate__(self, state):
+        # The receiving process keeps whatever trees it already had open.
+        state = dict(state)
+        state.pop("_tree_map", None)
+        existing = self.__dict__.get("_tree_map")
+        self.__dict__.update(state)
+        self.__dict__["_tree_map"] = {} if existing is None else existing
 
     def open_tree(self, treename, shot, treepath=None):
         tree = self._get_tree(treename, shot)


### PR DESCRIPTION
Fixes #53.

`MdsConnectionRegistry.__getstate__` returned `self.__dict__` **by reference**
and then blanked `_connection_map` on it. `self.__dict__` *is* the live
singleton's dict, so serializing the registry dropped every cached connection
in the process doing the pickling — and because the class is a singleton,
unpickling handed the same object back and overwrote the map again, clearing
the cache in the receiving process too.

```python
r.connect('atlas.gat.com'); len(r._connection_map)   # 1
pickle.dumps(r);            len(r._connection_map)   # 0   <-- before
pickle.loads(blob);         len(r._connection_map)   # 0   <-- before
```

After this change: `1, 1, 1`, and `connect()` returns the same connection
object it did before the round trip.

## The fix

- `__getstate__` copies before clearing, so the live object is untouched.
- A new `__setstate__` keeps the receiving process's connections rather than
  replacing them. Everything else the registry carries still travels — only
  the connections are process-local.

I used `__getstate__`/`__setstate__` rather than a `__reduce__` returning
`(MdsConnectionRegistry, ())`. The latter is arguably tidier for a singleton,
but it would silently drop any non-connection state the class gains later.
There's a test pinning that behaviour.

## Also fixed: `MdsTreeRegistry`

`MdsTreeRegistry.__getstate__` had the identical defect — same
reference-not-copy pattern, blanking the live `_tree_map` — and gets the
identical fix. There the casualty is the open-tree cache, dropped without the
trees being closed.

This is beyond the letter of #53, which names only the connection registry. I
took it as within its spirit: it is the same bug, in the same file, with the
same two-line fix, and shipping one without the other seemed the wrong
deliverable. Happy to split it out if you'd rather keep the PR to #53 exactly.

## Impact, honestly

Low today, and #53 says so: under `compute_multiprocessing`, loky unpickles the
mapper once per batch and workers hold one connection each regardless of
`batch_size` (measured at 1/16/64). This is a latent correctness trap rather
than a live performance bug — but any future path that pickles per task would
become a reconnect per task with nothing at the call site to suggest why.

## Tests

7 new, in `tests/test_mds.py`. Four fail without the source change — pickling
and unpickling, for each of the two registries:

```
FAILED TestMdsConnectionRegistry::test_pickling_does_not_drop_the_live_connection_cache
FAILED TestMdsConnectionRegistry::test_unpickling_keeps_the_receiving_process_cache
FAILED TestMdsTreeRegistryPickling::test_pickling_does_not_drop_the_live_tree_cache
FAILED TestMdsTreeRegistryPickling::test_unpickling_keeps_the_receiving_process_trees
```

The other three are guards that pass either way: that the maps are excluded
from the serialized state, and that non-connection state survives a round trip.
They use `MagicMock` for the cached values, which is deliberate — a `MagicMock`
cannot be pickled, so getting through `dumps` at all is itself proof the map
was left out.

Full suite: 320 passed, 3 skipped.

## Note

Branched off `main`, independent of #56 (the #55 registry-leak work). Both
touch `toksearch/signal/mds.py` but in different regions, and they merge
cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
