### PR TITLE
Open a remote MDSplus tree once per shot, not once per signal

### DIFF
--- a/tests/test_mds.py
+++ b/tests/test_mds.py
@@ -820,9 +820,13 @@ class _FakeConnection:
         self.gets = []
         self.executes = 0
         self.opened = []
+        self.closes = 0
 
     def openTree(self, treename, shot):
         self.opened.append((treename, shot))
+
+    def closeAllTrees(self):
+        self.closes += 1
 
     def get(self, expression):
         self.gets.append(expression)
@@ -846,10 +850,15 @@ class TestMdsRemoteBatchedGather(unittest.TestCase):
             dims=dims, fetch_units=fetch_units,
         )
 
+    def tearDown(self):
+        MdsConnectionRegistry()._connection_map.pop("fake.host:9999", None)
+
     def _connection(self, sig, **kwargs):
         values = {expr: f"value-of-{expr}" for _, _, expr in sig._gather_plan()}
         connection = _FakeConnection(values, **kwargs)
-        sig.connect = lambda: connection
+        # _do_gather asks the registry for its connection, so that is where a
+        # stand-in has to go.
+        MdsConnectionRegistry()._connection_map[sig.server] = connection
         return connection
 
     def test_plan_covers_data_then_dims_then_units(self):
@@ -920,3 +929,92 @@ class TestMdsRemoteBatchedGather(unittest.TestCase):
         sig._do_gather(1234)
         self.assertEqual(connection.executes, 1)
         self.assertEqual(len(connection.gets), 8)
+
+
+class TestMdsRemoteOpenTreeDedup(unittest.TestCase):
+    """openTree only sets the connection's current tree, and signals sharing a
+    server share one connection -- so opening per signal costs a round trip
+    per signal for a tree the previous one just opened.
+    """
+
+    SERVER = "fake.host:9999"
+
+    def tearDown(self):
+        MdsConnectionRegistry()._connection_map.pop(self.SERVER, None)
+
+    def _signals(self, expressions, treename="efit01"):
+        return [
+            MdsRemoteSignal(expression, treename, self.SERVER,
+                            dims=("times",), fetch_units=False)
+            for expression in expressions
+        ]
+
+    def _install(self, sigs):
+        values = {
+            expression: f"value-of-{expression}"
+            for sig in sigs
+            for _, _, expression in sig._gather_plan()
+        }
+        connection = _FakeConnection(values)
+        MdsConnectionRegistry()._connection_map[self.SERVER] = connection
+        return connection
+
+    def test_signals_sharing_a_tree_open_it_once(self):
+        sigs = self._signals([r"\a", r"\b", r"\c"])
+        connection = self._install(sigs)
+
+        for sig in sigs:
+            sig._do_gather(1234)
+
+        self.assertEqual(connection.opened, [("efit01", 1234)])
+
+    def test_a_new_shot_reopens(self):
+        sigs = self._signals([r"\a", r"\b"])
+        connection = self._install(sigs)
+
+        for shot in (1234, 1235):
+            for sig in sigs:
+                sig._do_gather(shot)
+
+        self.assertEqual(connection.opened,
+                         [("efit01", 1234), ("efit01", 1235)])
+
+    def test_a_different_tree_reopens(self):
+        first = self._signals([r"\a"], treename="efit01")[0]
+        second = self._signals([r"\b"], treename="d3d")[0]
+        connection = self._install([first, second])
+
+        first._do_gather(1234)
+        second._do_gather(1234)
+        first._do_gather(1234)
+
+        self.assertEqual(
+            connection.opened,
+            [("efit01", 1234), ("d3d", 1234), ("efit01", 1234)],
+        )
+
+    def test_cleanup_shot_means_the_next_fetch_reopens(self):
+        sig = self._signals([r"\a"])[0]
+        connection = self._install([sig])
+
+        sig._do_gather(1234)
+        sig.cleanup_shot(1234)
+        sig._do_gather(1234)
+
+        self.assertEqual(connection.closes, 1)
+        self.assertEqual(connection.opened,
+                         [("efit01", 1234), ("efit01", 1234)])
+
+    def test_a_failed_fetch_does_not_leave_the_tree_assumed_open(self):
+        # If a fetch fails the tree may be gone, so the next signal must not
+        # skip its open on the strength of the failed one.
+        sigs = self._signals([r"\a", r"\b"])
+        connection = self._install(sigs)
+        connection.fail.add(r"\a")
+
+        with self.assertRaises(_FakeMdsError):
+            sigs[0]._do_gather(1234)
+        sigs[1]._do_gather(1234)
+
+        self.assertEqual(connection.opened,
+                         [("efit01", 1234), ("efit01", 1234)])

--- a/toksearch/signal/mds.py
+++ b/toksearch/signal/mds.py
@@ -81,6 +81,11 @@ def _dim_of_expression(expression, dim=0):
     return "dim_of({}, {})".format(expression, dim)
 
 
+# Set on a Connection to record the tree it currently has open. Kept on the
+# connection so it dies with it -- see MdsConnectionRegistry.open_tree.
+_CURRENT_TREE = "_toksearch_current_tree"
+
+
 class _BatchedGatherFailed(Exception):
     """Internal: the batched fetch was unusable, so fall back to one at a time.
 
@@ -439,6 +444,39 @@ class MdsConnectionRegistry(object):
             self._connection_map[server] = conn
         return conn
 
+    def open_tree(self, server, treename, shot):
+        """Open a tree on the server's connection, if it isn't already open.
+
+        Signals sharing a server share a connection, and openTree only sets
+        that connection's current tree. Several signals reading one tree --
+        the ordinary case in a pipeline -- would otherwise each spend a round
+        trip opening what the previous one just opened.
+
+        The marker lives on the connection rather than on this registry so it
+        cannot outlive what it describes: connections are deliberately left
+        out of the registry's pickled state, so a marker kept here could
+        travel to a process whose connection has none of those trees open.
+        """
+        connection = self.connect(server)
+        if getattr(connection, _CURRENT_TREE, None) != (treename, shot):
+            connection.openTree(treename, shot)
+            setattr(connection, _CURRENT_TREE, (treename, shot))
+        return connection
+
+    def close_all_trees(self, server):
+        """Close every tree open on the server's connection."""
+        connection = self.connect(server)
+        try:
+            connection.closeAllTrees()
+        finally:
+            setattr(connection, _CURRENT_TREE, None)
+
+    def invalidate_open_tree(self, server):
+        """Stop assuming anything is open on this server's connection."""
+        connection = self._connection_map.get(server, None)
+        if connection is not None:
+            setattr(connection, _CURRENT_TREE, None)
+
     def disconnect(self, server):
         """Drop the cached connection for a server and close it.
 
@@ -615,18 +653,24 @@ class MdsRemoteSignal(Signal):
         return self._assemble(plan, values)
 
     def _do_gather(self, shot):
-        connection = self.connect()
-        connection.openTree(self.treename, shot)
+        registry = MdsConnectionRegistry()
+        connection = registry.open_tree(self.server, self.treename, shot)
 
         plan = self._gather_plan()
 
-        if self._use_getmany:
-            try:
-                return self._gather_batched(connection, plan)
-            except _BatchedGatherFailed:
-                pass
+        try:
+            if self._use_getmany:
+                try:
+                    return self._gather_batched(connection, plan)
+                except _BatchedGatherFailed:
+                    pass
 
-        return self._gather_serial(connection, plan)
+            return self._gather_serial(connection, plan)
+        except Exception:
+            # Whatever went wrong, the tree may no longer be open. Don't let
+            # the next signal skip its openTree on the strength of this one.
+            registry.invalidate_open_tree(self.server)
+            raise
 
 
     def cleanup_shot(self, shot):
@@ -636,8 +680,7 @@ class MdsRemoteSignal(Signal):
             shot (int): The shot number to close the tree for
         """
         try:
-            connection = self.connect()
-            connection.closeAllTrees()
+            MdsConnectionRegistry().close_all_trees(self.server)
         except:
             pass
 


### PR DESCRIPTION
The follow-up flagged in #58. Opens a remote tree once per shot instead of once
per signal.

**Stacked on #58** (base `perf/getmany-dims-units`, which is itself on #56).
Retarget as those merge.

## What was happening

`MdsConnectionRegistry` hands out one connection per server, and `openTree` does
nothing but set that connection's current tree. Every signal opened the tree for
itself, so a pipeline reading three signals from `efit01` spent **three round
trips per shot** opening a tree the previous signal had just opened. Same shape
of redundancy as #55, one layer down.

The registry now owns opening: `open_tree(server, treename, shot)` skips the call
when the connection already has that tree and shot open. The marker is the
`(treename, shot)` pair, so a different tree, or the same tree at a different
shot, still opens as before.

## Where the marker lives, and why

On the **connection**, not on the registry. The registry deliberately leaves
connections out of its pickled state, so a marker kept on the registry would
travel to a worker whose connection has nothing open and make it skip an open it
actually needs. Keeping it on the connection means it cannot outlive what it
describes — a dropped connection takes its marker with it, which also covers the
`disconnect()` in `gather()`'s retry path for free.

(This is why the change is safe to land ahead of #57. Had the marker gone in the
registry `__dict__`, the current `__getstate__` would blank `_connection_map` and
carry the marker across — precisely the failure mode above.)

## Two invalidations

- `cleanup_shot` now closes through the registry, which clears the marker, so the
  record after a cleanup opens again.
- Any exception out of `_do_gather` clears it. If a fetch failed the tree may be
  gone, and the next signal must not skip its open on the strength of the failed
  one. This is the case that makes the optimization safe rather than merely fast.

## Verified against atlas

```
3 signals, same tree+shot -> openTree calls: 1   [('efit01', 190016)]
next shot                 -> openTree calls: 1
after cleanup_shot        -> openTree calls: 1
```

with data and units intact. A three-signal pipeline is now **five round trips per
shot** — one open, three batched gets, one close — down from seven after #58, and
eighteen before any of this work.

## Results

800 shots, 8 workers, medians of 3:

| | shots/s | fetch ms/shot |
|---|---|---|
| mdsip relay | 142.6 → **193.1** (1.35×) | 33.3 → 23.3 |
| atlas | 276.8 → 285.3 | 12.6 → **8.2** |

Atlas throughput is inside its run-to-run spread — the fetch time is the reliable
figure there. Relay at 3000 shots, 8/16/24 workers:

| workers | before | after |
|---|---|---|
| 8 | 150.7 | **222.7** |
| 16 | 193.0 | **292.7** |
| 24 | 240.3 | **353.2** |

## Tests

5 new, hermetic, counting `openTree` calls through an injected fake connection:
signals sharing a tree open it once; a new shot reopens; a different tree
reopens; `cleanup_shot` forces a reopen; a failed fetch does not leave the tree
assumed open. Two of the five fail without the change; the other three are guards
against over-deduplicating, and pass either way.

The existing `TestMdsRemoteBatchedGather` fakes were updated to inject through the
registry, since `_do_gather` no longer calls `self.connect()` directly.

Full suite: 340 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
