### PR TITLE
Provenance: derive a run's description from the Pipeline itself

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -22,8 +22,21 @@ requirements:
     - setuptools
     - numpy >=1.20, <2
     - openblas
+  # rattler-build 0.39 synthesises a python run-export of
+  # `python 3.12.* *_debug_cpython` from a host python whose build string is
+  # plainly `h5f976f7_2_cpython` -- no debug about it. Nothing on conda-forge
+  # declares that export (the 3.12.14 builds declare none at all), and the
+  # python_abi export beside it is correct, so this is a tool bug. The bad pin
+  # makes the built package uninstallable: no such python exists.
+  #
+  # Ignore the synthesised python export and state the constraint ourselves.
+  # python_abi still pins the ABI correctly, so the package stays
+  # version-specific.
+  ignore_run_exports:
+    by_name:
+      - python
   run:
-    - python
+    - python ${{ python }}
     - mdsplus-xrdcl >=1,<2
     # libMdsIpFDP.so, the transport MDSplus loads for an 'fdp://' location.
     # A protocol, not a device: DIII-D is served this way today and C-Mod is

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -3,5 +3,16 @@ c_stdlib:
 c_stdlib_version:
   - "2.28"
 python:
-  - "3.11"
-  - "3.12"
+  # "3.11" and "3.12" (without the .*) mean ==3.11.0 and ==3.12.0 exactly, not
+  # "any 3.11.x". Those specific patch releases carry debug-interpreter builds
+  # on conda-forge (*_debug_cpython), and when the build environment resolved
+  # one, python's run_export pinned the built package to
+  # `python 3.12.* *_debug_cpython` -- which the test environment then could
+  # not satisfy. The pin was always fragile; it only broke once conda-forge's
+  # 3.12.0 build set shifted, which is why main was green on 2026-08-18 with
+  # no commits since.
+  #
+  # "3.11.*" / "3.12.*" resolve to the newest patch release with an ordinary
+  # cpython build.
+  - "3.11.*"
+  - "3.12.*"

--- a/tests/test_pipeline_write.py
+++ b/tests/test_pipeline_write.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import os
 import tempfile
 import unittest
@@ -372,3 +373,185 @@ class TestSafeWrite(unittest.TestCase):
                 code=capture_code(),
             )
             self.assertEqual(ctx.write_directories(), [os.path.abspath(d)])
+
+
+from toksearch import Pipeline
+from toksearch.signal.mock_signal import MockSignal
+
+
+class TestPipelineWrite(unittest.TestCase):
+    def _pipeline(self):
+        pipeline = Pipeline([1, 2, 3])
+        pipeline.fetch_dataset("ds", {"ip": MockSignal()})
+        return pipeline
+
+    def test_declarative_form_writes_one_file_per_shot(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            pipeline = self._pipeline()
+            pipeline.write(out, field="ds", fmt="netcdf")
+            pipeline.compute_serial()
+            self.assertEqual(sorted(os.listdir(out)), ["1.nc", "2.nc", "3.nc"])
+
+    def test_declarative_form_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            pipeline = self._pipeline()
+            self.assertIsNone(pipeline.write(os.path.join(d, "p"), field="ds"))
+
+    def test_decorator_form_writes_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            pipeline = self._pipeline()
+
+            @pipeline.write(out, fmt="netcdf")
+            def shot_file(rec):
+                return rec["ds"]
+
+            pipeline.compute_serial()
+            self.assertEqual(sorted(os.listdir(out)), ["1.nc", "2.nc", "3.nc"])
+
+    def test_decorator_returns_the_original_function(self):
+        with tempfile.TemporaryDirectory() as d:
+            pipeline = self._pipeline()
+
+            @pipeline.write(os.path.join(d, "p"), fmt="netcdf")
+            def shot_file(rec):
+                return rec["ds"]
+
+            self.assertEqual(shot_file.__name__, "shot_file")
+            self.assertTrue(callable(shot_file))
+
+    def test_two_argument_decorator_form(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            pipeline = self._pipeline()
+
+            @pipeline.write(out)
+            def shot_file(rec, path):
+                with open(path, "w") as fh:
+                    fh.write(str(rec.shot))
+                return path
+
+            pipeline.compute_serial()
+            self.assertEqual(sorted(os.listdir(out)), ["1", "2", "3"])
+
+    def test_multiprocessing_backend_writes_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            pipeline = self._pipeline()
+            pipeline.write(out, field="ds", fmt="netcdf")
+            pipeline.compute_multiprocessing(num_workers=2)
+            self.assertEqual(sorted(os.listdir(out)), ["1.nc", "2.nc", "3.nc"])
+
+    def test_written_files_are_readable(self):
+        # Per-file open, not open_mfdataset: dask is not installed here.
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            pipeline = self._pipeline()
+            pipeline.write(out, field="ds", fmt="netcdf")
+            pipeline.compute_serial()
+            written = sorted(glob.glob(os.path.join(out, "*.nc")))
+            merged = xr.concat([xr.open_dataset(f) for f in written], dim="shot")
+            self.assertIn("ip", merged)
+
+    def test_non_empty_directory_is_refused(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            os.makedirs(out)
+            with open(os.path.join(out, "stale.nc"), "w") as fh:
+                fh.write("old")
+            pipeline = self._pipeline()
+            with self.assertRaises(ValueError):
+                pipeline.write(out, field="ds", fmt="netcdf")
+
+    def test_the_refusal_explains_why(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            os.makedirs(out)
+            with open(os.path.join(out, "stale.nc"), "w") as fh:
+                fh.write("old")
+            pipeline = self._pipeline()
+            with self.assertRaises(ValueError) as caught:
+                pipeline.write(out, field="ds", fmt="netcdf")
+            self.assertIn("exist_ok", str(caught.exception))
+
+    def test_non_empty_directory_allowed_with_exist_ok(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            os.makedirs(out)
+            with open(os.path.join(out, "stale.nc"), "w") as fh:
+                fh.write("old")
+            pipeline = self._pipeline()
+            pipeline.write(out, field="ds", fmt="netcdf", exist_ok=True)
+
+    def test_an_empty_existing_directory_is_fine(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            os.makedirs(out)
+            self._pipeline().write(out, field="ds", fmt="netcdf")
+
+    def test_write_appears_in_the_run_context_ops(self):
+        from toksearch.backend.serial import SerialRecordSet
+
+        with tempfile.TemporaryDirectory() as d:
+            pipeline = self._pipeline()
+            pipeline.write(os.path.join(d, "p"), field="ds", fmt="netcdf")
+            ctx = pipeline._run_context(SerialRecordSet, None)
+            self.assertEqual([op.op for op in ctx.ops][-1], "write")
+
+    def test_write_directories_needs_no_computation(self):
+        # RunContext.write_directories reads the pipeline definition, so the
+        # output directory is known before anything runs. That is what keeps
+        # provenance from forcing materialization on lazy Ray/Spark backends.
+        from toksearch.backend.serial import SerialRecordSet
+
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            pipeline = self._pipeline()
+            pipeline.write(out, field="ds", fmt="netcdf")
+            ctx = pipeline._run_context(SerialRecordSet, None)
+            self.assertEqual(ctx.write_directories(), [os.path.abspath(out)])
+
+    def test_track_file_is_recorded_in_the_spec(self):
+        from toksearch.backend.serial import SerialRecordSet
+
+        with tempfile.TemporaryDirectory() as d:
+            pipeline = self._pipeline()
+            pipeline.write(os.path.join(d, "p"), field="ds", fmt="netcdf",
+                           track="file")
+            ctx = pipeline._run_context(SerialRecordSet, None)
+            self.assertEqual(ctx.ops[-1].detail["track"], "file")
+
+    def test_track_file_is_excluded_from_write_directories(self):
+        from toksearch.backend.serial import SerialRecordSet
+
+        with tempfile.TemporaryDirectory() as d:
+            pipeline = self._pipeline()
+            pipeline.write(os.path.join(d, "p"), field="ds", fmt="netcdf",
+                           track="file")
+            ctx = pipeline._run_context(SerialRecordSet, None)
+            self.assertEqual(ctx.write_directories(), [])
+
+    def test_invalid_track_value_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            pipeline = self._pipeline()
+            with self.assertRaises(ValueError):
+                pipeline.write(os.path.join(d, "p"), field="ds", track="bogus")
+
+    def test_end_to_end_with_provenance(self):
+        import json
+
+        from toksearch.provenance import JsonProvenance
+
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            record = os.path.join(d, "run.json")
+            prov = JsonProvenance("study", path=record)
+            pipeline = self._pipeline()
+            pipeline.write(out, field="ds", fmt="netcdf")
+            pipeline.compute_serial(provenance=prov)
+            prov.finalize()
+            with open(record) as fh:
+                payload = json.load(fh)
+        self.assertEqual([o["path"] for o in payload["outputs"]],
+                         [os.path.abspath(out)])

--- a/tests/test_pipeline_write.py
+++ b/tests/test_pipeline_write.py
@@ -561,3 +561,74 @@ class TestPipelineWrite(unittest.TestCase):
                 payload = json.load(fh)
         self.assertEqual([o["path"] for o in payload["outputs"]],
                          [os.path.abspath(out)])
+
+
+class TestWriteSkipsFailedRecords(unittest.TestCase):
+    """A record that already failed must not be written by default.
+
+    Its fields are whatever survived the failure -- a fetch_dataset result that
+    never went through the map meant to reduce it, say -- so the file looks
+    valid while silently missing a pipeline stage, and the output directory's
+    DVC hash then vouches for it. Found by the CmfRun integration test, which
+    asserted the documented behaviour and caught the code not doing it.
+    """
+
+    def _pipeline(self, **write_kwargs):
+        def boom(rec):
+            if rec.shot == 2:
+                raise ValueError("no data")
+            rec["computed"] = rec.shot
+
+        pipeline = Pipeline([1, 2, 3])
+        pipeline.fetch_dataset("ds", {"ip": MockSignal()})
+        pipeline.map(boom)
+        return pipeline, boom
+
+    def test_a_failed_record_writes_no_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            pipeline, _ = self._pipeline()
+            pipeline.write(out, field="ds", fmt="netcdf")
+            pipeline.compute_serial()
+            self.assertEqual(sorted(os.listdir(out)), ["1.nc", "3.nc"])
+
+    def test_the_failed_record_still_reaches_the_recordset(self):
+        # Skipping the write must not drop the record: record_outcomes counts
+        # failures from it, and a dropped record would make a partial run look
+        # like a smaller complete one.
+        with tempfile.TemporaryDirectory() as d:
+            pipeline, _ = self._pipeline()
+            pipeline.write(os.path.join(d, "peaks"), field="ds", fmt="netcdf")
+            results = pipeline.compute_serial()
+            self.assertEqual(sorted(r.shot for r in results), [1, 2, 3])
+
+    def test_the_failed_record_has_no_output_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            pipeline, _ = self._pipeline()
+            pipeline.write(os.path.join(d, "peaks"), field="ds", fmt="netcdf")
+            results = pipeline.compute_serial()
+            failed = next(r for r in results if r.shot == 2)
+            self.assertIsNone(failed.get("output_path", None))
+
+    def test_on_error_write_keeps_the_old_behaviour(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "peaks")
+            pipeline, _ = self._pipeline()
+            pipeline.write(out, field="ds", fmt="netcdf", on_error="write")
+            pipeline.compute_serial()
+            self.assertEqual(sorted(os.listdir(out)), ["1.nc", "2.nc", "3.nc"])
+
+    def test_an_invalid_on_error_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            pipeline, _ = self._pipeline()
+            with self.assertRaises(ValueError):
+                pipeline.write(os.path.join(d, "p"), field="ds", on_error="maybe")
+
+    def test_on_error_appears_in_the_spec(self):
+        from toksearch.backend.serial import SerialRecordSet
+
+        with tempfile.TemporaryDirectory() as d:
+            pipeline, _ = self._pipeline()
+            pipeline.write(os.path.join(d, "p"), field="ds", fmt="netcdf")
+            ctx = pipeline._run_context(SerialRecordSet, None)
+            self.assertEqual(ctx.ops[-1].detail["on_error"], "skip")

--- a/tests/test_pipeline_write.py
+++ b/tests/test_pipeline_write.py
@@ -210,3 +210,165 @@ class TestWrittenPathIsTheReturnedPath(unittest.TestCase):
             for fmt, obj in cases:
                 returned = write_object(obj, os.path.join(d, fmt), fmt=fmt)
                 self.assertTrue(os.path.exists(returned), f"{fmt} path mismatch")
+
+
+from toksearch.pipeline.pipeline_funcs import _SafeWrite
+from toksearch.record import Record
+
+
+def _make_record(shot, value=1.0):
+    rec = Record(shot)
+    rec["ds"] = xr.Dataset({"a": ("t", [value, value])})
+    return rec
+
+
+class TestSafeWrite(unittest.TestCase):
+    def test_writes_one_file_named_for_the_shot(self):
+        with tempfile.TemporaryDirectory() as d:
+            _SafeWrite(d, field="ds", fmt="netcdf")(_make_record(123))
+            self.assertTrue(os.path.exists(os.path.join(d, "123.nc")))
+
+    def test_returns_the_record(self):
+        with tempfile.TemporaryDirectory() as d:
+            rec = _make_record(123)
+            self.assertIs(_SafeWrite(d, field="ds", fmt="netcdf")(rec), rec)
+
+    def test_records_the_output_path_on_the_record(self):
+        with tempfile.TemporaryDirectory() as d:
+            rec = _SafeWrite(d, field="ds", fmt="netcdf")(_make_record(123))
+            self.assertEqual(rec["output_path"], os.path.join(d, "123.nc"))
+
+    def test_the_recorded_path_actually_exists(self):
+        with tempfile.TemporaryDirectory() as d:
+            rec = _SafeWrite(d, field="ds", fmt="netcdf")(_make_record(123))
+            self.assertTrue(os.path.exists(rec["output_path"]))
+
+    def test_records_the_output_directory_on_the_record(self):
+        with tempfile.TemporaryDirectory() as d:
+            rec = _SafeWrite(d, field="ds", fmt="netcdf")(_make_record(123))
+            self.assertEqual(rec["_toksearch_write_dir"], os.path.abspath(d))
+
+    def test_creates_the_directory_if_absent(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "nested", "deeper")
+            _SafeWrite(out, field="ds", fmt="netcdf")(_make_record(1))
+            self.assertTrue(os.path.exists(os.path.join(out, "1.nc")))
+
+    def test_infers_format_from_the_object(self):
+        with tempfile.TemporaryDirectory() as d:
+            _SafeWrite(d, field="ds")(_make_record(123))
+            self.assertTrue(os.path.exists(os.path.join(d, "123.nc")))
+
+    def test_missing_field_sets_an_error_and_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as d:
+            rec = _SafeWrite(d, field="nope", fmt="netcdf")(_make_record(123))
+            self.assertIn("write", rec["errors"])
+
+    def test_missing_field_writes_no_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            _SafeWrite(d, field="nope", fmt="netcdf")(_make_record(123))
+            self.assertEqual(os.listdir(d), [])
+
+    def test_missing_field_still_returns_the_record(self):
+        # A failed write must not break the pipeline chain: _apply_operations
+        # stops on a falsy return.
+        with tempfile.TemporaryDirectory() as d:
+            rec = _make_record(123)
+            self.assertIs(_SafeWrite(d, field="nope", fmt="netcdf")(rec), rec)
+
+    def test_an_unwritable_object_sets_an_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            rec = Record(1)
+            rec["scalar"] = 3.14
+            out = _SafeWrite(d, field="scalar")(rec)
+            self.assertIn("write", out["errors"])
+
+    def test_multiple_fields_are_merged_into_one_dataset(self):
+        with tempfile.TemporaryDirectory() as d:
+            rec = Record(7)
+            rec["a"] = xr.Dataset({"x": ("t", [1.0])})
+            rec["b"] = xr.Dataset({"y": ("t", [2.0])})
+            _SafeWrite(d, fields=["a", "b"], fmt="netcdf")(rec)
+            written = xr.open_dataset(os.path.join(d, "7.nc"))
+            self.assertIn("x", written)
+            self.assertIn("y", written)
+
+    def test_custom_name_callable(self):
+        with tempfile.TemporaryDirectory() as d:
+            op = _SafeWrite(d, field="ds", fmt="netcdf",
+                            name=lambda rec: f"shot_{rec.shot}")
+            op(_make_record(5))
+            self.assertTrue(os.path.exists(os.path.join(d, "shot_5.nc")))
+
+    def test_writer_func_returning_an_object(self):
+        with tempfile.TemporaryDirectory() as d:
+            _SafeWrite(d, func=lambda rec: rec["ds"], fmt="netcdf")(_make_record(9))
+            self.assertTrue(os.path.exists(os.path.join(d, "9.nc")))
+
+    def test_writer_func_returning_a_path_it_wrote(self):
+        def writer(rec, path):
+            with open(path, "w") as fh:
+                fh.write("hi")
+            return path
+
+        with tempfile.TemporaryDirectory() as d:
+            rec = _SafeWrite(d, func=writer)(_make_record(11))
+            self.assertTrue(os.path.exists(os.path.join(d, "11")))
+            self.assertEqual(rec["output_path"], os.path.join(d, "11"))
+
+    def test_a_raising_writer_func_sets_an_error(self):
+        def writer(rec):
+            raise ValueError("nope")
+
+        with tempfile.TemporaryDirectory() as d:
+            rec = _SafeWrite(d, func=writer, fmt="netcdf")(_make_record(1))
+            self.assertIn("write", rec["errors"])
+
+    def test_custom_path_field(self):
+        with tempfile.TemporaryDirectory() as d:
+            op = _SafeWrite(d, field="ds", fmt="netcdf", path_field="nc_path")
+            rec = op(_make_record(3))
+            self.assertIn("nc_path", rec)
+
+    def test_spec_reports_the_write_op(self):
+        with tempfile.TemporaryDirectory() as d:
+            spec = _SafeWrite(d, field="ds", fmt="netcdf").spec().to_dict()
+            self.assertEqual(spec["op"], "write")
+            self.assertEqual(spec["detail"]["fields"], ["ds"])
+            self.assertEqual(spec["detail"]["track"], "directory")
+
+    def test_spec_directory_is_absolute(self):
+        with tempfile.TemporaryDirectory() as d:
+            spec = _SafeWrite(d, field="ds", fmt="netcdf").spec().to_dict()
+            self.assertEqual(spec["detail"]["directory"], os.path.abspath(d))
+
+    def test_spec_is_canonically_serializable(self):
+        from toksearch.provenance.hashing import canonical_json
+
+        with tempfile.TemporaryDirectory() as d:
+            op = _SafeWrite(d, field="ds", fmt="netcdf",
+                            name=lambda rec: str(rec.shot))
+            canonical_json(op.spec().to_dict())
+
+    def test_spec_carries_no_memory_address(self):
+        from toksearch.provenance.hashing import canonical_json
+
+        with tempfile.TemporaryDirectory() as d:
+            op = _SafeWrite(d, func=lambda rec: rec["ds"], fmt="netcdf")
+            self.assertNotIn("0x", canonical_json(op.spec().to_dict()))
+
+    def test_spec_keys_match_what_write_directories_reads(self):
+        # RunContext.write_directories filters on op == "write" and
+        # detail["track"] == "directory", then reads detail["directory"].
+        from toksearch.provenance.code import capture_code
+        from toksearch.provenance.context import BackendSpec, RunContext, SourceSpec
+
+        with tempfile.TemporaryDirectory() as d:
+            ctx = RunContext(
+                source=SourceSpec(kind="shotlist", count=1),
+                ops=(_SafeWrite(d, field="ds", fmt="netcdf").spec(),),
+                signals={},
+                backend=BackendSpec(kind="SerialRecordSet"),
+                code=capture_code(),
+            )
+            self.assertEqual(ctx.write_directories(), [os.path.abspath(d)])

--- a/tests/test_pipeline_write.py
+++ b/tests/test_pipeline_write.py
@@ -451,7 +451,13 @@ class TestPipelineWrite(unittest.TestCase):
             pipeline.write(out, field="ds", fmt="netcdf")
             pipeline.compute_serial()
             written = sorted(glob.glob(os.path.join(out, "*.nc")))
-            merged = xr.concat([xr.open_dataset(f) for f in written], dim="shot")
+            # data_vars is explicit: xarray warns that its default changes in a
+            # future release, and the suite's warning count is a signal.
+            merged = xr.concat(
+                [xr.open_dataset(f) for f in written],
+                dim="shot",
+                data_vars="all",
+            )
             self.assertIn("ip", merged)
 
     def test_non_empty_directory_is_refused(self):

--- a/tests/test_pipeline_write.py
+++ b/tests/test_pipeline_write.py
@@ -163,3 +163,50 @@ class TestRegistration(unittest.TestCase):
             writers._WRITERS.pop("custom_test_fmt", None)
             if "custom_test_fmt" in writers._ORDER:
                 writers._ORDER.remove("custom_test_fmt")
+
+
+class TestWrittenPathIsTheReturnedPath(unittest.TestCase):
+    """write_object's return value is recorded as a provenance artifact.
+
+    np.save/np.savez append their extension to a path that lacks one, which
+    would make the recorded path point at a file that does not exist.
+    """
+
+    def test_npy_writes_exactly_where_it_says(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "bare")
+            returned = write_object(np.array([1, 2]), path, fmt="npy")
+            self.assertTrue(os.path.exists(returned))
+            self.assertEqual(os.listdir(d), ["bare"])
+
+    def test_npz_writes_exactly_where_it_says(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "bare")
+            returned = write_object({"a": np.array([1, 2])}, path, fmt="npz")
+            self.assertTrue(os.path.exists(returned))
+            self.assertEqual(os.listdir(d), ["bare"])
+
+    def test_npy_still_roundtrips(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.npy")
+            write_object(np.array([1, 2, 3]), path, fmt="npy")
+            self.assertEqual(list(np.load(path)), [1, 2, 3])
+
+    def test_npz_still_roundtrips(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.npz")
+            write_object({"a": np.array([1, 2])}, path, fmt="npz")
+            self.assertEqual(list(np.load(path)["a"]), [1, 2])
+
+    def test_every_format_writes_to_the_returned_path(self):
+        cases = [
+            ("netcdf", xr.Dataset({"a": ("t", [1.0])})),
+            ("parquet", pd.DataFrame({"a": [1]})),
+            ("npy", np.array([1, 2])),
+            ("npz", {"a": np.array([1, 2])}),
+            ("json", {"a": 1}),
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            for fmt, obj in cases:
+                returned = write_object(obj, os.path.join(d, fmt), fmt=fmt)
+                self.assertTrue(os.path.exists(returned), f"{fmt} path mismatch")

--- a/tests/test_pipeline_write.py
+++ b/tests/test_pipeline_write.py
@@ -1,0 +1,165 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from toksearch.pipeline.writers import (
+    UnknownFormat,
+    extension_for,
+    write_object,
+    writer_for,
+)
+
+
+class TestWriterLookup(unittest.TestCase):
+    def test_explicit_format_wins(self):
+        self.assertIsNotNone(writer_for(fmt="netcdf", obj=None))
+
+    def test_infers_netcdf_from_dataset(self):
+        self.assertEqual(writer_for(obj=xr.Dataset()).fmt, "netcdf")
+
+    def test_infers_netcdf_from_dataarray(self):
+        self.assertEqual(writer_for(obj=xr.DataArray([1, 2])).fmt, "netcdf")
+
+    def test_infers_parquet_from_dataframe(self):
+        self.assertEqual(writer_for(obj=pd.DataFrame({"a": [1]})).fmt, "parquet")
+
+    def test_infers_npy_from_ndarray(self):
+        self.assertEqual(writer_for(obj=np.array([1, 2])).fmt, "npy")
+
+    def test_infers_json_from_dict(self):
+        self.assertEqual(writer_for(obj={"a": 1}).fmt, "json")
+
+    def test_a_dict_of_arrays_is_json_not_npz(self):
+        # npz is registered with no types precisely because a dict of arrays
+        # is indistinguishable from a plain dict. It must be asked for.
+        self.assertEqual(writer_for(obj={"a": np.array([1, 2])}).fmt, "json")
+
+    def test_unknown_type_raises_a_clear_error(self):
+        with self.assertRaises(UnknownFormat):
+            writer_for(obj=object())
+
+    def test_a_bare_scalar_raises_rather_than_guessing(self):
+        # The likely user mistake: write(dir, field='betan_max') where the
+        # field is a float. Must fail loudly with usable guidance.
+        with self.assertRaises(UnknownFormat):
+            writer_for(obj=3.14)
+
+    def test_a_pandas_series_raises_rather_than_guessing(self):
+        # Ambiguous between npy and parquet -- make the caller choose.
+        with self.assertRaises(UnknownFormat):
+            writer_for(obj=pd.Series([1, 2]))
+
+    def test_the_error_names_the_type_and_says_what_to_do(self):
+        with self.assertRaises(UnknownFormat) as caught:
+            writer_for(obj=3.14)
+        message = str(caught.exception)
+        self.assertIn("float", message)
+        self.assertIn("fmt=", message)
+
+    def test_unknown_format_name_raises(self):
+        with self.assertRaises(UnknownFormat):
+            writer_for(fmt="nonesuch", obj=None)
+
+    def test_unknown_format_error_lists_known_formats(self):
+        with self.assertRaises(UnknownFormat) as caught:
+            writer_for(fmt="nonesuch", obj=None)
+        self.assertIn("netcdf", str(caught.exception))
+
+    def test_extension_for_netcdf(self):
+        self.assertEqual(extension_for("netcdf"), ".nc")
+
+    def test_extension_for_parquet(self):
+        self.assertEqual(extension_for("parquet"), ".parquet")
+
+
+class TestWriteObject(unittest.TestCase):
+    def test_writes_a_dataset(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.nc")
+            write_object(xr.Dataset({"a": ("t", [1.0, 2.0])}), path, fmt="netcdf")
+            self.assertTrue(os.path.exists(path))
+
+    def test_roundtrips_a_dataset(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.nc")
+            write_object(xr.Dataset({"a": ("t", [1.0, 2.0])}), path, fmt="netcdf")
+            self.assertEqual(list(xr.open_dataset(path)["a"].values), [1.0, 2.0])
+
+    def test_writes_a_dataframe(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.parquet")
+            write_object(pd.DataFrame({"a": [1]}), path, fmt="parquet")
+            self.assertTrue(os.path.exists(path))
+
+    def test_roundtrips_a_dataframe(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.parquet")
+            write_object(pd.DataFrame({"a": [1, 2]}), path, fmt="parquet")
+            self.assertEqual(len(pd.read_parquet(path)), 2)
+
+    def test_writes_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.json")
+            write_object({"a": 1}, path, fmt="json")
+            self.assertTrue(os.path.exists(path))
+
+    def test_writes_npz_when_asked_explicitly(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.npz")
+            write_object({"a": np.array([1, 2])}, path, fmt="npz")
+            self.assertTrue(os.path.exists(path))
+
+    def test_infers_the_format_when_not_given(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.nc")
+            write_object(xr.Dataset({"a": ("t", [1.0])}), path)
+            self.assertTrue(os.path.exists(path))
+
+    def test_returns_the_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "x.json")
+            self.assertEqual(write_object({"a": 1}, path, fmt="json"), path)
+
+
+class TestRegistration(unittest.TestCase):
+    def test_a_custom_writer_can_be_registered(self):
+        from toksearch.pipeline.writers import register_writer
+
+        class _Custom:
+            pass
+
+        def _write(obj, path):
+            with open(path, "w") as fh:
+                fh.write("custom")
+
+        try:
+            register_writer("custom_test_fmt", ".custom", _write, (_Custom,))
+            self.assertEqual(writer_for(obj=_Custom()).fmt, "custom_test_fmt")
+            with tempfile.TemporaryDirectory() as d:
+                path = os.path.join(d, "x.custom")
+                write_object(_Custom(), path)
+                self.assertTrue(os.path.exists(path))
+        finally:
+            from toksearch.pipeline import writers
+
+            writers._WRITERS.pop("custom_test_fmt", None)
+            if "custom_test_fmt" in writers._ORDER:
+                writers._ORDER.remove("custom_test_fmt")

--- a/tests/test_provenance_backend.py
+++ b/tests/test_provenance_backend.py
@@ -346,3 +346,52 @@ class TestComputeWiring(unittest.TestCase):
         self.assertEqual(payload["pipeline_name"], "study")
         self.assertIn("ip", payload["context"]["signals"])
         self.assertEqual(payload["context"]["backend"]["kind"], "SerialRecordSet")
+
+
+class TestAllBackendsForwardProvenance(unittest.TestCase):
+    """Ray and Spark accept provenance= but no test runs them.
+
+    A wrapper that takes the argument and drops it would pass every signature
+    check while recording nothing, and compute_ray's **ray_init_kwargs makes
+    that a live risk. Intercept Pipeline.compute so all four wrappers can be
+    checked without starting a Ray cluster or a Spark context.
+    """
+
+    def test_every_compute_wrapper_forwards_provenance(self):
+        seen = {}
+        sentinel = object()
+        real = Pipeline.compute
+
+        class _FakeRecordSet:
+            provenance = None
+            run_id = None
+
+            def __iter__(self):
+                return iter(())
+
+        def _spy(self, recordset_cls, config=None, provenance=None):
+            seen[recordset_cls.__name__] = provenance
+            return _FakeRecordSet()
+
+        pipeline = Pipeline([1])
+        pipeline.fetch("ip", MockSignal())
+        try:
+            Pipeline.compute = _spy
+            pipeline.compute_serial(provenance=sentinel)
+            pipeline.compute_multiprocessing(num_workers=1, provenance=sentinel)
+            pipeline.compute_ray(provenance=sentinel)
+            pipeline.compute_spark(provenance=sentinel)
+        finally:
+            Pipeline.compute = real
+
+        self.assertEqual(
+            sorted(seen),
+            [
+                "MultiprocessingRecordSet",
+                "RayRecordSet",
+                "SerialRecordSet",
+                "SparkRecordSet",
+            ],
+        )
+        for name, forwarded in seen.items():
+            self.assertIs(forwarded, sentinel, f"{name} dropped provenance")

--- a/tests/test_provenance_backend.py
+++ b/tests/test_provenance_backend.py
@@ -229,3 +229,120 @@ class TestJsonProvenance(unittest.TestCase):
             with open(path) as fh:
                 outputs = [o["path"] for o in json.load(fh)["outputs"]]
         self.assertEqual(outputs, ["/tmp/peaks"])
+
+
+class _RecordingProvenance(Provenance):
+    def __init__(self):
+        self.run_id = "run-abc"
+        self.calls = []
+
+    def on_compute_start(self, ctx):
+        self.calls.append(("start", ctx))
+
+    def on_compute_end(self, ctx, recordset):
+        self.calls.append(("end", ctx, recordset))
+
+    def output(self, *paths, **custom_properties):
+        self.calls.append(("output", paths))
+
+    def metrics(self, name, values):
+        self.calls.append(("metrics", name))
+
+    def finalize(self):
+        self.calls.append(("finalize",))
+
+
+class TestComputeWiring(unittest.TestCase):
+    def _pipeline(self):
+        pipeline = Pipeline([1, 2, 3])
+        pipeline.fetch("ip", MockSignal())
+        return pipeline
+
+    def test_serial_calls_start_and_end(self):
+        prov = _RecordingProvenance()
+        self._pipeline().compute_serial(provenance=prov)
+        self.assertEqual([c[0] for c in prov.calls], ["start", "end"])
+
+    def test_multiprocessing_calls_start_and_end(self):
+        prov = _RecordingProvenance()
+        self._pipeline().compute_multiprocessing(num_workers=2, provenance=prov)
+        self.assertEqual([c[0] for c in prov.calls], ["start", "end"])
+
+    def test_start_receives_a_run_context(self):
+        from toksearch.provenance import RunContext
+
+        prov = _RecordingProvenance()
+        self._pipeline().compute_serial(provenance=prov)
+        self.assertIsInstance(prov.calls[0][1], RunContext)
+
+    def test_no_provenance_means_no_calls_and_no_error(self):
+        results = self._pipeline().compute_serial()
+        self.assertEqual(len(results), 3)
+
+    def test_no_provenance_leaves_recordset_attributes_none(self):
+        results = self._pipeline().compute_serial()
+        self.assertIsNone(results.provenance)
+        self.assertIsNone(results.run_id)
+
+    def test_recordset_carries_the_provenance(self):
+        prov = _RecordingProvenance()
+        results = self._pipeline().compute_serial(provenance=prov)
+        self.assertIs(results.provenance, prov)
+
+    def test_recordset_carries_the_run_id(self):
+        prov = _RecordingProvenance()
+        results = self._pipeline().compute_serial(provenance=prov)
+        self.assertEqual(results.run_id, "run-abc")
+
+    def test_chained_pipeline_records_the_parent_run(self):
+        prov = _RecordingProvenance()
+        first = self._pipeline().compute_serial(provenance=prov)
+        second = Pipeline(first)
+        ctx = second._run_context(SerialRecordSet, None)
+        self.assertEqual(ctx.parent_run, "run-abc")
+
+    def test_a_failing_backend_does_not_fail_the_run(self):
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            results = self._pipeline().compute_serial(
+                provenance=_ExplodingProvenance()
+            )
+        self.assertEqual(len(results), 3)
+
+    def test_a_failing_backend_warns(self):
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._pipeline().compute_serial(provenance=_ExplodingProvenance())
+        self.assertTrue(any("_ExplodingProvenance" in str(c.message) for c in caught))
+
+    def test_end_receives_the_returned_recordset(self):
+        prov = _RecordingProvenance()
+        results = self._pipeline().compute_serial(provenance=prov)
+        self.assertIs(prov.calls[1][2], results)
+
+    def test_the_same_context_object_reaches_both_hooks(self):
+        # One derivation per compute, not two: re-deriving could produce a
+        # different code capture or a different identity mid-run.
+        prov = _RecordingProvenance()
+        self._pipeline().compute_serial(provenance=prov)
+        self.assertIs(prov.calls[0][1], prov.calls[1][1])
+
+    def test_json_provenance_end_to_end_through_compute(self):
+        import json
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "run.json")
+            prov = JsonProvenance("study", path=path)
+            self._pipeline().compute_serial(provenance=prov)
+            prov.finalize()
+            with open(path) as fh:
+                payload = json.load(fh)
+        self.assertEqual(payload["pipeline_name"], "study")
+        self.assertIn("ip", payload["context"]["signals"])
+        self.assertEqual(payload["context"]["backend"]["kind"], "SerialRecordSet")

--- a/tests/test_provenance_backend.py
+++ b/tests/test_provenance_backend.py
@@ -115,3 +115,117 @@ class TestProvenanceIsAbstract(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             _Partial()
+
+
+import json
+import os
+import tempfile
+
+from toksearch import Pipeline
+from toksearch.provenance import JsonProvenance
+from toksearch.signal.mock_signal import MockSignal
+from toksearch.backend.serial import SerialRecordSet
+
+
+def _ctx():
+    pipeline = Pipeline([1, 2, 3])
+    pipeline.fetch("ip", MockSignal())
+    return pipeline._run_context(SerialRecordSet, None)
+
+
+class TestJsonProvenance(unittest.TestCase):
+    def _finalized(self, directory, act=None):
+        """Run a JsonProvenance through a full cycle, return the payload."""
+        path = os.path.join(directory, "run.json")
+        prov = JsonProvenance("study", path=path)
+        prov.on_compute_start(_ctx())
+        if act is not None:
+            act(prov)
+        prov.finalize()
+        with open(path) as fh:
+            return json.load(fh)
+
+    def test_writes_a_file_on_finalize(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "run.json")
+            prov = JsonProvenance("study", path=path)
+            prov.on_compute_start(_ctx())
+            prov.finalize()
+            self.assertTrue(os.path.exists(path))
+
+    def test_records_the_pipeline_name(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(self._finalized(d)["pipeline_name"], "study")
+
+    def test_stage_defaults_to_the_pipeline_name(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(self._finalized(d)["stage"], "study")
+
+    def test_records_the_run_context(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIn("ip", self._finalized(d)["context"]["signals"])
+
+    def test_records_the_input_identity(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(len(self._finalized(d)["input_identity"]), 64)
+
+    def test_records_declared_outputs(self):
+        with tempfile.TemporaryDirectory() as d:
+            payload = self._finalized(d, lambda p: p.output("a.nc", "b.png"))
+            self.assertEqual([o["path"] for o in payload["outputs"]],
+                             ["a.nc", "b.png"])
+
+    def test_output_custom_properties_are_kept(self):
+        with tempfile.TemporaryDirectory() as d:
+            payload = self._finalized(d, lambda p: p.output("a.nc", kind="figure"))
+            self.assertEqual(payload["outputs"][0]["kind"], "figure")
+
+    def test_records_metrics(self):
+        with tempfile.TemporaryDirectory() as d:
+            payload = self._finalized(d, lambda p: p.metrics("eval", {"rmse": 0.1}))
+            self.assertEqual(payload["metrics"]["eval"]["rmse"], 0.1)
+
+    def test_has_a_run_id(self):
+        self.assertTrue(JsonProvenance("study").run_id)
+
+    def test_run_ids_are_distinct(self):
+        self.assertNotEqual(JsonProvenance("a").run_id, JsonProvenance("b").run_id)
+
+    def test_creates_missing_parent_directories(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "nested", "deeper", "run.json")
+            prov = JsonProvenance("study", path=path)
+            prov.on_compute_start(_ctx())
+            prov.finalize()
+            self.assertTrue(os.path.exists(path))
+
+    def test_strict_is_settable(self):
+        self.assertTrue(JsonProvenance("study", strict=True).strict)
+
+    def test_payload_is_json_round_trippable(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsInstance(self._finalized(d), dict)
+
+    def test_on_compute_end_logs_write_directories_from_the_context(self):
+        # Not from the recordset: see RunContext.write_directories. Passing
+        # None as the recordset proves the paths never came from iterating it.
+        from toksearch.provenance.context import OpSpec
+
+        ctx = _ctx()
+        ctx_with_write = type(ctx)(
+            source=ctx.source,
+            ops=ctx.ops + (OpSpec("write", {"directory": "/tmp/peaks",
+                                            "track": "directory"}),),
+            signals=ctx.signals,
+            backend=ctx.backend,
+            code=ctx.code,
+        )
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "run.json")
+            prov = JsonProvenance("study", path=path)
+            prov.on_compute_start(ctx_with_write)
+            prov.on_compute_end(ctx_with_write, None)
+            prov.finalize()
+            with open(path) as fh:
+                outputs = [o["path"] for o in json.load(fh)["outputs"]]
+        self.assertEqual(outputs, ["/tmp/peaks"])

--- a/tests/test_provenance_backend.py
+++ b/tests/test_provenance_backend.py
@@ -1,0 +1,117 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import warnings
+
+from toksearch.provenance.base import Provenance, safe_call
+
+
+class _ExplodingProvenance(Provenance):
+    def on_compute_start(self, ctx):
+        raise RuntimeError("boom")
+
+    def on_compute_end(self, ctx, recordset):
+        pass
+
+    def output(self, *paths, **custom_properties):
+        pass
+
+    def metrics(self, name, values):
+        pass
+
+    def finalize(self):
+        pass
+
+
+class TestSafeCall(unittest.TestCase):
+    def test_swallows_errors_by_default(self):
+        prov = _ExplodingProvenance()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            safe_call(prov, "on_compute_start", None)
+        self.assertEqual(len(caught), 1)
+
+    def test_warning_names_the_backend_and_hook(self):
+        prov = _ExplodingProvenance()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            safe_call(prov, "on_compute_start", None)
+        message = str(caught[0].message)
+        self.assertIn("_ExplodingProvenance", message)
+        self.assertIn("on_compute_start", message)
+
+    def test_warning_says_results_are_unaffected(self):
+        # The message is the only thing standing between a user and the
+        # assumption that their compute failed. It must say otherwise.
+        prov = _ExplodingProvenance()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            safe_call(prov, "on_compute_start", None)
+        self.assertIn("unaffected", str(caught[0].message))
+
+    def test_strict_mode_reraises(self):
+        prov = _ExplodingProvenance()
+        prov.strict = True
+        with self.assertRaises(RuntimeError):
+            safe_call(prov, "on_compute_start", None)
+
+    def test_none_provenance_is_a_no_op(self):
+        safe_call(None, "on_compute_start", None)
+
+    def test_none_provenance_returns_none(self):
+        self.assertIsNone(safe_call(None, "on_compute_start", None))
+
+    def test_returns_the_hook_result(self):
+        class _Ok(_ExplodingProvenance):
+            def on_compute_start(self, ctx):
+                return "ok"
+
+        self.assertEqual(safe_call(_Ok(), "on_compute_start", None), "ok")
+
+    def test_passes_through_arguments(self):
+        seen = {}
+
+        class _Recorder(_ExplodingProvenance):
+            def on_compute_start(self, ctx):
+                seen["ctx"] = ctx
+
+        safe_call(_Recorder(), "on_compute_start", "the-context")
+        self.assertEqual(seen["ctx"], "the-context")
+
+    def test_strict_defaults_to_false(self):
+        self.assertFalse(_ExplodingProvenance().strict)
+
+    def test_run_id_defaults_to_none(self):
+        self.assertIsNone(_ExplodingProvenance().run_id)
+
+
+class TestProvenanceIsAbstract(unittest.TestCase):
+    def test_cannot_instantiate_the_abc(self):
+        with self.assertRaises(TypeError):
+            Provenance()
+
+    def test_all_five_hooks_are_abstract(self):
+        self.assertEqual(
+            sorted(Provenance.__abstractmethods__),
+            ["finalize", "metrics", "on_compute_end", "on_compute_start", "output"],
+        )
+
+    def test_a_partial_implementation_cannot_be_instantiated(self):
+        class _Partial(Provenance):
+            def on_compute_start(self, ctx):
+                pass
+
+        with self.assertRaises(TypeError):
+            _Partial()

--- a/tests/test_provenance_context.py
+++ b/tests/test_provenance_context.py
@@ -100,3 +100,106 @@ class TestCaptureCode(unittest.TestCase):
             code = capture_code(cwd=d)
             with self.assertRaises(dataclasses.FrozenInstanceError):
                 code.commit = "nope"
+
+
+from toksearch import Pipeline
+from toksearch.signal.mock_signal import MockSignal
+
+
+def _a_map_func(rec):
+    rec["doubled"] = 2
+
+
+def _a_where_func(rec):
+    return True
+
+
+def _specs_for(build):
+    pipeline = Pipeline([1, 2])
+    build(pipeline)
+    return [op.spec().to_dict() for op in pipeline._operations]
+
+
+class TestOperationSpecs(unittest.TestCase):
+    def test_fetch_reports_op_name_and_field(self):
+        op_specs = _specs_for(lambda p: p.fetch("ip", MockSignal()))
+        self.assertEqual(op_specs[0]["op"], "fetch")
+        self.assertEqual(op_specs[0]["detail"]["name"], "ip")
+
+    def test_fetch_includes_the_signal_spec(self):
+        op_specs = _specs_for(lambda p: p.fetch("ip", MockSignal()))
+        self.assertEqual(op_specs[0]["detail"]["signal"]["class"], "MockSignal")
+
+    def test_map_reports_the_function(self):
+        op_specs = _specs_for(lambda p: p.map(_a_map_func))
+        self.assertEqual(op_specs[0]["op"], "map")
+        self.assertEqual(op_specs[0]["detail"]["func"]["name"], "_a_map_func")
+
+    def test_keep_is_reported_as_keep_not_map(self):
+        op_specs = _specs_for(lambda p: p.keep(["ip"]))
+        self.assertEqual(op_specs[0]["op"], "keep")
+        self.assertEqual(op_specs[0]["detail"]["fields"], ["ip"])
+
+    def test_where_reports_the_predicate(self):
+        op_specs = _specs_for(lambda p: p.where(_a_where_func))
+        self.assertEqual(op_specs[0]["op"], "where")
+        self.assertEqual(op_specs[0]["detail"]["func"]["name"], "_a_where_func")
+
+    def test_fetch_dataset_reports_dataset_and_signal_names(self):
+        op_specs = _specs_for(
+            lambda p: p.fetch_dataset("ds", {"ip": MockSignal()})
+        )
+        self.assertEqual(op_specs[0]["op"], "fetch_dataset")
+        self.assertEqual(op_specs[0]["detail"]["ds_name"], "ds")
+        self.assertEqual(op_specs[0]["detail"]["signame"], "ip")
+
+    def test_align_reports_its_configuration_not_a_repr(self):
+        op_specs = _specs_for(
+            lambda p: p.align("ds", [0, 1, 2], dim="times", method="nearest")
+        )
+        detail = op_specs[0]["detail"]
+        self.assertEqual(op_specs[0]["op"], "align")
+        self.assertEqual(detail["align_with"], [0, 1, 2])
+        self.assertEqual(detail["dim"], "times")
+        self.assertEqual(detail["method"], "nearest")
+
+    def test_align_spec_carries_no_memory_address(self):
+        from toksearch.provenance.hashing import canonical_json
+
+        op_specs = _specs_for(lambda p: p.align("ds", [0, 1, 2]))
+        self.assertNotIn("0x", canonical_json(op_specs))
+
+    def test_two_identical_aligns_produce_equal_specs(self):
+        a = _specs_for(lambda p: p.align("ds", [0, 1, 2]))
+        b = _specs_for(lambda p: p.align("ds", [0, 1, 2]))
+        self.assertEqual(a, b)
+
+    def test_align_with_a_numpy_array_is_serializable(self):
+        import numpy as np
+
+        from toksearch.provenance.hashing import canonical_json
+
+        op_specs = _specs_for(lambda p: p.align("ds", np.array([0.0, 1.0])))
+        canonical_json(op_specs)
+
+    def test_op_order_is_preserved(self):
+        def build(p):
+            p.fetch("ip", MockSignal())
+            p.map(_a_map_func)
+            p.keep(["ip"])
+
+        self.assertEqual([s["op"] for s in _specs_for(build)],
+                         ["fetch", "map", "keep"])
+
+    def test_every_op_spec_is_canonically_serializable(self):
+        from toksearch.provenance.hashing import canonical_json
+
+        def build(p):
+            p.fetch("ip", MockSignal())
+            p.fetch_dataset("ds", {"bt": MockSignal()})
+            p.map(_a_map_func)
+            p.keep(["ip"])
+            p.align("ds", [0, 1])
+            p.where(_a_where_func)
+
+        canonical_json(_specs_for(build))

--- a/tests/test_provenance_context.py
+++ b/tests/test_provenance_context.py
@@ -203,3 +203,133 @@ class TestOperationSpecs(unittest.TestCase):
             p.where(_a_where_func)
 
         canonical_json(_specs_for(build))
+
+
+from toksearch.backend.serial import SerialRecordSet
+from toksearch.backend.multiprocessing import (
+    MultiprocessingRecordSet,
+    MultiprocessingConfig,
+)
+
+
+class TestRunContext(unittest.TestCase):
+    def _ctx(self, shots=(1, 2, 3)):
+        pipeline = Pipeline(list(shots))
+        pipeline.fetch("ip", MockSignal())
+        pipeline.map(_a_map_func)
+        return pipeline._run_context(SerialRecordSet, None)
+
+    def test_source_kind_is_shotlist(self):
+        self.assertEqual(self._ctx().source.kind, "shotlist")
+
+    def test_source_records_the_count(self):
+        self.assertEqual(self._ctx().source.count, 3)
+
+    def test_source_hash_is_stable_for_the_same_shots(self):
+        self.assertEqual(self._ctx().source.hash, self._ctx().source.hash)
+
+    def test_source_hash_ignores_shot_order(self):
+        a = self._ctx(shots=(1, 2, 3)).source.hash
+        b = self._ctx(shots=(3, 1, 2)).source.hash
+        self.assertEqual(a, b)
+
+    def test_source_hash_differs_for_different_shots(self):
+        self.assertNotEqual(self._ctx(shots=(1, 2)).source.hash,
+                            self._ctx(shots=(1, 2, 3)).source.hash)
+
+    def test_signals_are_collected_by_field_name(self):
+        self.assertIn("ip", self._ctx().signals)
+
+    def test_ops_are_recorded_in_order(self):
+        self.assertEqual([op.op for op in self._ctx().ops], ["fetch", "map"])
+
+    def test_backend_kind_is_the_recordset_class_name(self):
+        self.assertEqual(self._ctx().backend.kind, "SerialRecordSet")
+
+    def test_backend_config_is_captured(self):
+        pipeline = Pipeline([1])
+        config = MultiprocessingConfig(num_workers=4)
+        ctx = pipeline._run_context(MultiprocessingRecordSet, config)
+        self.assertEqual(ctx.backend.config["num_workers"], 4)
+
+    def test_code_is_captured(self):
+        self.assertIsInstance(self._ctx().code.argv, tuple)
+
+    def test_parent_run_is_none_without_a_parent(self):
+        self.assertIsNone(self._ctx().parent_run)
+
+    def test_to_dict_is_canonically_serializable(self):
+        from toksearch.provenance.hashing import canonical_json
+        canonical_json(self._ctx().to_dict())
+
+    def test_to_dict_carries_no_memory_address(self):
+        from toksearch.provenance.hashing import canonical_json
+        self.assertNotIn("0x", canonical_json(self._ctx().to_dict()))
+
+    def test_two_identical_pipelines_share_an_input_identity(self):
+        self.assertEqual(self._ctx().input_identity(), self._ctx().input_identity())
+
+    def test_input_identity_changes_with_signals(self):
+        a = self._ctx()
+        p = Pipeline([1, 2, 3])
+        p.fetch("ip", MockSignal(data=[9, 9]))
+        b = p._run_context(SerialRecordSet, None)
+        self.assertNotEqual(a.input_identity(), b.input_identity())
+
+    def test_input_identity_ignores_the_backend(self):
+        # Two runs reading the same data share an input artifact even when
+        # computed on different backends. That shared artifact is what
+        # connects the lineage graph.
+        p = Pipeline([1, 2, 3])
+        p.fetch("ip", MockSignal())
+        a = p._run_context(SerialRecordSet, None)
+        b = p._run_context(MultiprocessingRecordSet, MultiprocessingConfig(num_workers=4))
+        self.assertEqual(a.input_identity(), b.input_identity())
+
+    def test_input_identity_ignores_map_functions(self):
+        # Same reasoning: what you do with the data does not change which
+        # data you read.
+        p1 = Pipeline([1, 2, 3])
+        p1.fetch("ip", MockSignal())
+        p2 = Pipeline([1, 2, 3])
+        p2.fetch("ip", MockSignal())
+        p2.map(_a_map_func)
+        self.assertEqual(
+            p1._run_context(SerialRecordSet, None).input_identity(),
+            p2._run_context(SerialRecordSet, None).input_identity(),
+        )
+
+    def test_is_frozen(self):
+        import dataclasses
+
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            self._ctx().device = "nope"
+
+
+class TestSqlSource(unittest.TestCase):
+    def test_shotlist_pipeline_has_no_sql_source(self):
+        self.assertIsNone(Pipeline([1, 2])._sql_source)
+
+    def test_chained_pipeline_inherits_sql_source(self):
+        parent = Pipeline([1, 2])
+        parent._sql_source = {"query": "select shot from shots", "params": ()}
+        self.assertEqual(Pipeline(parent)._sql_source, parent._sql_source)
+
+    def test_sql_source_produces_a_sql_source_spec(self):
+        pipeline = Pipeline([1, 2])
+        pipeline._sql_source = {"query": "select shot from shots", "params": ("a",)}
+        source = pipeline._source_spec()
+        self.assertEqual(source.kind, "sql")
+        self.assertEqual(source.query, "select shot from shots")
+        self.assertEqual(source.params, ("a",))
+        self.assertIsNotNone(source.hash)
+
+
+class TestRecordSetSource(unittest.TestCase):
+    def test_recordset_parent_is_reported_as_recordset(self):
+        first = Pipeline([1, 2, 3])
+        first.fetch("ip", MockSignal())
+        results = first.compute_serial()
+        source = Pipeline(results)._source_spec()
+        self.assertEqual(source.kind, "recordset")
+        self.assertEqual(source.count, 3)

--- a/tests/test_provenance_context.py
+++ b/tests/test_provenance_context.py
@@ -379,3 +379,53 @@ class TestSqlSourceEndToEnd(unittest.TestCase):
             a._run_context(SerialRecordSet, None).input_identity(),
             b._run_context(SerialRecordSet, None).input_identity(),
         )
+
+
+class TestWriteDirectories(unittest.TestCase):
+    """Built from a hand-made RunContext.
+
+    Pipeline.write does not exist yet (a later task adds it), and this method
+    cannot wait for it: JsonProvenance already depends on it.
+    """
+
+    def _ctx(self, ops):
+        from toksearch.provenance.code import capture_code
+        from toksearch.provenance.context import BackendSpec, RunContext, SourceSpec
+
+        return RunContext(
+            source=SourceSpec(kind="shotlist", count=1),
+            ops=tuple(ops),
+            signals={},
+            backend=BackendSpec(kind="SerialRecordSet"),
+            code=capture_code(),
+        )
+
+    def test_reads_the_directory_from_a_write_op(self):
+        from toksearch.provenance.context import OpSpec
+
+        ctx = self._ctx([OpSpec("write", {"directory": "/tmp/out",
+                                          "track": "directory"})])
+        self.assertEqual(ctx.write_directories(), ["/tmp/out"])
+
+    def test_skips_track_file_writes(self):
+        from toksearch.provenance.context import OpSpec
+
+        ctx = self._ctx([OpSpec("write", {"directory": "/tmp/out",
+                                          "track": "file"})])
+        self.assertEqual(ctx.write_directories(), [])
+
+    def test_is_empty_without_write_ops(self):
+        from toksearch.provenance.context import OpSpec
+
+        ctx = self._ctx([OpSpec("map", {"func": None})])
+        self.assertEqual(ctx.write_directories(), [])
+
+    def test_collects_several_write_ops_in_order(self):
+        from toksearch.provenance.context import OpSpec
+
+        ctx = self._ctx([
+            OpSpec("write", {"directory": "/tmp/a", "track": "directory"}),
+            OpSpec("map", {"func": None}),
+            OpSpec("write", {"directory": "/tmp/b", "track": "directory"}),
+        ])
+        self.assertEqual(ctx.write_directories(), ["/tmp/a", "/tmp/b"])

--- a/tests/test_provenance_context.py
+++ b/tests/test_provenance_context.py
@@ -333,3 +333,49 @@ class TestRecordSetSource(unittest.TestCase):
         source = Pipeline(results)._source_spec()
         self.assertEqual(source.kind, "recordset")
         self.assertEqual(source.count, 3)
+
+class TestSqlSourceEndToEnd(unittest.TestCase):
+    """Exercise the real from_sql path, not a hand-set _sql_source.
+
+    from_sql is the only pre-existing public API this work modifies, so the
+    round trip through it needs direct coverage: a hand-set attribute would
+    still pass if the from_sql edit were reverted.
+    """
+
+    def _conn(self):
+        import sqlite3
+
+        conn = sqlite3.connect(":memory:")
+        conn.execute("create table shots_type (shot int, shot_type text)")
+        conn.executemany(
+            "insert into shots_type values (?,?)",
+            [(101, "plasma"), (102, "plasma"), (103, "calibration")],
+        )
+        conn.commit()
+        return conn
+
+    _QUERY = "select shot from shots_type where shot_type = ?"
+
+    def test_from_sql_records_the_query(self):
+        pipeline = Pipeline.from_sql(self._conn(), self._QUERY, "plasma")
+        self.assertEqual(pipeline._source_spec().query, self._QUERY)
+
+    def test_from_sql_records_the_params(self):
+        pipeline = Pipeline.from_sql(self._conn(), self._QUERY, "plasma")
+        self.assertEqual(pipeline._source_spec().params, ("plasma",))
+
+    def test_from_sql_source_kind_is_sql(self):
+        pipeline = Pipeline.from_sql(self._conn(), self._QUERY, "plasma")
+        self.assertEqual(pipeline._source_spec().kind, "sql")
+
+    def test_from_sql_still_returns_a_working_pipeline(self):
+        pipeline = Pipeline.from_sql(self._conn(), self._QUERY, "plasma")
+        self.assertEqual(len(pipeline.compute_serial()), 2)
+
+    def test_different_queries_have_different_input_identities(self):
+        a = Pipeline.from_sql(self._conn(), self._QUERY, "plasma")
+        b = Pipeline.from_sql(self._conn(), self._QUERY, "calibration")
+        self.assertNotEqual(
+            a._run_context(SerialRecordSet, None).input_identity(),
+            b._run_context(SerialRecordSet, None).input_identity(),
+        )

--- a/tests/test_provenance_context.py
+++ b/tests/test_provenance_context.py
@@ -1,0 +1,102 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+from toksearch.provenance.code import capture_code
+
+
+def _init_repo(path):
+    env = dict(os.environ, GIT_AUTHOR_NAME="t", GIT_AUTHOR_EMAIL="t@e",
+               GIT_COMMITTER_NAME="t", GIT_COMMITTER_EMAIL="t@e")
+    subprocess.run(["git", "init", "-q", path], check=True, env=env)
+    with open(os.path.join(path, "f.txt"), "w") as fh:
+        fh.write("one\n")
+    subprocess.run(["git", "-C", path, "add", "f.txt"], check=True, env=env)
+    subprocess.run(["git", "-C", path, "commit", "-qm", "init"], check=True, env=env)
+    return env
+
+
+class TestCaptureCode(unittest.TestCase):
+    def test_returns_commit_in_a_repo(self):
+        with tempfile.TemporaryDirectory() as d:
+            _init_repo(d)
+            code = capture_code(cwd=d)
+            self.assertEqual(len(code.commit), 40)
+
+    def test_reports_clean_tree(self):
+        with tempfile.TemporaryDirectory() as d:
+            _init_repo(d)
+            self.assertFalse(capture_code(cwd=d).dirty)
+
+    def test_reports_dirty_tree(self):
+        with tempfile.TemporaryDirectory() as d:
+            _init_repo(d)
+            with open(os.path.join(d, "f.txt"), "w") as fh:
+                fh.write("two\n")
+            self.assertTrue(capture_code(cwd=d).dirty)
+
+    def test_records_repo_root(self):
+        with tempfile.TemporaryDirectory() as d:
+            _init_repo(d)
+            self.assertIsNotNone(capture_code(cwd=d).repo_root)
+
+    def test_outside_a_repo_returns_none_commit_not_an_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            code = capture_code(cwd=d)
+            self.assertIsNone(code.commit)
+
+    def test_outside_a_repo_dirty_is_none_not_false(self):
+        # None means "unknown", False means "known clean". Conflating them
+        # would let a provenance record claim a clean tree it never saw.
+        with tempfile.TemporaryDirectory() as d:
+            self.assertIsNone(capture_code(cwd=d).dirty)
+
+    def test_records_argv(self):
+        code = capture_code()
+        self.assertIsInstance(code.argv, tuple)
+
+    def test_is_json_serializable(self):
+        from toksearch.provenance.hashing import canonical_json
+        canonical_json(capture_code().to_dict())
+
+    def test_to_dict_round_trips_every_field(self):
+        with tempfile.TemporaryDirectory() as d:
+            _init_repo(d)
+            code = capture_code(cwd=d)
+            as_dict = code.to_dict()
+            for field in ("commit", "dirty", "repo_root", "script", "argv"):
+                self.assertIn(field, as_dict)
+
+    def test_untracked_files_alone_count_as_dirty(self):
+        # `git status --porcelain` lists untracked files, so a tree with only
+        # untracked additions reads as dirty. That is the intended reading:
+        # the run may depend on a file that is not in the recorded commit.
+        with tempfile.TemporaryDirectory() as d:
+            _init_repo(d)
+            with open(os.path.join(d, "scratch.py"), "w") as fh:
+                fh.write("x = 1\n")
+            self.assertTrue(capture_code(cwd=d).dirty)
+
+    def test_is_frozen(self):
+        import dataclasses
+
+        with tempfile.TemporaryDirectory() as d:
+            _init_repo(d)
+            code = capture_code(cwd=d)
+            with self.assertRaises(dataclasses.FrozenInstanceError):
+                code.commit = "nope"

--- a/tests/test_provenance_hashing.py
+++ b/tests/test_provenance_hashing.py
@@ -1,3 +1,17 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from toksearch.provenance.hashing import canonical_json, sha256_of, callable_spec
@@ -49,12 +63,21 @@ class TestCallableSpec(unittest.TestCase):
         self.assertEqual(spec["module"], __name__)
 
     def test_captures_source_hash(self):
-        spec = callable_spec(_example_func)
-        self.assertEqual(len(spec["source_sha256"]), 64)
+        import hashlib
+        import inspect
+
+        expected = hashlib.sha256(
+            inspect.getsource(_example_func).encode("utf-8")
+        ).hexdigest()
+        self.assertEqual(callable_spec(_example_func)["source_sha256"], expected)
 
     def test_source_hash_is_none_when_source_unavailable(self):
+        # A lambda built by eval has no retrievable source: inspect.getsource
+        # raises OSError. The key must still be present, and its value None --
+        # asserting only that the key exists would let a regression that
+        # populates it with a stale digest pass unnoticed.
         spec = callable_spec(eval("lambda x: x"))
-        self.assertIn("source_sha256", spec)
+        self.assertIsNone(spec["source_sha256"])
 
     def test_builtin_does_not_raise(self):
         spec = callable_spec(len)

--- a/tests/test_provenance_hashing.py
+++ b/tests/test_provenance_hashing.py
@@ -1,0 +1,61 @@
+import unittest
+
+from toksearch.provenance.hashing import canonical_json, sha256_of, callable_spec
+
+
+def _example_func(x):
+    return x + 1
+
+
+class TestCanonicalJson(unittest.TestCase):
+    def test_key_order_does_not_matter(self):
+        a = {"b": 1, "a": 2}
+        b = {"a": 2, "b": 1}
+        self.assertEqual(canonical_json(a), canonical_json(b))
+
+    def test_no_incidental_whitespace(self):
+        self.assertEqual(canonical_json({"a": 1}), '{"a":1}')
+
+    def test_non_serializable_falls_back_to_repr_string(self):
+        out = canonical_json({"a": object()})
+        self.assertIn("object object at", out)
+
+    def test_nested_dicts_are_also_sorted(self):
+        a = {"outer": {"z": 1, "y": 2}}
+        b = {"outer": {"y": 2, "z": 1}}
+        self.assertEqual(canonical_json(a), canonical_json(b))
+
+
+class TestSha256Of(unittest.TestCase):
+    def test_is_stable_across_calls(self):
+        self.assertEqual(sha256_of({"a": 1}), sha256_of({"a": 1}))
+
+    def test_differs_for_different_values(self):
+        self.assertNotEqual(sha256_of({"a": 1}), sha256_of({"a": 2}))
+
+    def test_is_a_64_char_hex_digest(self):
+        digest = sha256_of({"a": 1})
+        self.assertEqual(len(digest), 64)
+        int(digest, 16)
+
+
+class TestCallableSpec(unittest.TestCase):
+    def test_none_returns_none(self):
+        self.assertIsNone(callable_spec(None))
+
+    def test_captures_name_and_module(self):
+        spec = callable_spec(_example_func)
+        self.assertEqual(spec["name"], "_example_func")
+        self.assertEqual(spec["module"], __name__)
+
+    def test_captures_source_hash(self):
+        spec = callable_spec(_example_func)
+        self.assertEqual(len(spec["source_sha256"]), 64)
+
+    def test_source_hash_is_none_when_source_unavailable(self):
+        spec = callable_spec(eval("lambda x: x"))
+        self.assertIn("source_sha256", spec)
+
+    def test_builtin_does_not_raise(self):
+        spec = callable_spec(len)
+        self.assertEqual(spec["name"], "len")

--- a/tests/test_provenance_hashing.py
+++ b/tests/test_provenance_hashing.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import unittest
 
 from toksearch.provenance.hashing import canonical_json, sha256_of, callable_spec
@@ -19,6 +20,17 @@ from toksearch.provenance.hashing import canonical_json, sha256_of, callable_spe
 
 def _example_func(x):
     return x + 1
+
+
+class _CallableObject:
+    """An instance used as a map function -- has no __name__."""
+
+    def __call__(self, record):
+        return record
+
+
+class _Plain:
+    """No custom __repr__, so its default repr embeds a memory address."""
 
 
 class TestCanonicalJson(unittest.TestCase):
@@ -32,7 +44,8 @@ class TestCanonicalJson(unittest.TestCase):
 
     def test_non_serializable_falls_back_to_repr_string(self):
         out = canonical_json({"a": object()})
-        self.assertIn("object object at", out)
+        self.assertIn("object object", out)
+        self.assertNotIn("0x", out)
 
     def test_nested_dicts_are_also_sorted(self):
         a = {"outer": {"z": 1, "y": 2}}
@@ -82,3 +95,75 @@ class TestCallableSpec(unittest.TestCase):
     def test_builtin_does_not_raise(self):
         spec = callable_spec(len)
         self.assertEqual(spec["name"], "len")
+
+
+class TestDeterminismAcrossRuns(unittest.TestCase):
+    """The properties everything downstream rests on.
+
+    Each of these fails against a naive ``default=repr`` implementation. They
+    exist because a fingerprint that changes between runs silently breaks
+    input-artifact dedup: CMF records two runs over identical data as two
+    different inputs, and the lineage graph stops connecting.
+    """
+
+    def test_partial_name_has_no_memory_address(self):
+        p = functools.partial(_example_func)
+        self.assertNotIn("0x", canonical_json(callable_spec(p)))
+
+    def test_partial_fingerprint_is_stable(self):
+        a = functools.partial(_example_func, 1)
+        b = functools.partial(_example_func, 1)
+        self.assertEqual(sha256_of(callable_spec(a)), sha256_of(callable_spec(b)))
+
+    def test_partial_keeps_the_wrapped_function_identity(self):
+        spec = callable_spec(functools.partial(_example_func, 1))
+        self.assertEqual(spec["name"], "_example_func")
+
+    def test_partial_records_bound_arguments(self):
+        spec = callable_spec(functools.partial(_example_func, threshold=5))
+        self.assertEqual(spec["partial_keywords"], {"threshold": "5"})
+
+    def test_partials_with_different_bound_args_differ(self):
+        a = callable_spec(functools.partial(_example_func, threshold=5))
+        b = callable_spec(functools.partial(_example_func, threshold=6))
+        self.assertNotEqual(a, b)
+
+    def test_callable_object_name_has_no_memory_address(self):
+        self.assertNotIn("0x", canonical_json(callable_spec(_CallableObject())))
+
+    def test_callable_object_is_identified_by_its_class(self):
+        spec = callable_spec(_CallableObject())
+        self.assertEqual(spec["name"], f"{__name__}._CallableObject")
+
+    def test_two_callable_object_instances_fingerprint_alike(self):
+        self.assertEqual(
+            sha256_of(callable_spec(_CallableObject())),
+            sha256_of(callable_spec(_CallableObject())),
+        )
+
+    def test_callable_object_captures_class_source(self):
+        self.assertIsNotNone(callable_spec(_CallableObject())["source_sha256"])
+
+    def test_sets_serialize_in_a_stable_order(self):
+        a = canonical_json({"s": {"zebra", "apple", "mango"}})
+        b = canonical_json({"s": {"mango", "zebra", "apple"}})
+        self.assertEqual(a, b)
+
+    def test_nested_sets_are_stable(self):
+        self.assertEqual(
+            canonical_json([{"b", "a"}]), canonical_json([{"a", "b"}])
+        )
+
+    def test_tuple_dict_keys_do_not_raise(self):
+        canonical_json({(1, 2): "a"})
+
+    def test_mixed_type_dict_keys_do_not_raise(self):
+        canonical_json({1: "a", "1": "b"})
+
+    def test_object_without_custom_repr_has_no_memory_address(self):
+        self.assertNotIn("0x", canonical_json({"o": object()}))
+
+    def test_object_fallback_is_stable_across_instances(self):
+        self.assertEqual(
+            canonical_json({"o": _Plain()}), canonical_json({"o": _Plain()})
+        )

--- a/tests/test_provenance_signal_spec.py
+++ b/tests/test_provenance_signal_spec.py
@@ -1,0 +1,161 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from toksearch.signal.signal import Signal
+from toksearch.signal.mock_signal import MockSignal
+
+
+class _UnspeccedSignal(Signal):
+    """A third-party-style signal that never implements _spec_fields."""
+
+    def __init__(self, thing, count=3):
+        super().__init__()
+        self.thing = thing
+        self.count = count
+        self._private = "should not appear"
+
+    def gather(self, shot):
+        return {"data": [0]}
+
+    def cleanup_shot(self, shot):
+        pass
+
+    def cleanup(self):
+        pass
+
+
+class _SpeccedSignal(Signal):
+    def __init__(self, thing):
+        super().__init__()
+        self.thing = thing
+
+    def _spec_fields(self):
+        return {"thing": self.thing}
+
+    def gather(self, shot):
+        return {"data": [0]}
+
+    def cleanup_shot(self, shot):
+        pass
+
+    def cleanup(self):
+        pass
+
+
+def _a_callback(result):
+    return result
+
+
+class TestSignalSpec(unittest.TestCase):
+    def test_spec_reports_class_and_module(self):
+        spec = _SpeccedSignal("x").spec()
+        self.assertEqual(spec["class"], "_SpeccedSignal")
+        self.assertEqual(spec["module"], __name__)
+
+    def test_spec_includes_declared_fields(self):
+        spec = _SpeccedSignal("x").spec()
+        self.assertEqual(spec["fields"], {"thing": "x"})
+
+    def test_spec_is_not_marked_incomplete_when_declared(self):
+        self.assertNotIn("spec_incomplete", _SpeccedSignal("x").spec())
+
+    def test_spec_records_dims_and_units(self):
+        spec = _SpeccedSignal("x").spec()
+        self.assertEqual(spec["dims"], ["times"])
+        self.assertTrue(spec["with_units"])
+
+    def test_spec_records_callback(self):
+        sig = _SpeccedSignal("x").set_callback(_a_callback)
+        self.assertEqual(sig.spec()["callback"]["name"], "_a_callback")
+
+    def test_spec_callback_is_none_by_default(self):
+        self.assertIsNone(_SpeccedSignal("x").spec()["callback"])
+
+    def test_two_identical_signals_have_equal_specs(self):
+        self.assertEqual(_SpeccedSignal("x").spec(), _SpeccedSignal("x").spec())
+
+    def test_different_signals_have_different_specs(self):
+        self.assertNotEqual(_SpeccedSignal("x").spec(), _SpeccedSignal("y").spec())
+
+
+class TestReflectiveFallback(unittest.TestCase):
+    def test_unspecced_signal_does_not_raise(self):
+        _UnspeccedSignal("x").spec()
+
+    def test_unspecced_signal_is_marked_incomplete(self):
+        self.assertTrue(_UnspeccedSignal("x").spec()["spec_incomplete"])
+
+    def test_reflective_fields_capture_public_attributes(self):
+        fields = _UnspeccedSignal("x", count=7).spec()["fields"]
+        self.assertEqual(fields["thing"], "x")
+        self.assertEqual(fields["count"], 7)
+
+    def test_reflective_fields_exclude_private_attributes(self):
+        self.assertNotIn("_private", _UnspeccedSignal("x").spec()["fields"])
+
+    def test_reflective_fields_exclude_base_class_state(self):
+        fields = _UnspeccedSignal("x").spec()["fields"]
+        for excluded in ("dims", "data_order", "with_units"):
+            self.assertNotIn(excluded, fields)
+
+
+class TestMockSignalSpec(unittest.TestCase):
+    def test_mock_signal_declares_its_fields(self):
+        spec = MockSignal().spec()
+        self.assertNotIn("spec_incomplete", spec)
+
+    def test_mock_signal_spec_reflects_data(self):
+        a = MockSignal(data=[1, 2, 3]).spec()
+        b = MockSignal(data=[9, 9, 9]).spec()
+        self.assertNotEqual(a, b)
+
+
+class TestSpecDeterminism(unittest.TestCase):
+    """The spec feeds an input-identity hash, so it must serialize stably."""
+
+    def test_specced_signal_spec_is_canonically_serializable(self):
+        from toksearch.provenance.hashing import canonical_json
+
+        canonical_json(_SpeccedSignal("x").spec())
+
+    def test_reflective_spec_is_canonically_serializable(self):
+        from toksearch.provenance.hashing import canonical_json
+
+        canonical_json(_UnspeccedSignal("x").spec())
+
+    def test_mock_signal_spec_hashes_identically_for_equal_signals(self):
+        from toksearch.provenance.hashing import sha256_of
+
+        self.assertEqual(sha256_of(MockSignal().spec()), sha256_of(MockSignal().spec()))
+
+    def test_reflective_spec_carries_no_memory_address(self):
+        from toksearch.provenance.hashing import canonical_json
+
+        class _HoldsAnObject(Signal):
+            def __init__(self):
+                super().__init__()
+                self.thing = object()
+
+            def gather(self, shot):
+                return {"data": [0]}
+
+            def cleanup_shot(self, shot):
+                pass
+
+            def cleanup(self):
+                pass
+
+        self.assertNotIn("0x", canonical_json(_HoldsAnObject().spec()))

--- a/tests/test_provenance_signal_spec.py
+++ b/tests/test_provenance_signal_spec.py
@@ -16,6 +16,8 @@ import unittest
 
 from toksearch.signal.signal import Signal
 from toksearch.signal.mock_signal import MockSignal
+from toksearch.signal.mds import MdsSignal, MdsTreePath
+from toksearch.signal.zarr import ZarrSignal
 
 
 class _UnspeccedSignal(Signal):
@@ -159,3 +161,70 @@ class TestSpecDeterminism(unittest.TestCase):
                 pass
 
         self.assertNotIn("0x", canonical_json(_HoldsAnObject().spec()))
+
+
+class TestMdsSignalSpec(unittest.TestCase):
+    def test_declares_its_fields(self):
+        sig = MdsSignal(r"\ipmhd", "efit01", location="remote://atlas.gat.com")
+        self.assertNotIn("spec_incomplete", sig.spec())
+
+    def test_captures_expression_and_tree(self):
+        sig = MdsSignal(r"\ipmhd", "efit01", location="remote://atlas.gat.com")
+        fields = sig.spec()["fields"]
+        self.assertEqual(fields["expression"], r"\ipmhd")
+        self.assertEqual(fields["treename"], "efit01")
+
+    def test_captures_location(self):
+        sig = MdsSignal(r"\ipmhd", "efit01", location="remote://atlas.gat.com")
+        self.assertEqual(sig.spec()["fields"]["location"], "remote://atlas.gat.com")
+
+    def test_tree_path_location_is_serializable(self):
+        sig = MdsSignal(r"\ipmhd", "efit01", location=MdsTreePath(efit01="/a/b"))
+        location = sig.spec()["fields"]["location"]
+        self.assertIsInstance(location, (str, dict))
+
+    def test_different_expressions_differ(self):
+        a = MdsSignal(r"\ipmhd", "efit01", location="remote://atlas.gat.com")
+        b = MdsSignal(r"\betan", "efit01", location="remote://atlas.gat.com")
+        self.assertNotEqual(a.spec(), b.spec())
+
+    def test_spec_carries_no_memory_address(self):
+        from toksearch.provenance.hashing import canonical_json
+
+        sig = MdsSignal(r"\ipmhd", "efit01", location="remote://atlas.gat.com")
+        self.assertNotIn("0x", canonical_json(sig.spec()))
+
+    def test_identical_signals_hash_alike(self):
+        from toksearch.provenance.hashing import sha256_of
+
+        a = MdsSignal(r"\ipmhd", "efit01", location="remote://atlas.gat.com")
+        b = MdsSignal(r"\ipmhd", "efit01", location="remote://atlas.gat.com")
+        self.assertEqual(sha256_of(a.spec()), sha256_of(b.spec()))
+
+
+class TestZarrSignalSpec(unittest.TestCase):
+    def test_declares_its_fields(self):
+        sig = ZarrSignal(path="s3://bucket", treepath="magnetics/ip")
+        self.assertNotIn("spec_incomplete", sig.spec())
+
+    def test_captures_path_and_treepath(self):
+        sig = ZarrSignal(path="s3://bucket", treepath="magnetics/ip")
+        fields = sig.spec()["fields"]
+        self.assertEqual(fields["path"], "s3://bucket")
+        self.assertEqual(fields["treepath"], "magnetics/ip")
+
+    def test_captures_file_name_format(self):
+        sig = ZarrSignal(
+            path="s3://bucket", treepath="magnetics/ip", file_name_format="x-{shot}.zarr"
+        )
+        self.assertEqual(sig.spec()["fields"]["file_name_format"], "x-{shot}.zarr")
+
+    def test_filesystem_object_is_not_in_the_spec(self):
+        sig = ZarrSignal(path="s3://bucket", treepath="magnetics/ip")
+        self.assertNotIn("fs", sig.spec()["fields"])
+
+    def test_spec_carries_no_memory_address(self):
+        from toksearch.provenance.hashing import canonical_json
+
+        sig = ZarrSignal(path="s3://bucket", treepath="magnetics/ip")
+        self.assertNotIn("0x", canonical_json(sig.spec()))

--- a/tests/test_provenance_signal_spec.py
+++ b/tests/test_provenance_signal_spec.py
@@ -219,6 +219,14 @@ class TestZarrSignalSpec(unittest.TestCase):
         )
         self.assertEqual(sig.spec()["fields"]["file_name_format"], "x-{shot}.zarr")
 
+    def test_fetch_units_changes_the_spec(self):
+        # ZarrSignal.__init__ does not sync fetch_units into the base class's
+        # with_units, so spec()["with_units"] is always True here. Without
+        # fetch_units in fields, these two would collide.
+        a = ZarrSignal(path="s3://bucket", treepath="magnetics/ip", fetch_units=True)
+        b = ZarrSignal(path="s3://bucket", treepath="magnetics/ip", fetch_units=False)
+        self.assertNotEqual(a.spec(), b.spec())
+
     def test_filesystem_object_is_not_in_the_spec(self):
         sig = ZarrSignal(path="s3://bucket", treepath="magnetics/ip")
         self.assertNotIn("fs", sig.spec()["fields"])

--- a/tests/test_recordset_output.py
+++ b/tests/test_recordset_output.py
@@ -1,0 +1,198 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+
+import pandas as pd
+
+from toksearch import Pipeline
+from toksearch.signal.mock_signal import MockSignal
+from toksearch.provenance import JsonProvenance
+
+
+def _add_scalar(rec):
+    rec["peak"] = float(max(rec["ip"]["data"]))
+
+
+def _pipeline():
+    pipeline = Pipeline([1, 2, 3])
+    pipeline.fetch("ip", MockSignal())
+    pipeline.map(_add_scalar)
+    pipeline.keep(["peak"])
+    return pipeline
+
+
+class TestToDataFrame(unittest.TestCase):
+    def test_returns_a_dataframe(self):
+        self.assertIsInstance(_pipeline().compute_serial().to_dataframe(), pd.DataFrame)
+
+    def test_has_one_row_per_record(self):
+        self.assertEqual(len(_pipeline().compute_serial().to_dataframe()), 3)
+
+    def test_includes_the_shot_column(self):
+        df = _pipeline().compute_serial().to_dataframe()
+        self.assertEqual(sorted(df["shot"]), [1, 2, 3])
+
+    def test_shot_is_the_first_column(self):
+        df = _pipeline().compute_serial().to_dataframe()
+        self.assertEqual(list(df.columns)[0], "shot")
+
+    def test_includes_kept_fields(self):
+        self.assertIn("peak", _pipeline().compute_serial().to_dataframe().columns)
+
+    def test_excludes_the_errors_field_by_default(self):
+        # errors survives keep(), so this exclusion is doing real work.
+        self.assertNotIn("errors", _pipeline().compute_serial().to_dataframe().columns)
+
+    def test_explicit_fields_selection(self):
+        df = _pipeline().compute_serial().to_dataframe(fields=["peak"])
+        self.assertEqual(list(df.columns), ["shot", "peak"])
+
+    def test_empty_recordset_gives_an_empty_frame(self):
+        pipeline = Pipeline([1])
+        pipeline.where(lambda rec: False)
+        self.assertEqual(len(pipeline.compute_serial().to_dataframe()), 0)
+
+    def test_empty_recordset_still_has_a_shot_column(self):
+        pipeline = Pipeline([1])
+        pipeline.where(lambda rec: False)
+        self.assertIn("shot", pipeline.compute_serial().to_dataframe().columns)
+
+    def test_write_bookkeeping_field_is_excluded(self):
+        pipeline = Pipeline([1, 2])
+        pipeline.fetch("ip", MockSignal())
+        pipeline.map(_add_scalar)
+        results = pipeline.compute_serial()
+        for rec in results:
+            rec["_toksearch_write_dir"] = "/tmp/somewhere"
+        self.assertNotIn("_toksearch_write_dir", results.to_dataframe().columns)
+
+
+class TestToDataFrameWithFailures(unittest.TestCase):
+    """Records go ragged when a shot fails mid-map.
+
+    A shot whose map function raised keeps `errors` and `shot` but never gains
+    the field the others have. to_dataframe must still produce a frame, with
+    the failed shot showing NaN rather than dropping out or raising --
+    otherwise a partial run looks like a smaller complete one.
+    """
+
+    def _ragged(self):
+        def peak_but_fail_on_two(rec):
+            if rec.shot == 2:
+                raise ValueError("no data")
+            rec["peak"] = float(max(rec["ip"]["data"]))
+
+        pipeline = Pipeline([1, 2, 3])
+        pipeline.fetch("ip", MockSignal())
+        pipeline.map(peak_but_fail_on_two)
+        pipeline.keep(["peak"])
+        return pipeline.compute_serial()
+
+    def test_all_shots_are_present(self):
+        self.assertEqual(sorted(self._ragged().to_dataframe()["shot"]), [1, 2, 3])
+
+    def test_the_failed_shot_is_nan_not_missing(self):
+        self.assertEqual(int(self._ragged().to_dataframe()["peak"].isna().sum()), 1)
+
+    def test_the_successful_shots_keep_their_values(self):
+        self.assertEqual(int(self._ragged().to_dataframe()["peak"].notna().sum()), 2)
+
+    def test_errors_are_still_excluded_from_the_frame(self):
+        self.assertNotIn("errors", self._ragged().to_dataframe().columns)
+
+
+class TestToParquet(unittest.TestCase):
+    def test_writes_a_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.parquet")
+            _pipeline().compute_serial().to_parquet(path)
+            self.assertTrue(os.path.exists(path))
+
+    def test_roundtrips(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.parquet")
+            _pipeline().compute_serial().to_parquet(path)
+            self.assertEqual(len(pd.read_parquet(path)), 3)
+
+    def test_returns_the_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.parquet")
+            self.assertEqual(_pipeline().compute_serial().to_parquet(path), path)
+
+    def test_honours_field_selection(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "out.parquet")
+            _pipeline().compute_serial().to_parquet(path, fields=["peak"])
+            self.assertEqual(list(pd.read_parquet(path).columns), ["shot", "peak"])
+
+    def test_declares_the_output_to_provenance(self):
+        with tempfile.TemporaryDirectory() as d:
+            record_path = os.path.join(d, "run.json")
+            out = os.path.join(d, "out.parquet")
+            prov = JsonProvenance("study", path=record_path)
+            results = _pipeline().compute_serial(provenance=prov)
+            results.to_parquet(out)
+            self.assertIn(out, [o["path"] for o in prov._outputs])
+
+    def test_the_declared_output_is_tagged_with_its_source(self):
+        with tempfile.TemporaryDirectory() as d:
+            record_path = os.path.join(d, "run.json")
+            out = os.path.join(d, "out.parquet")
+            prov = JsonProvenance("study", path=record_path)
+            results = _pipeline().compute_serial(provenance=prov)
+            results.to_parquet(out)
+            entry = next(o for o in prov._outputs if o["path"] == out)
+            self.assertEqual(entry["source"], "to_parquet")
+
+    def test_without_provenance_it_just_writes(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "out.parquet")
+            _pipeline().compute_serial().to_parquet(out)
+            self.assertTrue(os.path.exists(out))
+
+    def test_a_failing_provenance_backend_does_not_lose_the_file(self):
+        # The file is written before provenance is told about it. A backend
+        # failure must not cost the user their output.
+        import warnings
+
+        from toksearch.provenance.base import Provenance
+
+        class _Exploding(Provenance):
+            run_id = "x"
+
+            def on_compute_start(self, ctx): pass
+            def on_compute_end(self, ctx, recordset): pass
+            def output(self, *paths, **kw): raise RuntimeError("boom")
+            def metrics(self, name, values): pass
+            def finalize(self): pass
+
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "out.parquet")
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                results = _pipeline().compute_serial(provenance=_Exploding())
+                results.to_parquet(out)
+            self.assertTrue(os.path.exists(out))
+
+
+class TestNoToNetcdf(unittest.TestCase):
+    def test_to_netcdf_is_deliberately_absent(self):
+        # Driver-side concatenation is slow and is a transformation that
+        # deserves its own stage. Array-shaped results go through
+        # Pipeline.write instead.
+        results = _pipeline().compute_serial()
+        self.assertFalse(hasattr(results, "to_netcdf"))

--- a/toksearch/__init__.py
+++ b/toksearch/__init__.py
@@ -111,12 +111,13 @@ All backends return an iterable ``RecordSet``.  Iterate directly::
     for rec in records:
         print(rec['shot'], rec.get('max_ip', None))
 
-To build a pandas DataFrame, convert records explicitly —
-``pd.DataFrame(records)`` does **not** work because RecordSet is not a list
-of dicts::
+To build a pandas DataFrame from scalar results, use ``to_dataframe``::
 
-    import pandas as pd
-    df = pd.DataFrame([dict(r) for r in records])
+    df = records.to_dataframe()
+
+``pd.DataFrame(records)`` does **not** work because RecordSet is not a list.
+For records holding arrays or datasets, write per-shot files from inside the
+pipeline with ``Pipeline.write`` instead.
 
 Critical Gotchas
 ================
@@ -126,7 +127,7 @@ Gotcha                      Wrong                               Right
 ==========================  ==================================  ==============================
 ``map`` return value        ``return {'key': val}``             ``rec['key'] = val`` (in-place)
 ``keep`` signature          ``keep('a', 'b')``                  ``keep(['a', 'b'])``
-DataFrame from results      ``pd.DataFrame(records)``           ``pd.DataFrame([dict(r)...])``
+DataFrame from results      ``pd.DataFrame(records)``           ``records.to_dataframe()``
 Record safe access          ``rec.get('k')``                    ``rec.get('k', None)``
 ==========================  ==================================  ==============================
 

--- a/toksearch/pipeline/pipeline_funcs.py
+++ b/toksearch/pipeline/pipeline_funcs.py
@@ -175,7 +175,8 @@ class _SafeWrite(object):
 
     def __init__(self, directory, field=None, fields=None, fmt=None,
                  func=None, name=None, track="directory",
-                 path_field="output_path"):
+                 path_field="output_path", on_error="skip"):
+        self.on_error = on_error
         self.directory = os.path.abspath(directory)
         self.fields = [field] if field is not None else (list(fields) if fields else [])
         self.fmt = fmt
@@ -208,6 +209,16 @@ class _SafeWrite(object):
         return xr.merge(values, join="outer"), None
 
     def __call__(self, record):
+        # A record that already failed an earlier operation must not be
+        # written by default. Its fields are whatever survived the failure --
+        # a fetch_dataset result that never went through the map that was
+        # supposed to reduce it, say -- so the file would look valid while
+        # silently missing a pipeline stage, and the output directory's DVC
+        # hash would then vouch for it. Skipping keeps the recorded artifact
+        # honest: it covers exactly the shots that completed.
+        if self.on_error == "skip" and record.get("errors", None):
+            return record
+
         try:
             os.makedirs(self.directory, exist_ok=True)
             obj, written_path = self._payload(record)
@@ -238,6 +249,7 @@ class _SafeWrite(object):
                 "name": callable_spec(self.name),
                 "track": self.track,
                 "path_field": self.path_field,
+                "on_error": self.on_error,
             },
         )
 

--- a/toksearch/pipeline/pipeline_funcs.py
+++ b/toksearch/pipeline/pipeline_funcs.py
@@ -14,6 +14,8 @@
 
 import xarray as xr
 from ..signal.signal import SignalRegistry
+from ..provenance.context import OpSpec
+from ..provenance.hashing import callable_spec
 
 
 class _SafeMap(object):
@@ -27,6 +29,15 @@ class _SafeMap(object):
             name = getattr(self.func, "__name__", repr(self.func))
             record.set_error(name, e)
         return record
+
+    def spec(self):
+        # keep() and align() are implemented as map(), so delegate to the
+        # wrapped callable when it can describe itself. Otherwise this really
+        # is a user map function.
+        inner = getattr(self.func, "spec", None)
+        if callable(inner):
+            return inner()
+        return OpSpec("map", {"func": callable_spec(self.func)})
 
 
 class _SafeFetch(object):
@@ -42,6 +53,9 @@ class _SafeFetch(object):
             record.set_error(self.name, e)
             record[self.name] = None
         return record
+
+    def spec(self):
+        return OpSpec("fetch", {"name": self.name, "signal": self.signal.spec()})
 
 
 class _SafeFetchAsXarray(object):
@@ -70,6 +84,17 @@ class _SafeFetchAsXarray(object):
             record.set_error(self.ds_name, e)
         return record
 
+    def spec(self):
+        return OpSpec(
+            "fetch_dataset",
+            {
+                "ds_name": self.ds_name,
+                "signame": self.signame,
+                "append": self.append,
+                "signal": self.signal.spec(),
+            },
+        )
+
 
 class _PipelineKeep(object):
     def __init__(self, fields):
@@ -77,6 +102,9 @@ class _PipelineKeep(object):
 
     def __call__(self, rec):
         rec.keep(self.fields)
+
+    def spec(self):
+        return OpSpec("keep", {"fields": list(self.fields)})
 
 
 class _PipelineAlign(object):
@@ -86,6 +114,31 @@ class _PipelineAlign(object):
 
     def __call__(self, record):
         record[self.ds_name] = self.aligner(record[self.ds_name])
+
+    def spec(self):
+        # NOT repr(self.aligner): XarrayAligner defines no __repr__, so its
+        # repr embeds a memory address and two identical aligners compare
+        # unequal. canonical_json cannot rescue this -- it only rewrites
+        # non-serializable *values*, and a repr string is already a str, so
+        # the address would pass straight into the hash. Describe the
+        # aligner's actual configuration instead.
+        aligner = self.aligner
+        align_with = getattr(aligner, "align_with", None)
+        if callable(align_with):
+            align_with = callable_spec(align_with)
+        elif hasattr(align_with, "tolist"):
+            align_with = align_with.tolist()
+        return OpSpec(
+            "align",
+            {
+                "ds_name": self.ds_name,
+                "align_with": align_with,
+                "dim": getattr(aligner, "dim", None),
+                "method": getattr(aligner, "method", None),
+                "extrapolate": getattr(aligner, "extrapolate", None),
+                "interp_kwargs": getattr(aligner, "interp_kwargs", None),
+            },
+        )
 
 
 class _PipelineWhere(object):
@@ -102,6 +155,9 @@ class _PipelineWhere(object):
         except Exception as e:
             record.set_error("where", e)
             return None
+
+    def spec(self):
+        return OpSpec("where", {"func": callable_spec(self.func)})
 
 
 def _map_multiple(record_list, operations):

--- a/toksearch/pipeline/pipeline_funcs.py
+++ b/toksearch/pipeline/pipeline_funcs.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+import os
+
 import xarray as xr
 from ..signal.signal import SignalRegistry
 from ..provenance.context import OpSpec
 from ..provenance.hashing import callable_spec
+from .writers import extension_for, write_object, writer_for
 
 
 class _SafeMap(object):
@@ -158,6 +162,84 @@ class _PipelineWhere(object):
 
     def spec(self):
         return OpSpec("where", {"func": callable_spec(self.func)})
+
+
+class _SafeWrite(object):
+    """Write one file per record, in the worker, and record where it went.
+
+    This operation deliberately does *not* talk to a provenance backend. It
+    runs inside worker processes, which may be forked; cmflib and DVC must
+    never be touched there. It records the path on the record instead, and the
+    driver collects those paths after compute returns.
+    """
+
+    def __init__(self, directory, field=None, fields=None, fmt=None,
+                 func=None, name=None, track="directory",
+                 path_field="output_path"):
+        self.directory = os.path.abspath(directory)
+        self.fields = [field] if field is not None else (list(fields) if fields else [])
+        self.fmt = fmt
+        self.func = func
+        self.name = name
+        self.track = track
+        self.path_field = path_field
+
+    def _basename(self, record):
+        if self.name is not None:
+            return str(self.name(record))
+        return str(record.shot)
+
+    def _payload(self, record):
+        """Return (object_to_write, already_written_path)."""
+        if self.func is not None:
+            if len(inspect.signature(self.func).parameters) >= 2:
+                path = os.path.join(self.directory, self._basename(record))
+                return None, self.func(record, path)
+            return self.func(record), None
+
+        missing = [f for f in self.fields if f not in record]
+        if missing:
+            raise KeyError(f"record has no field(s) {missing}")
+
+        values = [record[f] for f in self.fields]
+        if len(values) == 1:
+            return values[0], None
+
+        return xr.merge(values, join="outer"), None
+
+    def __call__(self, record):
+        try:
+            os.makedirs(self.directory, exist_ok=True)
+            obj, written_path = self._payload(record)
+
+            if written_path is None:
+                fmt = self.fmt or writer_for(obj=obj).fmt
+                path = os.path.join(
+                    self.directory, self._basename(record) + extension_for(fmt)
+                )
+                write_object(obj, path, fmt=fmt)
+            else:
+                path = str(written_path)
+
+            record[self.path_field] = path
+            record["_toksearch_write_dir"] = self.directory
+        except Exception as e:
+            record.set_error("write", e)
+        return record
+
+    def spec(self):
+        return OpSpec(
+            "write",
+            {
+                "directory": self.directory,
+                "fields": list(self.fields),
+                "fmt": self.fmt,
+                "func": callable_spec(self.func),
+                "name": callable_spec(self.name),
+                "track": self.track,
+                "path_field": self.path_field,
+            },
+        )
 
 
 def _map_multiple(record_list, operations):

--- a/toksearch/pipeline/record_pipeline.py
+++ b/toksearch/pipeline/record_pipeline.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
 
 from .pipeline_source import PipelineSource
 
+from ..provenance.base import safe_call
 from ..provenance.code import capture_code
 from ..provenance.context import RunContext, SourceSpec, BackendSpec
 from ..provenance.hashing import sha256_of
@@ -357,7 +358,10 @@ class Pipeline:
         # return self._map_single_shot(record)
 
     def compute(
-        self, recordset_cls: Type[RecordSet], config: Optional[object] = None
+        self,
+        recordset_cls: Type[RecordSet],
+        config: Optional[object] = None,
+        provenance: Optional[object] = None,
     ) -> RecordSet:
         """Apply the pipeline using a backend defined by recordset_cls
 
@@ -366,26 +370,43 @@ class Pipeline:
                 of RecordSet.
             config: Configuration object for the backend RecordSet (e.g. RayConfig if
                 using Ray, MultiprocessingConfig if using multiprocessing, etc.)
+            provenance: Optional Provenance backend. When given, the run is
+                described and recorded. Backend failures are warnings, never
+                exceptions -- see toksearch.provenance.safe_call.
 
         Returns:
             RecordSet: The record set
         """
+        ctx = None
+        if provenance is not None:
+            ctx = self._run_context(recordset_cls, config)
+            safe_call(provenance, "on_compute_start", ctx)
 
         if isinstance(self.parent, RecordSet):
             initial_result = self.parent
         else:
             initial_result = self.parent.create_recordset(recordset_cls, config=config)
 
-        return initial_result.map(*self._operations)
+        result = initial_result.map(*self._operations)
+
+        if provenance is not None:
+            result.provenance = provenance
+            result.run_id = getattr(provenance, "run_id", None)
+            safe_call(provenance, "on_compute_end", ctx, result)
+
+        return result
 
     ####################### SERIAL ######################
 
-    def compute_serial(self):
+    def compute_serial(self, provenance: Optional[object] = None):
         """Apply the pipeline serially on the local host
+
+        Arguments:
+            provenance: Optional Provenance backend. See Pipeline.compute.
 
         Returns a SerialRecordSet object
         """
-        return self.compute(SerialRecordSet)
+        return self.compute(SerialRecordSet, provenance=provenance)
 
     ####################### RAY  ######################
 
@@ -396,6 +417,7 @@ class Pipeline:
         verbose: bool = True,
         placement_group_func: Optional[Callable] = None,
         memory_per_shot: Optional[int] = None,
+        provenance: Optional[object] = None,
         **ray_init_kwargs,
     ) -> RayRecordSet:
         """Apply the pipeline using Ray
@@ -410,6 +432,7 @@ class Pipeline:
                 for more information on placement groups.
             memory_per_shot: Memory to allocate to each shot in bytes. If not provided, there
                 is no limit.
+            provenance: Optional Provenance backend. See Pipeline.compute.
 
         Other Arguments:
             **ray_init_kwargs: Keyword arguments to pass to ray.init
@@ -426,7 +449,7 @@ class Pipeline:
             **ray_init_kwargs,
         )
 
-        return self.compute(RayRecordSet, config=config)
+        return self.compute(RayRecordSet, config=config, provenance=provenance)
 
     ####################### SPARK  ######################
     def compute_spark(
@@ -434,6 +457,7 @@ class Pipeline:
         sc: Optional[SparkContext] = None,
         numparts: Optional[int] = None,
         cache: bool = False,
+        provenance: Optional[object] = None,
     ) -> SparkRecordSet:
         """Apply the pipeline using Spark
 
@@ -442,6 +466,7 @@ class Pipeline:
         numparts: Number of partitions to use. If not provided, defaults to the number of records.
                 will be used.
             cache: Whether to cache the RDD. Default is False.
+            provenance: Optional Provenance backend. See Pipeline.compute.
 
         Returns:
             SparkRecordSet: The record set
@@ -449,13 +474,14 @@ class Pipeline:
         from ..backend.spark import SparkRecordSet, ToksearchSparkConfig
 
         config = ToksearchSparkConfig(sc=sc, numparts=numparts, cache=cache)
-        return self.compute(SparkRecordSet, config=config)
+        return self.compute(SparkRecordSet, config=config, provenance=provenance)
 
     ####################### MULTIPROCESSING  ######################
     def compute_multiprocessing(
         self,
         num_workers: Optional[int] = None,
         batch_size: Union[str, int] = "auto",
+        provenance: Optional[object] = None,
     ) -> MultiprocessingRecordSet:
         """Apply the pipeline using multiprocessing
 
@@ -464,12 +490,13 @@ class Pipeline:
                 If set to None (the default), half the number of CPUs on the machine will be used.
             batch_size: The batch size to use for parallel processing, passed to joblib.Parallel.
                 Defaults to "auto".
+            provenance: Optional Provenance backend. See Pipeline.compute.
 
         Returns:
             MultiprocessingRecordSet: The record set
         """
         config = MultiprocessingConfig(num_workers=num_workers, batch_size=batch_size)
-        return self.compute(MultiprocessingRecordSet, config=config)
+        return self.compute(MultiprocessingRecordSet, config=config, provenance=provenance)
 
     ####################### Private methods ######################
 

--- a/toksearch/pipeline/record_pipeline.py
+++ b/toksearch/pipeline/record_pipeline.py
@@ -343,6 +343,7 @@ class Pipeline:
         track: str = "directory",
         exist_ok: bool = False,
         path_field: str = "output_path",
+        on_error: str = "skip",
     ):
         """Write one file per record, in the worker that produced it.
 
@@ -397,6 +398,12 @@ class Pipeline:
                 corrupt the directory's content hash, and ``flock`` is not
                 cross-client on BeeGFS so nothing else prevents it.
             path_field: Record field that receives the written path.
+            on_error: What to do with a record that already carries an error
+                from an earlier operation. 'skip' (default) writes no file for
+                it, so the output directory -- and the provenance hash over it
+                -- covers exactly the shots that completed. 'write' writes
+                anyway, which means the file may be missing whatever a failed
+                stage was supposed to add.
 
         Returns:
             None in declarative form, a decorator in decorator form.
@@ -404,6 +411,11 @@ class Pipeline:
         if track not in ("directory", "file"):
             raise ValueError(
                 f"track must be 'directory' or 'file', got {track!r}"
+            )
+
+        if on_error not in ("skip", "write"):
+            raise ValueError(
+                f"on_error must be 'skip' or 'write', got {on_error!r}"
             )
 
         if not exist_ok and os.path.isdir(directory) and os.listdir(directory):
@@ -425,6 +437,7 @@ class Pipeline:
                     name=name,
                     track=track,
                     path_field=path_field,
+                    on_error=on_error,
                 )
             )
 

--- a/toksearch/pipeline/record_pipeline.py
+++ b/toksearch/pipeline/record_pipeline.py
@@ -81,6 +81,10 @@ if TYPE_CHECKING:
 
 from .pipeline_source import PipelineSource
 
+from ..provenance.code import capture_code
+from ..provenance.context import RunContext, SourceSpec, BackendSpec
+from ..provenance.hashing import sha256_of
+
 
 class MissingColumnName(Exception):
     pass
@@ -181,7 +185,9 @@ class Pipeline:
 
         results = [dict(zip(column_names, row)) for row in cursor.fetchall()]
 
-        return cls(results)
+        pipeline = cls(results)
+        pipeline._sql_source = {"query": query, "params": tuple(query_params)}
+        return pipeline
 
     def __init__(
         self,
@@ -226,6 +232,14 @@ class Pipeline:
             self.do_shot_cleanups = False
             self.do_cleanups = False
             self._operations = []
+
+        # Propagate through pipeline chaining; a RecordSet or shot-list parent
+        # has no query behind it.
+        self._sql_source = (
+            getattr(parent, "_sql_source", None)
+            if isinstance(parent, Pipeline)
+            else None
+        )
 
     def fetch(self, name: str, signal: "Signal"):
         """Add a signal to be fetched by the pipeline
@@ -467,3 +481,63 @@ class Pipeline:
 
     def _append_operation(self, func):
         self._operations.append(func)
+
+    def _source_spec(self) -> SourceSpec:
+        """Describe where this pipeline's records come from."""
+        if self._sql_source is not None:
+            return SourceSpec(
+                kind="sql",
+                query=self._sql_source["query"],
+                params=self._sql_source["params"],
+                hash=sha256_of(self._sql_source),
+            )
+
+        if isinstance(self.parent, RecordSet):
+            return SourceSpec(kind="recordset", count=len(self.parent))
+
+        records = getattr(self.parent, "_records", None)
+        if records is None:
+            return SourceSpec(kind="unknown")
+
+        shots = sorted(rec.shot for rec in records)
+        return SourceSpec(kind="shotlist", count=len(shots), hash=sha256_of(shots))
+
+    def _run_context(self, recordset_cls, config) -> RunContext:
+        """Derive the full description of the run about to happen."""
+        op_specs = tuple(
+            op.spec() for op in self._operations if hasattr(op, "spec")
+        )
+
+        signals = {}
+        for spec in op_specs:
+            if spec.op == "fetch":
+                signals[spec.detail["name"]] = spec.detail["signal"]
+            elif spec.op == "fetch_dataset":
+                key = f"{spec.detail['ds_name']}.{spec.detail['signame']}"
+                signals[key] = spec.detail["signal"]
+
+        config_dict = {}
+        if config is not None:
+            config_dict = {
+                k: v for k, v in vars(config).items() if not k.startswith("_")
+            }
+
+        return RunContext(
+            source=self._source_spec(),
+            ops=op_specs,
+            signals=signals,
+            backend=BackendSpec(kind=recordset_cls.__name__, config=config_dict),
+            code=capture_code(),
+            device=self._device_hint(signals),
+            parent_run=getattr(self.parent, "run_id", None),
+        )
+
+    @staticmethod
+    def _device_hint(signals) -> Optional[str]:
+        """Best-effort device name, from the modules the signals came from."""
+        modules = {s.get("module", "") or "" for s in signals.values()}
+        if any(m.startswith("toksearch_d3d") for m in modules):
+            return "d3d"
+        if any(m.startswith("toksearch_mast") for m in modules):
+            return "mast"
+        return None

--- a/toksearch/pipeline/record_pipeline.py
+++ b/toksearch/pipeline/record_pipeline.py
@@ -55,6 +55,7 @@ from .pipeline_funcs import (
     _PipelineKeep,
     _PipelineAlign,
     _PipelineWhere,
+    _SafeWrite,
 )
 
 from .align import XarrayAligner
@@ -113,6 +114,7 @@ class Pipeline:
         keep: Keep only the fields specified in the list
         align: Align an xarray dataset with a specified set of coordinates
             (typically times)
+        write: Write one file per record from within the pipeline
         where: Apply a function to the records of the previous step in the pipeline,
             and keep the record if the result is truthy, remove it otherwise
         compute_shot: Run the pipeline for a single shot, returning a record object
@@ -330,6 +332,111 @@ class Pipeline:
         )
 
         self.map(_PipelineAlign(ds_name, aligner))
+
+    def write(
+        self,
+        directory: str,
+        field: Optional[str] = None,
+        fields: Optional[List[str]] = None,
+        fmt: Optional[str] = None,
+        name: Optional[Callable] = None,
+        track: str = "directory",
+        exist_ok: bool = False,
+        path_field: str = "output_path",
+    ):
+        """Write one file per record, in the worker that produced it.
+
+        This is the recommended way to get data out of a pipeline. Writing per
+        shot in the workers is both faster and more honest than concatenating
+        on the driver: concatenation is a transformation, and it deserves its
+        own stage rather than hiding inside a writer.
+
+        Read the results back with ``xarray.open_mfdataset(directory +
+        '/*.nc')`` where ``dask`` is installed. Without it, open per file::
+
+            import glob, xarray as xr
+            ds = xr.concat(
+                [xr.open_dataset(f) for f in sorted(glob.glob('out/*.nc'))],
+                dim='shot',
+            )
+
+        Without ``netCDF4``/``h5netcdf``, xarray writes NetCDF3 via scipy,
+        which has no int64 -- integer coordinates read back as int32.
+
+        Two forms:
+
+        **Declarative** -- pass ``field`` or ``fields``. The operation is
+        appended immediately and None is returned::
+
+            pipeline.write('out/peaks', field='ds', fmt='netcdf')
+
+        **Decorator** -- pass neither. A decorator is returned; applying it to
+        a function appends the operation and gives the function back
+        unchanged::
+
+            @pipeline.write('out/peaks', fmt='netcdf')
+            def shot_file(rec):
+                return rec['ds']
+
+        A two-argument function takes ``(record, path)``, writes the file
+        itself, and returns the path it wrote.
+
+        Arguments:
+            directory: Output directory. Created if absent.
+            field: Single record field to write.
+            fields: Several record fields, merged with ``xarray.merge``.
+            fmt: Format name ('netcdf', 'parquet', 'npy', 'npz', 'json').
+                Inferred from the object's type when omitted.
+            name: Callable ``(record) -> str`` producing the basename without
+                extension. Defaults to the shot number.
+            track: Provenance granularity. 'directory' (default) records the
+                whole directory as one artifact; 'file' records one artifact
+                per shot.
+            exist_ok: Allow writing into a non-empty directory. Off by
+                default: two runs interleaving into one directory silently
+                corrupt the directory's content hash, and ``flock`` is not
+                cross-client on BeeGFS so nothing else prevents it.
+            path_field: Record field that receives the written path.
+
+        Returns:
+            None in declarative form, a decorator in decorator form.
+        """
+        if track not in ("directory", "file"):
+            raise ValueError(
+                f"track must be 'directory' or 'file', got {track!r}"
+            )
+
+        if not exist_ok and os.path.isdir(directory) and os.listdir(directory):
+            raise ValueError(
+                f"Output directory {directory!r} is not empty. Writing into "
+                f"it would mix this run's output with existing files and "
+                f"corrupt the directory's provenance hash. Use a fresh "
+                f"directory, or pass exist_ok=True if you are certain."
+            )
+
+        def _append(func=None):
+            self._append_operation(
+                _SafeWrite(
+                    directory,
+                    field=field,
+                    fields=fields,
+                    fmt=fmt,
+                    func=func,
+                    name=name,
+                    track=track,
+                    path_field=path_field,
+                )
+            )
+
+        if field is not None or fields:
+            _append()
+            return None
+
+        def decorator(func):
+            _append(func)
+            return func
+
+        return decorator
 
     def where(self, func):
         """

--- a/toksearch/pipeline/writers.py
+++ b/toksearch/pipeline/writers.py
@@ -91,16 +91,23 @@ def _write_parquet(obj, path):
     obj.to_parquet(path)
 
 
+# np.save and np.savez append ".npy"/".npz" to a path that lacks the
+# extension, so the file lands somewhere other than where the caller was
+# told. write_object returns that path and a provenance backend records it as
+# an artifact, so the mismatch would produce lineage pointing at a file that
+# does not exist. Writing through an open handle suppresses the rewriting.
 def _write_npy(obj, path):
     import numpy as np
 
-    np.save(path, obj)
+    with open(path, "wb") as fh:
+        np.save(fh, obj)
 
 
 def _write_npz(obj, path):
     import numpy as np
 
-    np.savez(path, **obj)
+    with open(path, "wb") as fh:
+        np.savez(fh, **obj)
 
 
 def _write_json(obj, path):

--- a/toksearch/pipeline/writers.py
+++ b/toksearch/pipeline/writers.py
@@ -1,0 +1,123 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-record output formats for Pipeline.write.
+
+Writers are looked up either by an explicit ``fmt`` name or by the type of the
+object being written. Registration is open so device packages and users can add
+their own formats.
+"""
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Tuple
+
+
+class UnknownFormat(Exception):
+    """Raised when no writer matches the requested format or object type."""
+
+
+@dataclass(frozen=True)
+class Writer:
+    fmt: str
+    extension: str
+    func: Callable[[Any, str], None]
+    types: Tuple[type, ...] = ()
+
+
+_WRITERS = {}
+_ORDER = []
+
+
+def register_writer(fmt, extension, func, types=()):
+    """Register a writer. Later registrations of the same fmt replace earlier."""
+    writer = Writer(fmt=fmt, extension=extension, func=func, types=tuple(types))
+    _WRITERS[fmt] = writer
+    if fmt not in _ORDER:
+        _ORDER.append(fmt)
+    return writer
+
+
+def writer_for(fmt: Optional[str] = None, obj: Any = None) -> Writer:
+    """Find a writer by explicit format name, else by the object's type."""
+    if fmt is not None:
+        try:
+            return _WRITERS[fmt]
+        except KeyError:
+            raise UnknownFormat(
+                f"No writer registered for format {fmt!r}. "
+                f"Known formats: {sorted(_WRITERS)}"
+            )
+
+    for name in _ORDER:
+        writer = _WRITERS[name]
+        if writer.types and isinstance(obj, writer.types):
+            return writer
+
+    raise UnknownFormat(
+        f"No writer knows how to write an object of type "
+        f"{type(obj).__name__}. Pass fmt= explicitly, register a writer with "
+        f"toksearch.pipeline.writers.register_writer, or use the decorator "
+        f"form of Pipeline.write and write the file yourself."
+    )
+
+
+def extension_for(fmt: str) -> str:
+    return writer_for(fmt=fmt).extension
+
+
+def write_object(obj: Any, path: str, fmt: Optional[str] = None) -> str:
+    """Write obj to path, returning path."""
+    writer_for(fmt=fmt, obj=obj).func(obj, path)
+    return path
+
+
+def _write_netcdf(obj, path):
+    obj.to_netcdf(path)
+
+
+def _write_parquet(obj, path):
+    obj.to_parquet(path)
+
+
+def _write_npy(obj, path):
+    import numpy as np
+
+    np.save(path, obj)
+
+
+def _write_npz(obj, path):
+    import numpy as np
+
+    np.savez(path, **obj)
+
+
+def _write_json(obj, path):
+    with open(path, "w") as fh:
+        json.dump(obj, fh, indent=2, sort_keys=True, default=repr)
+
+
+def _register_builtins():
+    import numpy as np
+    import pandas as pd
+    import xarray as xr
+
+    register_writer("netcdf", ".nc", _write_netcdf, (xr.Dataset, xr.DataArray))
+    register_writer("parquet", ".parquet", _write_parquet, (pd.DataFrame,))
+    register_writer("npy", ".npy", _write_npy, (np.ndarray,))
+    register_writer("npz", ".npz", _write_npz, ())
+    register_writer("json", ".json", _write_json, (dict, list))
+
+
+_register_builtins()

--- a/toksearch/provenance/__init__.py
+++ b/toksearch/provenance/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Provenance recording for toksearch pipelines.
+
+This subpackage is deliberately free of any provenance-*backend* dependency.
+It derives a ``RunContext`` describing a pipeline run and hands it to a
+``Provenance`` implementation. The CMF implementation lives in the separate
+``toksearch_cmf`` package.
+"""
+
+from .hashing import canonical_json, sha256_of, callable_spec
+
+__all__ = ["canonical_json", "sha256_of", "callable_spec"]

--- a/toksearch/provenance/__init__.py
+++ b/toksearch/provenance/__init__.py
@@ -20,5 +20,22 @@ It derives a ``RunContext`` describing a pipeline run and hands it to a
 """
 
 from .hashing import canonical_json, sha256_of, callable_spec
+from .context import RunContext, SourceSpec, OpSpec, BackendSpec
+from .code import CodeSpec, capture_code
+from .base import Provenance, safe_call
+from .json_backend import JsonProvenance
 
-__all__ = ["canonical_json", "sha256_of", "callable_spec"]
+__all__ = [
+    "canonical_json",
+    "sha256_of",
+    "callable_spec",
+    "RunContext",
+    "SourceSpec",
+    "OpSpec",
+    "BackendSpec",
+    "CodeSpec",
+    "capture_code",
+    "Provenance",
+    "safe_call",
+    "JsonProvenance",
+]

--- a/toksearch/provenance/base.py
+++ b/toksearch/provenance/base.py
@@ -1,0 +1,78 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The Provenance backend interface."""
+
+import warnings
+from abc import ABC, abstractmethod
+
+
+class Provenance(ABC):
+    """Receives a RunContext and records it somewhere.
+
+    Implementations must not raise in normal operation: losing a provenance
+    record is bad, but losing a completed multi-hour compute is worse. Errors
+    are converted to warnings by ``safe_call`` unless ``strict`` is set.
+    """
+
+    #: When True, hook failures propagate instead of warning. For CI.
+    strict: bool = False
+
+    #: Identifier for this run. Pipeline.compute copies it onto the returned
+    #: RecordSet, which is how an in-process pipeline chain links itself:
+    #: Pipeline(previous_recordset) reads it back as RunContext.parent_run.
+    run_id = None
+
+    @abstractmethod
+    def on_compute_start(self, ctx) -> None:
+        """Called before the backend runs, with the derived RunContext."""
+
+    @abstractmethod
+    def on_compute_end(self, ctx, recordset) -> None:
+        """Called after compute returns, with the resulting RecordSet."""
+
+    @abstractmethod
+    def output(self, *paths, **custom_properties) -> None:
+        """Declare output artifacts that toksearch did not write itself."""
+
+    @abstractmethod
+    def metrics(self, name: str, values: dict) -> None:
+        """Record a named set of metrics for this run."""
+
+    @abstractmethod
+    def finalize(self) -> None:
+        """Flush and close the record."""
+
+
+def safe_call(provenance, hook: str, *args, **kwargs):
+    """Invoke a provenance hook without letting it break the pipeline.
+
+    A None provenance is a no-op, so call sites need no branching.
+    """
+    if provenance is None:
+        return None
+
+    try:
+        return getattr(provenance, hook)(*args, **kwargs)
+    except Exception as e:
+        if getattr(provenance, "strict", False):
+            raise
+        warnings.warn(
+            f"Provenance backend {type(provenance).__name__}.{hook} failed "
+            f"and was ignored: {e!r}. The pipeline result is unaffected, but "
+            f"this run's provenance record is incomplete.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+        return None

--- a/toksearch/provenance/code.py
+++ b/toksearch/provenance/code.py
@@ -1,0 +1,79 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Capture of the code version behind a pipeline run."""
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, asdict
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class CodeSpec:
+    """Which code produced a run."""
+
+    commit: Optional[str]
+    dirty: Optional[bool]
+    repo_root: Optional[str]
+    script: Optional[str]
+    argv: Tuple[str, ...]
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _git(args, cwd):
+    try:
+        out = subprocess.run(
+            ["git"] + args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip()
+
+
+def capture_code(cwd: Optional[str] = None) -> CodeSpec:
+    """Describe the code version of the running script.
+
+    Running outside a git repository is not an error here — it yields a
+    CodeSpec with ``commit=None``. Backends that *require* git (cmflib does)
+    are responsible for rejecting that themselves, early and with a clear
+    message.
+    """
+    cwd = cwd or os.getcwd()
+
+    commit = _git(["rev-parse", "HEAD"], cwd)
+    repo_root = _git(["rev-parse", "--show-toplevel"], cwd)
+
+    dirty = None
+    if commit is not None:
+        status = _git(["status", "--porcelain"], cwd)
+        dirty = bool(status) if status is not None else None
+
+    script = sys.argv[0] if sys.argv else None
+
+    return CodeSpec(
+        commit=commit,
+        dirty=dirty,
+        repo_root=repo_root,
+        script=script,
+        argv=tuple(sys.argv),
+    )

--- a/toksearch/provenance/context.py
+++ b/toksearch/provenance/context.py
@@ -100,3 +100,24 @@ class RunContext:
                 "device": self.device,
             }
         )
+
+    def write_directories(self) -> list:
+        """Output directories declared by Pipeline.write operations.
+
+        Read from the pipeline definition, not from the records. Ray and Spark
+        RecordSets are lazy -- ``SparkRecordSet.map`` returns an un-actioned
+        RDD and ``RayRecordSet.map`` returns unmaterialized ObjectRefs -- so
+        iterating one to discover written paths would force materialization as
+        a side effect of recording provenance. On Spark without caching, the
+        user's next action would then recompute the whole pipeline. The
+        directory is known statically, so nothing needs to be forced.
+
+        Only ``track="directory"`` writes are covered. ``track="file"`` asks
+        for per-shot artifacts, whose paths genuinely are per-record; a backend
+        wanting those must iterate, and should say so.
+        """
+        return [
+            op.detail["directory"]
+            for op in self.ops
+            if op.op == "write" and op.detail.get("track") == "directory"
+        ]

--- a/toksearch/provenance/context.py
+++ b/toksearch/provenance/context.py
@@ -1,0 +1,28 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The RunContext contract between toksearch and a provenance backend."""
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict
+
+
+@dataclass(frozen=True)
+class OpSpec:
+    """One pipeline operation, described."""
+
+    op: str
+    detail: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return asdict(self)

--- a/toksearch/provenance/context.py
+++ b/toksearch/provenance/context.py
@@ -14,7 +14,11 @@
 """The RunContext contract between toksearch and a provenance backend."""
 
 from dataclasses import dataclass, field, asdict
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
+
+# code.py imports only stdlib, so this is a plain import -- there is no cycle.
+from .code import CodeSpec
+from .hashing import sha256_of
 
 
 @dataclass(frozen=True)
@@ -26,3 +30,73 @@ class OpSpec:
 
     def to_dict(self) -> dict:
         return asdict(self)
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    """Where the records came from."""
+
+    kind: str                       # "shotlist" | "sql" | "recordset" | "unknown"
+    count: Optional[int] = None
+    hash: Optional[str] = None
+    query: Optional[str] = None
+    params: Optional[Tuple[Any, ...]] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class BackendSpec:
+    """Which compute backend ran, and how it was configured."""
+
+    kind: str
+    config: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RunContext:
+    """Everything toksearch knows about one ``compute_*`` call.
+
+    This is the entire contract with a provenance backend. A backend receives
+    a RunContext and nothing else; it never touches a Pipeline, a Signal, or a
+    Record.
+    """
+
+    source: SourceSpec
+    ops: Tuple[OpSpec, ...]
+    signals: Dict[str, dict]
+    backend: BackendSpec
+    code: CodeSpec
+    device: Optional[str] = None
+    parent_run: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "source": self.source.to_dict(),
+            "ops": [op.to_dict() for op in self.ops],
+            "signals": self.signals,
+            "backend": self.backend.to_dict(),
+            "code": self.code.to_dict(),
+            "device": self.device,
+            "parent_run": self.parent_run,
+        }
+
+    def input_identity(self) -> str:
+        """Hash of *what data this run reads* -- source plus signals.
+
+        Deliberately excludes ops, backend, and code: two runs that read the
+        same data share an input artifact even if they then do different
+        things with it. That shared artifact is what connects the lineage
+        graph.
+        """
+        return sha256_of(
+            {
+                "source": self.source.to_dict(),
+                "signals": self.signals,
+                "device": self.device,
+            }
+        )

--- a/toksearch/provenance/hashing.py
+++ b/toksearch/provenance/hashing.py
@@ -1,0 +1,70 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Deterministic serialization and hashing helpers.
+
+Provenance identity depends on these being stable: the same logical input must
+produce the same bytes on every machine and every run, or CMF cannot recognize
+two runs as sharing an input artifact.
+"""
+
+import hashlib
+import inspect
+import json
+from typing import Any, Callable, Optional
+
+
+def canonical_json(obj: Any) -> str:
+    """Serialize obj to a deterministic JSON string.
+
+    Keys are sorted at every level and separators carry no incidental
+    whitespace. Objects JSON cannot represent fall back to ``repr``, which
+    keeps a weak-but-present record rather than raising mid-pipeline.
+    """
+    return json.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=repr,
+    )
+
+
+def sha256_of(obj: Any) -> str:
+    """Return the hex sha256 digest of ``canonical_json(obj)``."""
+    return hashlib.sha256(canonical_json(obj).encode("utf-8")).hexdigest()
+
+
+def callable_spec(func: Optional[Callable]) -> Optional[dict]:
+    """Describe a callable well enough to tell two versions of it apart.
+
+    Returns None for None. Source is captured as a hash rather than as text so
+    the record stays small and does not leak surrounding code.
+    """
+    if func is None:
+        return None
+
+    source_sha256 = None
+    try:
+        source_sha256 = hashlib.sha256(
+            inspect.getsource(func).encode("utf-8")
+        ).hexdigest()
+    except (OSError, TypeError):
+        # Builtins, C extensions, and callables defined in a REPL or via eval
+        # have no retrievable source. That is expected, not an error.
+        pass
+
+    return {
+        "name": getattr(func, "__qualname__", None) or getattr(func, "__name__", repr(func)),
+        "module": getattr(func, "__module__", None),
+        "source_sha256": source_sha256,
+    }

--- a/toksearch/provenance/hashing.py
+++ b/toksearch/provenance/hashing.py
@@ -18,30 +18,91 @@ produce the same bytes on every machine and every run, or CMF cannot recognize
 two runs as sharing an input artifact.
 """
 
+import functools
 import hashlib
 import inspect
 import json
+import re
 from typing import Any, Callable, Optional
+
+# repr() of an object with no custom __repr__ embeds its memory address, which
+# is different on every run. Stripping it keeps the informative part of the
+# repr while making it reproducible.
+_MEMORY_ADDRESS = re.compile(r" at 0x[0-9a-fA-F]+")
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _stable_repr(obj: Any) -> str:
+    """repr(obj) with any embedded memory address removed."""
+    return _MEMORY_ADDRESS.sub("", repr(obj))
+
+
+def _normalize(obj: Any) -> Any:
+    """Rewrite obj into a shape json.dumps renders deterministically.
+
+    Three hazards are handled here rather than left to ``json.dumps``:
+
+    * **Sets** iterate in an order that varies with ``PYTHONHASHSEED``, so the
+      same set serializes differently on every run. They are sorted.
+    * **Non-string dict keys** make ``json.dumps(sort_keys=True)`` raise --
+      either outright for unsupported types like tuples, or when comparing
+      mixed key types such as ``{1: ..., "1": ...}``. ``default=`` is never
+      consulted for keys, so this must be handled before dumping.
+    * **Memory addresses** in repr fallbacks, via ``_stable_repr``.
+    """
+    if isinstance(obj, dict):
+        return {
+            (key if isinstance(key, str) else _stable_repr(key)): _normalize(value)
+            for key, value in obj.items()
+        }
+    if isinstance(obj, (set, frozenset)):
+        return sorted((_normalize(v) for v in obj), key=_stable_repr)
+    if isinstance(obj, (list, tuple)):
+        return [_normalize(v) for v in obj]
+    return obj
 
 
 def canonical_json(obj: Any) -> str:
     """Serialize obj to a deterministic JSON string.
 
-    Keys are sorted at every level and separators carry no incidental
-    whitespace. Objects JSON cannot represent fall back to ``repr``, which
-    keeps a weak-but-present record rather than raising mid-pipeline.
+    Deterministic means: the same logical input produces identical bytes on
+    any machine, in any process, on any run. Everything downstream depends on
+    this -- two pipeline runs reading the same data are recognized as sharing
+    an input artifact only because their descriptions hash identically.
+
+    Keys are sorted at every level, separators carry no incidental whitespace,
+    and ``_normalize`` removes the three sources of run-to-run variation (see
+    its docstring). Values JSON cannot represent fall back to a repr with
+    memory addresses stripped.
+
+    Note: NaN and Infinity serialize as bare ``NaN``/``Infinity`` tokens,
+    which is stable and round-trips through Python's own ``json.loads``, but
+    is not strict RFC 8259.
     """
     return json.dumps(
-        obj,
+        _normalize(obj),
         sort_keys=True,
         separators=(",", ":"),
-        default=repr,
+        default=_stable_repr,
     )
 
 
 def sha256_of(obj: Any) -> str:
     """Return the hex sha256 digest of ``canonical_json(obj)``."""
-    return hashlib.sha256(canonical_json(obj).encode("utf-8")).hexdigest()
+    return _sha256_text(canonical_json(obj))
+
+
+def _source_sha256(func: Callable) -> Optional[str]:
+    """Hash a callable's source, or None when the source is unavailable."""
+    try:
+        return _sha256_text(inspect.getsource(func))
+    except (OSError, TypeError):
+        # Builtins, C extensions, and callables defined in a REPL or via eval
+        # have no retrievable source. That is expected, not an error.
+        return None
 
 
 def callable_spec(func: Optional[Callable]) -> Optional[dict]:
@@ -49,22 +110,45 @@ def callable_spec(func: Optional[Callable]) -> Optional[dict]:
 
     Returns None for None. Source is captured as a hash rather than as text so
     the record stays small and does not leak surrounding code.
+
+    The fingerprint must be stable across runs. That rules out ``repr(func)``
+    as a fallback name: ``functools.partial`` objects and instances of classes
+    with ``__call__`` -- both ordinary shapes for a pipeline map function --
+    have no ``__name__``, and their repr embeds a memory address that changes
+    every run. Each is handled explicitly instead.
     """
     if func is None:
         return None
 
-    source_sha256 = None
-    try:
-        source_sha256 = hashlib.sha256(
-            inspect.getsource(func).encode("utf-8")
-        ).hexdigest()
-    except (OSError, TypeError):
-        # Builtins, C extensions, and callables defined in a REPL or via eval
-        # have no retrievable source. That is expected, not an error.
-        pass
+    if isinstance(func, functools.partial):
+        # Identify the wrapped function, and record the bound arguments: they
+        # are what distinguishes partial(f, level=5) from partial(f, level=6),
+        # which is exactly the distinction provenance needs to draw.
+        inner = callable_spec(func.func)
+        return {
+            "name": inner["name"],
+            "module": inner["module"],
+            "source_sha256": inner["source_sha256"],
+            "partial_args": [_stable_repr(a) for a in func.args],
+            "partial_keywords": {
+                k: _stable_repr(v) for k, v in sorted(func.keywords.items())
+            },
+        }
 
+    name = getattr(func, "__qualname__", None) or getattr(func, "__name__", None)
+    if name is not None:
+        return {
+            "name": name,
+            "module": getattr(func, "__module__", None),
+            "source_sha256": _source_sha256(func),
+        }
+
+    # A callable object. Identify it by its class -- deterministic, where its
+    # own repr is not -- and hash the class source, which is the code that
+    # actually runs.
+    cls = type(func)
     return {
-        "name": getattr(func, "__qualname__", None) or getattr(func, "__name__", repr(func)),
-        "module": getattr(func, "__module__", None),
-        "source_sha256": source_sha256,
+        "name": f"{cls.__module__}.{cls.__qualname__}",
+        "module": cls.__module__,
+        "source_sha256": _source_sha256(cls),
     }

--- a/toksearch/provenance/json_backend.py
+++ b/toksearch/provenance/json_backend.py
@@ -1,0 +1,76 @@
+# Copyright 2026 General Atomics
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A dependency-free Provenance backend that writes JSON.
+
+This exists so toksearch's own test suite can exercise every provenance hook
+with no CMF, no DVC, and no database. It is also a usable record in its own
+right for people who want provenance without running a metadata server.
+"""
+
+import json
+import os
+import uuid
+from typing import Optional
+
+from .base import Provenance
+
+
+class JsonProvenance(Provenance):
+    """Record a run to a JSON file."""
+
+    def __init__(self, pipeline_name: str, stage: Optional[str] = None,
+                 path: str = "toksearch_run.json", strict: bool = False):
+        self.pipeline_name = pipeline_name
+        self.stage = stage or pipeline_name
+        self.path = path
+        self.strict = strict
+        self.run_id = uuid.uuid4().hex
+
+        self._context = None
+        self._input_identity = None
+        self._outputs = []
+        self._metrics = {}
+
+    def on_compute_start(self, ctx) -> None:
+        self._context = ctx.to_dict()
+        self._input_identity = ctx.input_identity()
+
+    def on_compute_end(self, ctx, recordset) -> None:
+        self._context = ctx.to_dict()
+        self._input_identity = ctx.input_identity()
+        # From the context, not the recordset: see RunContext.write_directories.
+        for path in ctx.write_directories():
+            self.output(path, source="pipeline_write")
+
+    def output(self, *paths, **custom_properties) -> None:
+        for path in paths:
+            self._outputs.append({"path": str(path), **custom_properties})
+
+    def metrics(self, name: str, values: dict) -> None:
+        self._metrics[name] = dict(values)
+
+    def finalize(self) -> None:
+        payload = {
+            "run_id": self.run_id,
+            "pipeline_name": self.pipeline_name,
+            "stage": self.stage,
+            "input_identity": self._input_identity,
+            "context": self._context,
+            "outputs": self._outputs,
+            "metrics": self._metrics,
+        }
+        directory = os.path.dirname(os.path.abspath(self.path))
+        os.makedirs(directory, exist_ok=True)
+        with open(self.path, "w") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True, default=repr)

--- a/toksearch/record/record_set.py
+++ b/toksearch/record/record_set.py
@@ -55,3 +55,64 @@ class RecordSet(ABC):
     @abstractmethod
     def cleanup(self, **kwargs):
         pass
+
+    #: Record fields that are bookkeeping, not results. Excluded from
+    #: to_dataframe unless explicitly requested.
+    _NON_RESULT_FIELDS = ("errors", "_toksearch_write_dir")
+
+    def to_dataframe(self, fields=None):
+        """Return a pandas DataFrame with one row per record.
+
+        Intended for scalar summary results. Array-valued and dataset-valued
+        fields belong in per-shot files written by ``Pipeline.write``, not in
+        a driver-side frame.
+
+        Rows are built from each record's own keys rather than one shared
+        column list: a shot whose map function failed never gains the field
+        its siblings have, and pandas unions the columns and fills NaN. That
+        keeps a partial run visibly partial instead of silently smaller.
+
+        Arguments:
+            fields: Field names to include, in order. When omitted, every
+                field except bookkeeping ones is included. ``shot`` is always
+                the first column.
+        """
+        import pandas as pd
+
+        rows = []
+        for record in self:
+            if fields is None:
+                keys = [
+                    k
+                    for k in record.keys()
+                    if k != "shot" and k not in self._NON_RESULT_FIELDS
+                ]
+            else:
+                keys = list(fields)
+
+            row = {"shot": record.shot}
+            for key in keys:
+                row[key] = record.get(key, None)
+            rows.append(row)
+
+        if not rows:
+            return pd.DataFrame(columns=["shot"] + list(fields or []))
+
+        return pd.DataFrame(rows)
+
+    def to_parquet(self, path, fields=None):
+        """Write the record set to a parquet file and return its path.
+
+        If this record set came from a ``compute_*`` call with a provenance
+        backend, the file is declared to that backend as an output artifact.
+        The file is written first: a provenance failure must not cost the user
+        their output.
+        """
+        self.to_dataframe(fields=fields).to_parquet(path)
+
+        if self.provenance is not None:
+            from ..provenance.base import safe_call
+
+            safe_call(self.provenance, "output", path, source="to_parquet")
+
+        return path

--- a/toksearch/record/record_set.py
+++ b/toksearch/record/record_set.py
@@ -30,6 +30,12 @@ class RecordSet(ABC):
             shutting down a SparkContext or Ray cluster
     """
 
+    #: Set by Pipeline.compute when a provenance backend is in use. Carrying
+    #: it on the record set is what makes an in-process pipeline chain
+    #: automatically linkable: Pipeline(previous_recordset) can read it.
+    provenance = None
+    run_id = None
+
     @abstractmethod
     def __len__(self):
         pass

--- a/toksearch/signal/mds.py
+++ b/toksearch/signal/mds.py
@@ -140,6 +140,10 @@ class MdsTreePath(object):
         """Return the name of the environment variable for the given treename"""
         return "{}_path".format(treename)
 
+    def _spec_value(self):
+        """Deterministic, JSON-serializable form for provenance records."""
+        return {"paths": dict(sorted(self.paths.items()))}
+
 
 class MdsLocalSignal(Signal):
     def __init__(
@@ -187,10 +191,21 @@ class MdsLocalSignal(Signal):
 
         self.set_dims(dims, data_order)
 
+    def _spec_fields(self):
+        # treepath is either None, a plain path string, or an MdsTreePath --
+        # normalize the latter to something JSON can render deterministically.
+        treepath = self.treepath
+        if hasattr(treepath, "_spec_value"):
+            treepath = treepath._spec_value()
+        return {
+            "expression": self.expression,
+            "treename": self.treename,
+            "treepath": treepath,
+        }
 
     def gather(self, shot):
         """Gather the data for a shot
-        
+
         Arguments:
             shot (int): The shot number to gather the data for
 
@@ -303,6 +318,20 @@ class MdsSignal(Signal):
         self.dims = self.sig.dims
         self.data_order = self.sig.data_order
         self.with_units = self.sig.with_units
+
+    def _spec_fields(self):
+        # MdsSignal itself never stores expression/treename -- __init__ hands
+        # them straight to create_local_or_remote_signal and keeps only the
+        # resulting self.sig (an MdsLocalSignal or MdsRemoteSignal), so those
+        # two fields are read back off it rather than off self.
+        location = self.location
+        if hasattr(location, "_spec_value"):
+            location = location._spec_value()
+        return {
+            "expression": self.sig.expression,
+            "treename": self.sig.treename,
+            "location": location,
+        }
 
     @classmethod
     def create_local_or_remote_signal(cls, expression, treename, location, **kwargs):
@@ -540,6 +569,13 @@ class MdsRemoteSignal(Signal):
         self._use_getmany = True
 
         self.set_dims(dims, data_order)
+
+    def _spec_fields(self):
+        return {
+            "expression": self.expression,
+            "treename": self.treename,
+            "server": self.server,
+        }
 
     def connect(self) -> mds.Connection:
         """Open the connection to remote server"""

--- a/toksearch/signal/mock_signal.py
+++ b/toksearch/signal/mock_signal.py
@@ -31,6 +31,12 @@ class MockSignal(Signal):
         self.data = data if data is not None else self.default_d
         self.times = times if times is not None else self.default_t
 
+    def _spec_fields(self):
+        return {
+            "data": list(self.data),
+            "times": list(self.times),
+        }
+
     def gather(self, shot):
         results = {}
 

--- a/toksearch/signal/signal.py
+++ b/toksearch/signal/signal.py
@@ -23,6 +23,8 @@ import uuid
 import warnings
 from abc import ABC, abstractmethod
 
+from ..provenance.hashing import callable_spec
+
 
 @contextlib.contextmanager
 def _gc_disabled():
@@ -131,6 +133,64 @@ class Signal(ABC):
         self.dims: Iterable[str] = ("times",)
         self.data_order: Iterable[str] = self.dims
         self.with_units: bool = True
+
+    # Attributes owned by Signal itself. The reflective fallback skips these
+    # because they are already reported as top-level spec keys; repeating them
+    # inside "fields" would make two spellings of the same fact.
+    _SPEC_BASE_ATTRS = frozenset(
+        {"_callback", "_state", "dims", "data_order", "with_units"}
+    )
+
+    def spec(self) -> dict:
+        """Return a canonical, JSON-serializable description of this signal.
+
+        The description must be *deterministic*: two signals configured
+        identically must produce equal dicts, on any machine. Provenance
+        identity depends on it.
+
+        Subclasses describe themselves by implementing ``_spec_fields``. A
+        subclass that does not is still usable -- it gets a reflective
+        description marked ``spec_incomplete`` rather than an exception,
+        because a weak provenance record beats a crashed pipeline.
+        """
+        fields = self._spec_fields()
+        incomplete = fields is None
+        if incomplete:
+            fields = self._reflective_spec_fields()
+
+        spec = {
+            "class": type(self).__name__,
+            "module": type(self).__module__,
+            "dims": list(self.dims) if self.dims else None,
+            "data_order": list(self.data_order) if self.data_order else None,
+            "with_units": self.with_units,
+            "callback": callable_spec(self._callback),
+            "fields": fields,
+        }
+        if incomplete:
+            spec["spec_incomplete"] = True
+        return spec
+
+    def _spec_fields(self):
+        """Return a dict of the fields that define this signal, or None.
+
+        Returning None selects the reflective fallback. Subclasses should
+        override this and return only the values that change *what data is
+        fetched* -- not caches, connections, or other incidental state.
+        """
+        return None
+
+    def _reflective_spec_fields(self) -> dict:
+        """Best-effort description built from public instance attributes."""
+        fields = {}
+        for key, value in sorted(vars(self).items()):
+            if key.startswith("_") or key in self._SPEC_BASE_ATTRS:
+                continue
+            if callable(value):
+                fields[key] = callable_spec(value)
+            else:
+                fields[key] = value
+        return fields
 
     def set_callback(self, func) -> "Signal":
         """Set a callback function to be called after the data is fetched in the fetch method

--- a/toksearch/signal/zarr.py
+++ b/toksearch/signal/zarr.py
@@ -60,6 +60,15 @@ class ZarrSignal(Signal):
                 fsspec.filesystem("file"), asynchronous=True
             )
 
+    def _spec_fields(self):
+        # `fs` is a live filesystem client, not a description of what is
+        # fetched. Including it would make the spec non-deterministic.
+        return {
+            "path": self.path,
+            "treepath": self.treepath,
+            "file_name_format": self.file_name_format,
+        }
+
     def gather(self, shot):
         """Gather the data for a shot
 

--- a/toksearch/signal/zarr.py
+++ b/toksearch/signal/zarr.py
@@ -67,6 +67,13 @@ class ZarrSignal(Signal):
             "path": self.path,
             "treepath": self.treepath,
             "file_name_format": self.file_name_format,
+            # fetch_units genuinely changes what gather() returns, so it must
+            # be in the spec. Note it is NOT reflected in the base class's
+            # with_units attribute -- ZarrSignal.__init__ never syncs the two
+            # -- so without this line two signals differing only in
+            # fetch_units would produce byte-identical specs and be recorded
+            # as the same provenance input.
+            "fetch_units": self.fetch_units,
         }
 
     def gather(self, shot):


### PR DESCRIPTION
Adds a CMF-agnostic provenance layer to toksearch. A curated run declares
itself, and toksearch derives *what* the run was — shot list or SQL query,
signal specs, operation sequence, backend config, code commit — rather than the
user hand-writing metadata calls.

The CMF backend lives in a separate package (`toksearch_cmf`). This PR is
everything on the toksearch side, and imports no `cmflib`, `dvc`, `ray` or
`pyspark`.

## What's here

- **`toksearch.provenance`** — `RunContext` (the whole contract with a
  backend), `Signal.spec()`, `OpSpec` per pipeline operation, git/argv capture,
  a `Provenance` ABC whose failures are warnings rather than exceptions, and
  `JsonProvenance` as a dependency-free reference implementation.
- **`provenance=` on all four `compute_*` methods**, funnelling through the
  single hook site in `Pipeline.compute`.
- **`Pipeline.write`** — a new operation writing one file per record *in the
  worker*, with a declarative and a decorator form, plus a pluggable format
  registry.
- **`RecordSet.to_dataframe` / `to_parquet`** — filling a gap the docstring in
  `toksearch/__init__.py` previously papered over with a hand-rolled list
  comprehension.

## Design notes worth a reviewer's attention

**Fork safety is structural.** `Pipeline.write` runs in workers but only
records paths; every backend call happens on the driver afterwards. cmflib can
never reach a forked child, where the xrdcl-pelican curl worker pool would be
dead — this is enforced by construction, not by a rule to remember.

**Provenance never reads output paths by iterating the RecordSet.**
`RunContext.write_directories()` reads them from the pipeline definition,
because Ray and Spark RecordSets are lazy and iterating one is a Spark action —
recording provenance would otherwise force the compute and, without caching,
make the user's next action recompute everything.

**No `RecordSet.to_netcdf`.** Driver-side concatenation is slow and is a
transformation that deserves its own stage. Array-shaped results go through
`Pipeline.write`; readers open per file.

## Defects found while building on it

Each of these could corrupt a provenance record silently rather than fail:

- `canonical_json`/`callable_spec` produced fingerprints that **changed between
  runs** for `functools.partial` and callable objects — both ordinary map
  functions — and raised on non-string dict keys.
- `_PipelineAlign.spec()` embedded a memory address via `repr(aligner)`.
- `np.save`/`np.savez` rewrite the path, so `write_object` returned a path with
  no file at it.
- `ZarrSignal` omitted `fetch_units`, so two signals fetching different data
  produced identical specs.
- **`_SafeWrite` wrote files for records that had already failed**, so an
  output directory's hash vouched for datasets that had skipped a pipeline
  stage. Now `on_error="skip"` by default.

## Verification

608 tests, OK, 4 skipped — the same skip count as the 511-test baseline, so
nothing stopped running silently. The whole suite passes with `cmflib`, `dvc`
and `ml_metadata` absent, exercising every provenance hook through
`JsonProvenance`.

Exercised end to end on **91 real DIII-D shots** via `toksearch_cmf`: 0
failures, output recorded as a DVC directory hash, execution carrying source,
ops, backend, `code.commit` and `device=d3d` — none hand-written.

## Not included

`toksearch_d3d` signal specs (deferred — its environment installs released
conda toksearch, which has no `Signal.spec()` to implement against). Ray and
Spark accept `provenance=` and are proven to forward it, but are not exercised
end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kpkx3jFwQxuBRqoVcw6f27
