### PR TITLE
Fetch MDSplus data, dims and units in one round trip

### DIFF
--- a/tests/test_mds.py
+++ b/tests/test_mds.py
@@ -27,6 +27,7 @@ import subprocess
 
 
 from toksearch.signal.mds import (
+    _BatchedGatherFailed,
     MdsConnectionRegistry,
     MdsTreeRegistry,
     MdsTreePath,
@@ -389,6 +390,52 @@ class TestMdsRemoteSignal(GenericTestMdsSignal, unittest.TestCase):
     #    self.assertEqual(results['units']['times']," ")
 
 
+    def test_batched_and_serial_gather_agree(self):
+        """The two paths must return the same thing, against a real server.
+
+        Skips on a server that cannot run GetManyExecute. The mdsip server
+        this suite starts is one: it fails with LIB-F-KEYNOTFOU regardless of
+        MDS_PATH, so batching cannot be exercised here. That is precisely the
+        case _do_gather falls back for, and it is covered hermetically by
+        TestMdsRemoteBatchedGather.
+        """
+        sig = self.signal()
+        connection = sig.connect()
+        connection.openTree(DEFAULT_TREE, DEFAULT_SHOT)
+        plan = sig._gather_plan()
+
+        serial = sig._gather_serial(connection, plan)
+        try:
+            batched = sig._gather_batched(connection, plan)
+        except _BatchedGatherFailed:
+            self.skipTest("server does not support GetManyExecute")
+
+        self.assertEqual(sorted(serial), sorted(batched))
+        for key, expected in serial.items():
+            got = batched[key]
+            if isinstance(expected, dict):
+                self.assertEqual(expected, got)
+            else:
+                np.testing.assert_array_equal(expected, got)
+
+
+
+    def test_do_gather_agrees_with_serial(self):
+        """Holds whether or not the server can batch, since _do_gather falls back."""
+        sig = self.signal()
+        connection = sig.connect()
+        connection.openTree(DEFAULT_TREE, DEFAULT_SHOT)
+        expected = sig._gather_serial(connection, sig._gather_plan())
+
+        got = sig._do_gather(DEFAULT_SHOT)
+
+        self.assertEqual(sorted(expected), sorted(got))
+        for key, value in expected.items():
+            if isinstance(value, dict):
+                self.assertEqual(value, got[key])
+            else:
+                np.testing.assert_array_equal(value, got[key])
+
 class TestMdsLocalSignal(GenericTestMdsSignal, unittest.TestCase):
     def _signal(self, expression, tree, dims, fetch_units, data_order):
         return MdsLocalSignal(
@@ -717,3 +764,159 @@ class TestMdsCleanupShotKey(unittest.TestCase):
     def test_mds_signal_delegates_to_the_underlying_signal(self):
         sig = MdsSignal("a", "efit01", location="remote://atlas.gat.com")
         self.assertEqual(sig.cleanup_shot_key(), sig.sig.cleanup_shot_key())
+
+
+class _Value:
+    """Stand-in for an MDSplus Data object: both gather paths unwrap .value."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeMdsError(Exception):
+    """Stand-in for a typed MDSplus exception, which only the serial path raises."""
+
+
+class _FakeGetMany:
+    def __init__(self, connection):
+        self.connection = connection
+        self.items = []
+        self.result = None
+
+    def append(self, name, expression):
+        self.items.append((name, expression))
+
+    def execute(self):
+        self.connection.executes += 1
+        if self.connection.execute_raises:
+            raise RuntimeError("server has no GetManyExecute")
+        self.result = {}
+        for name, expression in self.items:
+            if expression in self.connection.fail:
+                # How MDSplus reports a failed entry: no type, no useful text.
+                self.result[name] = {
+                    "error": "%MDSPLUS-E-Unknown, Unknown exception"
+                }
+            else:
+                self.result[name] = {
+                    "value": _Value(self.connection.values[expression])
+                }
+        return self.result
+
+    def get(self, name):
+        entry = self.result[name]
+        if "value" not in entry:
+            raise _FakeMdsError(name)
+        return entry["value"]
+
+
+class _FakeConnection:
+    """Counts round trips so a test can tell one batched call from several."""
+
+    def __init__(self, values, fail=(), execute_raises=False):
+        self.values = values
+        self.fail = set(fail)
+        self.execute_raises = execute_raises
+        self.gets = []
+        self.executes = 0
+        self.opened = []
+
+    def openTree(self, treename, shot):
+        self.opened.append((treename, shot))
+
+    def get(self, expression):
+        self.gets.append(expression)
+        if expression in self.fail:
+            raise _FakeMdsError(expression)
+        return _Value(self.values[expression])
+
+    def getMany(self):
+        return _FakeGetMany(self)
+
+
+class TestMdsRemoteBatchedGather(unittest.TestCase):
+    """Data, dims and units are independent expressions against an already-open
+    tree, so fetching them one at a time costs a round trip each for nothing."""
+
+    EXPRESSION = r"\ipmhd"
+
+    def _signal(self, fetch_units=True, dims=("times",)):
+        return MdsRemoteSignal(
+            self.EXPRESSION, "efit01", "fake.host:9999",
+            dims=dims, fetch_units=fetch_units,
+        )
+
+    def _connection(self, sig, **kwargs):
+        values = {expr: f"value-of-{expr}" for _, _, expr in sig._gather_plan()}
+        connection = _FakeConnection(values, **kwargs)
+        sig.connect = lambda: connection
+        return connection
+
+    def test_plan_covers_data_then_dims_then_units(self):
+        sig = self._signal(dims=("times", "space"))
+        slots = [(slot, name) for slot, name, _ in sig._gather_plan()]
+        self.assertEqual(
+            slots,
+            [("data", None), ("dim", "times"), ("dim", "space"),
+             ("units", "data"), ("units", "times"), ("units", "space")],
+        )
+
+    def test_plan_omits_units_when_not_requested(self):
+        sig = self._signal(fetch_units=False)
+        slots = [(slot, name) for slot, name, _ in sig._gather_plan()]
+        self.assertEqual(slots, [("data", None), ("dim", "times")])
+
+    def test_batched_gather_is_a_single_round_trip(self):
+        sig = self._signal()
+        connection = self._connection(sig)
+
+        sig._do_gather(1234)
+
+        self.assertEqual(connection.executes, 1)
+        self.assertEqual(connection.gets, [])
+
+    def test_serial_gather_is_a_round_trip_per_expression(self):
+        sig = self._signal()
+        connection = self._connection(sig)
+        sig._use_getmany = False
+
+        sig._do_gather(1234)
+
+        self.assertEqual(connection.executes, 0)
+        self.assertEqual(len(connection.gets), 4)
+
+    def test_batched_and_serial_agree(self):
+        for fetch_units in (True, False):
+            with self.subTest(fetch_units=fetch_units):
+                sig = self._signal(fetch_units=fetch_units)
+                self._connection(sig)
+                batched = sig._do_gather(1234)
+                sig._use_getmany = False
+                serial = sig._do_gather(1234)
+                self.assertEqual(batched, serial)
+
+    def test_failed_entry_falls_back_so_the_real_error_surfaces(self):
+        # A failed entry carries no exception type and no readable message, and
+        # gather() keys its retry on the type, so the fetch is redone one at a
+        # time to raise the real thing.
+        sig = self._signal()
+        connection = self._connection(sig, fail=[self.EXPRESSION])
+
+        with self.assertRaises(_FakeMdsError):
+            sig._do_gather(1234)
+
+        self.assertEqual(connection.executes, 1)
+        self.assertIn(self.EXPRESSION, connection.gets)
+
+    def test_server_without_getmany_is_not_asked_twice(self):
+        sig = self._signal()
+        connection = self._connection(sig, execute_raises=True)
+
+        sig._do_gather(1234)
+        self.assertEqual(connection.executes, 1)
+        self.assertFalse(sig._use_getmany)
+        self.assertEqual(len(connection.gets), 4)
+
+        sig._do_gather(1234)
+        self.assertEqual(connection.executes, 1)
+        self.assertEqual(len(connection.gets), 8)

--- a/toksearch/signal/mds.py
+++ b/toksearch/signal/mds.py
@@ -81,6 +81,16 @@ def _dim_of_expression(expression, dim=0):
     return "dim_of({}, {})".format(expression, dim)
 
 
+class _BatchedGatherFailed(Exception):
+    """Internal: the batched fetch was unusable, so fall back to one at a time.
+
+    Raised either because the server could not run the batch at all, or
+    because an expression in it failed. In both cases the remedy is the same --
+    refetch one expression at a time, so the caller sees the real MDSplus
+    exception.
+    """
+
+
 def _units_of_expression(expression, dim=0):
     exp = "units({})"
     if dim == -1:
@@ -479,6 +489,10 @@ class MdsRemoteSignal(Signal):
 
         self._shot_state = {}
 
+        # Cleared if the server turns out not to support batched gets, so the
+        # attempt is not repeated for every shot.
+        self._use_getmany = True
+
         self.set_dims(dims, data_order)
 
     def connect(self) -> mds.Connection:
@@ -520,37 +534,99 @@ class MdsRemoteSignal(Signal):
             MdsConnectionRegistry().disconnect(self.server)
             return self._do_gather(shot)
 
+    def _gather_plan(self):
+        """The expressions this signal needs, as (slot, name, expression).
+
+        ``slot`` says where the value belongs in the result -- "data", a
+        dimension, or a units entry. Both gather paths build their work from
+        this one list so they cannot drift apart.
+        """
+        plan = [("data", None, self.expression)]
+
+        dims = self.dims or []
+        for i, dim in enumerate(dims):
+            plan.append(("dim", dim, _dim_of_expression(self.expression, dim=i)))
+
+        if self.with_units:
+            plan.append(
+                ("units", "data", _units_of_expression(self.expression, dim=-1))
+            )
+            for i, dim in enumerate(dims):
+                plan.append(
+                    ("units", dim, _units_of_expression(self.expression, dim=i))
+                )
+
+        return plan
+
+    @staticmethod
+    def _assemble(plan, values):
+        """Fold values, in plan order, into the dict gather() returns."""
+        results = {}
+        units = {}
+        for (slot, name, _expression), value in zip(plan, values):
+            if slot == "data":
+                results["data"] = value
+            elif slot == "dim":
+                results[name] = value
+            else:
+                units[name] = value
+
+        if units:
+            results["units"] = units
+
+        return results
+
+    def _gather_serial(self, connection, plan):
+        """One round trip per expression."""
+        values = [connection.get(expression).value for _, _, expression in plan]
+        return self._assemble(plan, values)
+
+    def _gather_batched(self, connection, plan):
+        """One round trip for the whole plan.
+
+        The data, its dimensions and all of the units are independent
+        expressions against a tree the server already has open, so asking for
+        them one at a time costs a round trip each for no reason. On a remote
+        server that is most of the cost of a fetch.
+        """
+        getter = connection.getMany()
+        for i, (_slot, _name, expression) in enumerate(plan):
+            getter.append(f"e{i}", expression)
+
+        try:
+            result = getter.execute()
+        except Exception:
+            # Most likely a server without GetManyExecute. Stop trying rather
+            # than paying for the attempt on every shot; the serial path will
+            # re-raise anything that is actually a connection problem.
+            self._use_getmany = False
+            raise _BatchedGatherFailed()
+
+        values = []
+        for i in range(len(plan)):
+            if "value" not in result[f"e{i}"]:
+                # A failed entry carries no exception type and no message worth
+                # reading -- MDSplus reports it as "Unknown exception". Refetch
+                # serially so the caller gets the real error, which gather()
+                # needs in order to tell MDSplusERROR from a tree error.
+                raise _BatchedGatherFailed()
+            values.append(getter.get(f"e{i}").value)
+
+        return self._assemble(plan, values)
+
     def _do_gather(self, shot):
         connection = self.connect()
         connection.openTree(self.treename, shot)
 
-        results = {}
-        results["data"] = connection.get(self.expression).value
+        plan = self._gather_plan()
 
-        dims = self.dims
-        dims_dict = {}
-        if not dims:
-            dims = []
-        for i, dim in enumerate(dims):
-            dim_expression = _dim_of_expression(self.expression, dim=i)
-            results[dim] = connection.get(dim_expression).value
+        if self._use_getmany:
+            try:
+                return self._gather_batched(connection, plan)
+            except _BatchedGatherFailed:
+                pass
 
-
-        if self.with_units:
-            units = {}
-            units["data"] = connection.get(
-                _units_of_expression(self.expression, dim=-1)
-            ).value
-            dims = self.dims
-            if not dims:
-                dims = []
-            for i, dim in enumerate(dims):
-                units_expression = _units_of_expression(self.expression, dim=i)
-                units[dim] = connection.get(units_expression).value
-
-            results["units"] = units
-
-        return results
+        return self._gather_serial(connection, plan)
 
 
     def cleanup_shot(self, shot):


### PR DESCRIPTION
Batches the per-signal MDSplus fetch into a single round trip.

**Stacked on #56** (base is `fix/signal-registry-leak`), because the benchmark
is only legible once the registry leak is gone — before that, cleanup swamped
the fetch. Retarget to `main` once #56 merges.

## What was happening

`MdsRemoteSignal._do_gather` fetched each expression on its own: the data, then
one `get` per dimension, then `units` for the data and one per dimension. With
the default `dims=("times",)` and `fetch_units=True` that is four gets plus the
`openTree` — **five round trips per signal, fifteen per shot** for a
three-signal pipeline — for values the server could have returned together,
against a tree it already had open.

They now go out as one `Connection.getMany()`: `openTree` plus one batched get.

## Equivalence

Verified against atlas — byte-identical values *and* types for data, dims and
units, with and without units:

```
units=True   \ipmhd    identical=True  round trips serial=4 batched=1
units=False  \ipmhd    identical=True  round trips serial=2 batched=1
```

## Errors: why there is a fallback

A failed entry in a batched result is not usable as an error. MDSplus reports it
as `MdsIpException("%MDSPLUS-E-Unknown, Unknown exception")` — **both the type
and the message are lost**:

```
plain get   -> MDSplus.mdsExceptions.TreeNNF: %TREE-W-NNF, Node Not Found
getMany     -> MDSplus.connection.MdsIpException: %MDSPLUS-E-Unknown, Unknown exception
```

That matters twice over: users lose any diagnosable error, and `gather()` keys
its `MDSplusERROR` retry on the exception *type*, so batching alone would
silently disable that retry. Any failed entry, or a server that cannot run the
batch at all, therefore falls back to fetching one expression at a time and
raising the real exception. Confirmed: a missing node still raises `TreeNNF`.

The fallback is not hypothetical — **the mdsip server this test suite starts
cannot run `GetManyExecute`**. It fails with `LIB-F-KEYNOTFOU` regardless of
`MDS_PATH` (I probed `tdi`, `tdi;tdi/remote`, `tdi/remote;tdi`, and colon
delimiters; `;` is the delimiter and both dirs are searched, so this is not a
path-resolution problem). A server found to lack support is not asked again.

## Results

800 shots, 8 workers, three `efit01` signals, medians of 3:

| | shots/s | fetch ms/shot |
|---|---|---|
| mdsip relay | 63.9 → **144.2** (2.26×) | 97.4 → 37.9 |
| atlas | 228.7 → **258.2** | 16.3 → 11.4 |

The relay also **scales with workers again** instead of flattening — 3000
shots, 8/16/24 workers:

| workers | before | after |
|---|---|---|
| 8 | 101.8 | **150.7** |
| 16 | 107.3 | **193.0** |
| 24 | 111.4 | **240.3** |

It had been saturating because each shot cost 15 round trips; at 6 the same
server serves far more.

## Tests

10 new. `TestMdsRemoteBatchedGather` is hermetic, using a fake connection that
counts round trips: one `execute()` and zero single gets on the happy path;
four single gets when batching is off; the two paths agreeing with and without
units; a failed entry falling back so the real exception surfaces; and a server
without `GetManyExecute` not being asked twice. Plus plan-shape tests, and two
real-server tests (`_do_gather` agrees with the serial path — which holds
whether or not the server can batch; and a direct differential test that skips
where batching is unavailable).

Full suite: 335 passed, 4 skipped (3 pre-existing LLM integration skips, 1 the
batching skip above).

## Note

There is still one `openTree` per signal per shot, where signals sharing a tree
could share one — the same shape of redundancy as #55. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
