### PR TITLE
Release signal resources before a multiprocessing worker exits

### DIFF
--- a/tests/test_multiprocessing_backend.py
+++ b/tests/test_multiprocessing_backend.py
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import subprocess
+import sys
+import tempfile
 import unittest
+from unittest import mock
 
+import toksearch.backend.multiprocessing as mp_backend
 from toksearch.backend.multiprocessing import _Mapper
 from toksearch.pipeline.pipeline_funcs import _SafeFetch
 from toksearch.record import Record
@@ -103,3 +109,96 @@ class TestMapperRegistryScoping(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# Run as its own process, because the behaviour under test only happens when
+# one exits: the workers must release what they hold before they go.
+_PIPELINE_SCRIPT = """
+import os
+import sys
+
+from toksearch import Pipeline
+from toksearch.signal.mock_signal import MockSignal
+
+MARKS = sys.argv[1]
+
+
+class MarkerSignal(MockSignal):
+    def cleanup(self):
+        path = os.path.join(MARKS, "cleanup-%d" % os.getpid())
+        open(path, "w").close()
+
+
+if __name__ == "__main__":
+    open(os.path.join(MARKS, "parent-%d" % os.getpid()), "w").close()
+    pipe = Pipeline(list(range(40)))
+    pipe.fetch("sig", MarkerSignal())
+    pipe.keep([])
+    pipe.compute_multiprocessing(num_workers=2)
+"""
+
+
+class TestWorkerCleanup(unittest.TestCase):
+    """cleanup() has to actually run in the workers.
+
+    Nothing on this path used to call it. The backend dispatches _map_single
+    per record, which only calls cleanup_shot; _map_multiple, which does the
+    cleanup(), is used by the other backends. Whatever a worker held -- a
+    remote MDSplus connection above all -- was just dropped when it died.
+    """
+
+    def test_cleanup_runs_in_the_workers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            marks = os.path.join(tmp, "marks")
+            os.makedirs(marks)
+            script = os.path.join(tmp, "run_pipeline.py")
+            with open(script, "w") as fh:
+                fh.write(_PIPELINE_SCRIPT)
+
+            subprocess.run([sys.executable, script, marks],
+                           check=True, timeout=600)
+
+            written = os.listdir(marks)
+            parents = [f for f in written if f.startswith("parent-")]
+            cleaned = [f for f in written if f.startswith("cleanup-")]
+            parent_pid = parents[0].split("-", 1)[1]
+
+            self.assertTrue(cleaned, "cleanup() never ran in any worker")
+            # The workers, not the process that launched them.
+            self.assertNotIn(f"cleanup-{parent_pid}", cleaned)
+
+
+class TestWorkerCleanupRegistration(unittest.TestCase):
+
+    def setUp(self):
+        self._saved = mp_backend._cleanup_registered
+        mp_backend._cleanup_registered = False
+        SignalRegistry().reset()
+
+    def tearDown(self):
+        mp_backend._cleanup_registered = self._saved
+        SignalRegistry().reset()
+
+    def test_registers_once_however_many_records(self):
+        registered = []
+        with mock.patch.object(mp_backend.atexit, "register",
+                               side_effect=registered.append):
+            mapper = _Mapper([_SafeFetch("sig", MockSignal())])
+            for shot in range(5):
+                mapper(Record(shot))
+
+        self.assertEqual(len(registered), 1)
+
+    def test_the_handler_releases_registered_signals(self):
+        sig = MockSignal()
+        SignalRegistry().register(sig)
+
+        mp_backend._cleanup_signals()
+
+        self.assertNotIn(sig, SignalRegistry())
+
+    def test_the_handler_does_not_raise_at_shutdown(self):
+        # It runs during interpreter shutdown; throwing there only adds noise.
+        with mock.patch.object(SignalRegistry, "cleanup",
+                               side_effect=RuntimeError("boom")):
+            mp_backend._cleanup_signals()

--- a/toksearch/backend/multiprocessing/__init__.py
+++ b/toksearch/backend/multiprocessing/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import atexit
 import os
 
 from dataclasses import dataclass
@@ -26,12 +27,50 @@ from ...signal.signal import SignalRegistry
 
 DEFAULT_NUM_WORKERS = max(os.cpu_count() // 2, 1)
 
+_cleanup_registered = False
+
+
+def _cleanup_signals():
+    """Release whatever signals this process still has registered.
+
+    Best effort: this runs during interpreter shutdown, where raising would
+    do nothing but add noise on the way out.
+    """
+    try:
+        SignalRegistry().cleanup()
+    except Exception:
+        pass
+
+
+def _register_cleanup():
+    """Arrange for signal cleanup to run once, when this process exits.
+
+    Signal.cleanup() releases what is shared between shots -- for a remote
+    MDSplus signal, the server connection. joblib offers no end-of-work hook
+    inside a worker, and cleanup() must not be called per record or per batch:
+    loky reuses a worker, and its connection, across batches and across whole
+    pipeline runs, so disconnecting at either boundary would trade a large
+    reconnect cost for nothing.
+
+    Process exit is the last moment those resources are still ours to release,
+    and loky shuts its workers down cleanly rather than killing them, so an
+    atexit handler registered here does run. Without this, nothing in a worker
+    ever called cleanup() and the connection was simply dropped when the
+    process died.
+    """
+    global _cleanup_registered
+    if not _cleanup_registered:
+        _cleanup_registered = True
+        atexit.register(_cleanup_signals)
+
 
 class _Mapper:
     def __init__(self, operations):
         self.operations = operations
 
     def __call__(self, record):
+        _register_cleanup()
+
         # joblib unpickles a fresh copy of the operations -- and so fresh Signal
         # objects -- for every batch it dispatches. Signals register themselves
         # with the process-global SignalRegistry when fetched, and


### PR DESCRIPTION
Closes the gap noted at the end of #60: `Signal.cleanup()` was never called in a
multiprocessing worker.

**Stacked on #60.** Retarget as the stack merges.

## The gap

The backend dispatches `_map_single` per record, which only calls
`cleanup_shot`. `_map_multiple`, which does the `cleanup()`, is what the serial,
ray and spark backends use. So on the multiprocessing path nothing ever released
what a worker held — a remote MDSplus connection above all. It was dropped when
the process died, not closed.

## Why it can't just be called more often

`cleanup()` disconnects. Measured loky behaviour:

```
run 1 pids: [2239979, 2239980, 2239981, 2239982]
run 2 pids: [2239979, 2239980, 2239981, 2239982]
same workers reused: True
```

Workers — and their connections — survive not just batches but **entire
`Parallel` contexts**. Two consecutive `compute_multiprocessing` calls in one
process reuse the same workers. Calling `cleanup()` per record, per batch, or
even per run would trade a reconnect for nothing.

## The hook

Process exit is the last moment those resources are still ours, and loky shuts
workers down cleanly rather than killing them. Verified in the same probe:
atexit handlers registered inside workers fired in all four — and only when the
parent exited, **not** when the `Parallel` context closed (0 marks after each
context, 4 after the parent exited).

So `_Mapper` registers a one-shot atexit handler. This is also why it cannot be
per-run: there is no worker-side end-of-run event to hang it on.

## Cost

200 shots, 8 workers, against the mdsip relay. Instrumented per worker:

```
8 workers ran the exit handler
  total 9.7 ms   closeAllTrees 7.5 ms   disconnect 2.2 ms
  ... (all eight within 8.9-9.7 ms)
```

Teardown overall, 5 reps interleaved:

| | pipeline | teardown | total |
|---|---|---|---|
| before | 2.39s | 2.12s | 4.52s |
| after | 2.37s | 2.23s | 4.60s |

0.11s, against loky's own pool shutdown of ~2.1s. Pipeline time unchanged.

**A correction worth recording:** my first pass reported this as **+2.25s** and I
nearly abandoned the approach over it. That measurement was broken — it took a
median of several total walls and subtracted the inner pipeline time of only the
last run, mixing a median with a single sample while the pipeline time itself
varied. Measured per rep and interleaved, the difference is 0.11s and the ranges
overlap. The instrumented per-worker figure (~9.5 ms × 8 ≈ 0.08s) corroborates
the corrected number, not the original one.

## Tests

4 new, all failing without the change. The one that matters runs a real pipeline
in a **subprocess** — because the behaviour only happens when a process exits —
with a signal that writes a marker file from `cleanup()`, then asserts markers
exist and were written by pids other than the launcher's. Pre-change it fails
with "cleanup() never ran in any worker".

The other three cover registration happening once however many records, the
handler releasing registered signals, and the handler swallowing errors (it runs
during interpreter shutdown, where raising only adds noise).

Full suite: 346 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
